### PR TITLE
Ensure SimOptions is present in input JSON after parsing

### DIFF
--- a/cmd/wowsimcli/cmd/basic_sim.go
+++ b/cmd/wowsimcli/cmd/basic_sim.go
@@ -41,6 +41,10 @@ func simMain(cmd *cobra.Command, args []string) {
 		log.Fatalf("failed to load input json file: %s", err)
 	}
 
+	if input.SimOptions == nil {
+		log.Fatalf("expected property 'simOptions' to be present in the input json file")
+	}
+
 	var output []byte
 	reporter := make(chan *proto.ProgressMetrics, 10)
 	core.RunRaidSimConcurrentAsync(input, reporter, "cmd-raid-sim")


### PR DESCRIPTION
Currently the CLI tool does not validate input data and simply passes it on to `RunRaidSimConcurrentAsync`. This is fine for most input data, as invalid input data is reported back to the user through an `ErrorOutcomeError`:

```sh
$ printf '{ "simOptions": {} }' | ./wowsimcli-amd64-linux sim --infile /dev/stdin 2>&1 | jq | sed 's/Stack Trace:.*"/Stack Trace: ..."/'
{
  "raidMetrics": null,
  "encounterMetrics": null,
  "logs": "",
  "firstIterationDuration": 0,
  "avgIterationDuration": 0,
  "error": {
    "type": "ErrorOutcomeError",
    "message": "Iterations can't be 0 or negative!\nStack Trace: ..."
  },
  "iterationsDone": 0
}
```

However, this is not true for the `SimOptions` property, which causes the program to panic if unset:

```sh
$ printf '{}' | ./wowsimcli-amd64-linux sim --infile /dev/stdin
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1a pc=0x799f26]

goroutine 11 [running]:
github.com/wowsims/tbc/sim/core.runSimConcurrent.func1()
	/home/ges/doc/src/github.com/kruhlmann/tbc-new/sim/core/sim_concurrent.go:420 +0x26
panic({0xb2ed00?, 0x17cdf30?})
	/nix/store/qpblhiv8rdnw45j0ghbbswcckcgsa6i0-go-1.25.6/share/go/src/runtime/panic.go:783 +0x132
github.com/wowsims/tbc/sim/core.runSimConcurrent(0xc000f57c80, 0xc000f65500, {{0xc000048150}})
	/home/ges/doc/src/github.com/kruhlmann/tbc-new/sim/core/sim_concurrent.go:446 +0xa8
github.com/wowsims/tbc/sim/core.RunRaidSimConcurrentAsync.func1()
	/home/ges/doc/src/github.com/kruhlmann/tbc-new/sim/core/api.go:108 +0x58
created by github.com/wowsims/tbc/sim/core.RunRaidSimConcurrentAsync in goroutine 1
	/home/ges/doc/src/github.com/kruhlmann/tbc-new/sim/core/api.go:106 +0x1ab
```

This is fixed by adding a pre-run check in the CLI module resulting in:

```sh
$ printf '{}' | ./wowsimcli-amd64-linux sim --infile /dev/stdin
2026/03/06 15:30:19 expected property 'simOptions' to be present in the input json file
```