### PR TITLE
Add Enhancement Shaman talent presets and enable preset buttons in UI

### DIFF
--- a/ui/shaman/enhancement/presets.ts
+++ b/ui/shaman/enhancement/presets.ts
@@ -68,17 +68,24 @@ export const P3_EP_PRESET = PresetUtils.makePresetEpWeights(
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/tbc/talent-calc and copy the numbers in the url.
-export const StandardTalents = {
-	name: 'Standard',
+export const SubRestoIWT = {
+	name: 'Sub-Restoration IWT',
 	data: SavedTalents.create({
-		talentsString: '313133',
+		talentsString: '03-500502210501133531151-50005301',
 	}),
 };
 
-export const P3Talents = {
-	name: 'P3 (WiP)',
+export const SubRestoILS = {
+	name: 'Sub-Restoration ILS',
 	data: SavedTalents.create({
-		talentsString: '313122',
+		talentsString: '03-500503210500133531151-50005301',
+	}),
+};
+
+export const SubEle = {
+	name: 'Sub-Elemental',
+	data: SavedTalents.create({
+		talentsString: '250031501-500503210500133531151',
 	}),
 };
 

--- a/ui/shaman/enhancement/sim.ts
+++ b/ui/shaman/enhancement/sim.ts
@@ -79,7 +79,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 		// Default consumes settings.
 		consumables: Presets.DefaultConsumables,
 		// Default talents.
-		talents: Presets.P3Talents.data,
+		talents: Presets.SubRestoIWT.data,
 		// Default spec-specific settings.
 		specOptions: Presets.DefaultOptions,
 		// Default raid/party buffs settings.
@@ -114,7 +114,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 	presets: {
 		epWeights: [Presets.P1_EP_PRESET, Presets.P3_EP_PRESET],
 		// Preset talents that the user can quickly select.
-		talents: [Presets.StandardTalents, Presets.P3Talents],
+		talents: [Presets.SubRestoIWT, Presets.SubRestoILS, Presets.SubEle],
 		// Preset rotations that the user can quickly select.
 		rotations: [Presets.ROTATION_PRESET_DEFAULT, Presets.ROTATION_PRESET_P3],
 		// Preset gear configurations that the user can quickly select.
@@ -128,7 +128,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 	raidSimPresets: [
 		{
 			spec: Spec.SpecEnhancementShaman,
-			talents: Presets.P3Talents.data,
+			talents: Presets.SubRestoIWT.data,
 			specOptions: Presets.DefaultOptions,
 			consumables: Presets.DefaultConsumables,
 			defaultFactionRaces: {


### PR DESCRIPTION
Added three talent presets for Enhancement Shaman and wired presets into the sim config so the talent preset buttons render in the UI. Verified preset selection applies correctly by manually inspecting the UI behavior. Set Sub Resto IWT as the default spec and as the Raid Sim preset, since it is currently the most recommended Enhancement spec in the Shaman community.