### PR TITLE
fix enum picker sizing issue

### DIFF
--- a/ui/scss/core/components/_enum_picker.scss
+++ b/ui/scss/core/components/_enum_picker.scss
@@ -1,6 +1,5 @@
 .enum-picker-root {
 	.enum-picker-selector {
-		width: auto;
 		max-width: 100%;
 	}
 }


### PR DESCRIPTION
Fixes this weird styling issue (on mop as well). They become full-width after
<img width="301" height="306" alt="image" src="https://github.com/user-attachments/assets/7ff204b7-6d45-4976-8546-dad184eaed84" />
<img width="387" height="283" alt="image" src="https://github.com/user-attachments/assets/2dbeb851-e97d-4161-a1ed-49bc195466a6" />
