### PR TITLE
Add spell rank helper

### DIFF
--- a/sim/common/shared/shared_utils.go
+++ b/sim/common/shared/shared_utils.go
@@ -794,7 +794,7 @@ type SpellRankConfig struct {
 	FlatThreatBonus  float64
 }
 
-type SpellRankMap map[int32]SpellRankConfig
+type SpellRankMap []SpellRankConfig
 type SpellRankFactory func(config SpellRankConfig)
 
 func (spell SpellRankConfig) GetRankLabel() string {


### PR DESCRIPTION
Usage
```
shared.SpellRankMap{
	{
		Rank: 1, SpellID: 12345, Cost: 100, MinDamage: 500, MaxDamage: 600, Coefficient: 0.5, ThreatMultiplier: 1.0, FlatThreatBonus: 0,
	},
}.RegisterAll(func (config SpellRankConfig) {
	
})
```