### PR TITLE
[Hunter] Some fixes

### DIFF
--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -2438,7 +2438,8 @@
 				"to_exp_cap": "To Exp Cap:",
 				"spec_offsets": "Spec Offsets:",
 				"final_crit_cap": "Final Crit Cap:",
-				"can_raise_by": "Can Raise By:"
+				"can_raise_by": "Can Raise By:",
+				"eWS": "eWS:"
 			},
 			"attack_table": {
 				"glancing": "Glancing:",

--- a/schemas/translation.schema.json
+++ b/schemas/translation.schema.json
@@ -8509,6 +8509,9 @@
 								},
 								"can_raise_by": {
 									"type": "string"
+								},
+								"eWS": {
+									"type": "string"
 								}
 							},
 							"additionalProperties": false,
@@ -8527,7 +8530,8 @@
 								"to_exp_cap",
 								"spec_offsets",
 								"final_crit_cap",
-								"can_raise_by"
+								"can_raise_by",
+								"eWS"
 							]
 						},
 						"attack_table": {

--- a/sim/core/apl_actions_sequences.go
+++ b/sim/core/apl_actions_sequences.go
@@ -164,12 +164,6 @@ func (action *APLActionStrictSequence) IsReady(sim *Simulation) bool {
 		action.unit.Rotation.inSequence = false
 		return false
 	}
-	for _, spell := range action.subactionSpells {
-		if !spell.IsReady(sim) {
-			action.unit.Rotation.inSequence = false
-			return false
-		}
-	}
 
 	return true
 }

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -698,9 +698,13 @@ func registerStaticImbue(agent Agent, imbueId int32, isMH bool) {
 			character.AutoAttacks.OH().BaseDamageMin += 12
 		}
 
-		if imbueId == 34340 && character.AutoAttacks.Ranged() != nil {
+		if character.AutoAttacks.Ranged() != nil {
 			character.AutoAttacks.Ranged().BaseDamageMin += 12
 			character.AutoAttacks.Ranged().BaseDamageMax += 12
+
+			if imbueId == 29453 {
+				character.AddStat(stats.RangedCritPercent, -(14 / PhysicalCritRatingPerCritPercent))
+			}
 		}
 	case 28891: // Consecrated Sharpening Stone
 		character.Env.RegisterPostFinalizeEffect(func() {

--- a/sim/hunter/steady_shot.go
+++ b/sim/hunter/steady_shot.go
@@ -33,7 +33,10 @@ func (hunter *Hunter) registerSteadyShotSpell() {
 			} else if ranged != nil && ranged.Enchant.EffectID == 2723 {
 				weaponDamage -= 12
 			}
-			if hunter.Consumables.OhImbueId == 34340 || (hunter.Consumables.MhImbueId == 34340 && !hunter.windFuryEnabled) {
+			if hunter.Consumables.OhImbueId == 34340 || hunter.Consumables.OhImbueId == 29453 {
+				weaponDamage -= 12
+			}
+			if (hunter.Consumables.MhImbueId == 34340 || hunter.Consumables.MhImbueId == 29453) && !hunter.windFuryEnabled {
 				weaponDamage -= 12
 			}
 

--- a/sim/warrior/dps/TestDpsWarrior.results
+++ b/sim/warrior/dps/TestDpsWarrior.results
@@ -49,7 +49,7 @@ character_stats_results: {
   final_stats: 12.17422
   final_stats: 0
   final_stats: 0
-  final_stats: 0
+  final_stats: -0.63415
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -49,7 +49,7 @@ character_stats_results: {
   final_stats: 12.17422
   final_stats: 15.04
   final_stats: 0
-  final_stats: 0
+  final_stats: -0.63415
  }
 }
 dps_results: {
@@ -1512,8 +1512,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Protection-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2519.34338
-  tps: 2630.34709
+  dps: 2517.18739
+  tps: 2627.38036
   dtps: 26286.96223
  }
 }
@@ -1560,8 +1560,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Protection-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2394.89738
-  tps: 2518.85495
+  dps: 2391.79844
+  tps: 2515.2947
   dtps: 26624.115
  }
 }
@@ -1608,8 +1608,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Protection-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2496.19477
-  tps: 2609.19655
+  dps: 2494.32315
+  tps: 2606.75267
   dtps: 26398.96505
  }
 }
@@ -1656,8 +1656,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Protection-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2353.20724
-  tps: 2480.80099
+  dps: 2350.72705
+  tps: 2477.6835
   dtps: 26700.40059
  }
 }

--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -6,7 +6,7 @@ import i18n from '../../i18n/config.js';
 import * as Mechanics from '../constants/mechanics.js';
 import { IndividualSimUI } from '../individual_sim_ui';
 import { Player } from '../player.js';
-import { ItemSlot, PseudoStat, Race, Spec, Stat, TristateEffect, WeaponType } from '../proto/common.js';
+import { Class, ItemSlot, PseudoStat, Race, RangedWeaponType, Spec, Stat, TristateEffect, WeaponType } from '../proto/common.js';
 import { Stats, UnitStat } from '../proto_utils/stats.js';
 import { EventID, TypedEvent } from '../typed_event.js';
 import { Component } from './component.js';
@@ -196,6 +196,8 @@ export class CharacterStats extends Component {
 
 	private updateStats(player: Player<any>) {
 		const playerStats = player.getCurrentStats();
+		const gear = player.getGear();
+		const rangedWeapon = gear.getEquippedItem(ItemSlot.ItemSlotRanged);
 		const statMods = this.modifyDisplayStats ? this.modifyDisplayStats(this.player) : {};
 		this.hasRacialHitBonus = this.player.getRace() === Race.RaceDraenei;
 		this.activeRacialExpertiseBonuses = this.player.getActiveRacialExpertiseBonuses();
@@ -311,6 +313,23 @@ export class CharacterStats extends Component {
 					</div>
 				</div>
 			);
+
+			const hunterRangedTypes = [RangedWeaponType.RangedWeaponTypeBow, RangedWeaponType.RangedWeaponTypeCrossbow, RangedWeaponType.RangedWeaponTypeGun];
+			if (
+				player.getClass() === Class.ClassHunter &&
+				unitStat.isPseudoStat() &&
+				unitStat.getPseudoStat() === PseudoStat.PseudoStatRangedHastePercent &&
+				rangedWeapon &&
+				hunterRangedTypes.includes(rangedWeapon.item.rangedWeaponType)
+			) {
+				const speedStat = 1 + finalStats.getPseudoStat(PseudoStat.PseudoStatRangedHastePercent) / 100;
+				tooltipContent.appendChild(
+					<div className="character-stats-tooltip-row">
+						<span>{i18n.t('sidebar.character_stats.tooltip.eWS')}</span>
+						<span>{(rangedWeapon.item.weaponSpeed / speedStat).toFixed(2)}s</span>
+					</div>,
+				);
+			}
 
 			tippy(statLinkElem, {
 				content: tooltipContent,

--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -266,7 +266,7 @@ export class CharacterStats extends Component {
 			const valueElem = (
 				<div className="stat-value-link-container">
 					<button ref={statLinkElemRef} className={clsx('stat-value-link', contextualClass)}>
-						{`${this.statDisplayString(finalStats, unitStat, true)} `}
+						{`${this.statDisplayString(finalStats, unitStat, true, true)} `}
 					</button>
 				</div>
 			);
@@ -283,7 +283,7 @@ export class CharacterStats extends Component {
 					</div>
 					<div className="character-stats-tooltip-row">
 						<span>{i18n.t('sidebar.character_stats.tooltip.gear')}</span>
-						<span>{this.statDisplayString(gearDelta, unitStat)}</span>
+						<span>{this.statDisplayString(gearDelta, unitStat, false, true)}</span>
 					</div>
 					<div className="character-stats-tooltip-row">
 						<span>{i18n.t('sidebar.character_stats.tooltip.talents')}</span>
@@ -309,7 +309,7 @@ export class CharacterStats extends Component {
 					)}
 					<div className="character-stats-tooltip-row">
 						<span>{i18n.t('sidebar.character_stats.tooltip.total')}</span>
-						<span>{this.statDisplayString(finalStats, unitStat, true)}</span>
+						<span>{this.statDisplayString(finalStats, unitStat, true, true)}</span>
 					</div>
 				</div>
 			);
@@ -446,7 +446,7 @@ export class CharacterStats extends Component {
 		}
 	}
 
-	private statDisplayString(deltaStats: Stats, unitStat: UnitStat, includeBase?: boolean): string {
+	private statDisplayString(deltaStats: Stats, unitStat: UnitStat, includeBase?: boolean, includeGear?: boolean): string {
 		const rootStat = unitStat.hasRootStat() ? unitStat.getRootStat() : null;
 		let rootRatingValue = rootStat !== null ? deltaStats.getStat(rootStat) : null;
 		let percentDecimals = 2;
@@ -487,6 +487,14 @@ export class CharacterStats extends Component {
 				const ohPercentString = `${ohPercentValue.toFixed(percentDecimals)}` + displaySuffix;
 				const wrappedPercentString = hideRootRating ? `${mhPercentString} / ${ohPercentString}` : ` (${mhPercentString} / ${ohPercentString})`;
 				return rootRatingString + wrappedPercentString;
+			}
+		} else if (includeGear && rootRatingValue !== null && unitStat.equalsPseudoStat(PseudoStat.PseudoStatRangedHitPercent)) {
+			if (this.player.getEquippedItem(ItemSlot.ItemSlotRanged)?.enchant?.effectId === 2523) {
+				rootRatingValue += 30;
+			}
+		} else if (includeGear && rootRatingValue !== null && unitStat.equalsPseudoStat(PseudoStat.PseudoStatRangedCritPercent)) {
+			if (this.player.getEquippedItem(ItemSlot.ItemSlotRanged)?.enchant?.effectId === 2724) {
+				rootRatingValue += 28;
 			}
 		} else if (rootStat == Stat.StatBlockValue) {
 			if (rootRatingValue !== null && rootRatingValue > 0) {

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -301,7 +301,7 @@ function actionListFieldConfig(field: string): AplHelpers.APLPickerBuilderFieldC
 					index: number,
 					config: ListItemPickerConfig<Player<any>, APLAction>,
 				) => new APLActionPicker(parent, player, config),
-				allowedActions: ['create', 'delete', 'move'],
+				allowedActions: ['create', 'copy', 'delete', 'move'],
 				actions: {
 					create: {
 						useIcon: true,

--- a/ui/shaman/enhancement/apls/default.apl.json
+++ b/ui/shaman/enhancement/apls/default.apl.json
@@ -69,10 +69,17 @@
 				{
 					"action": {
 						"condition": {
-							"cmp": {
-								"op": "OpEq",
-								"lhs": { "variablePlaceholder": { "name": "Enable Fire Elemental?" } },
-								"rhs": { "variableRef": { "name": "Yes" } }
+							"and": {
+								"vals": [
+									{
+										"cmp": {
+											"op": "OpEq",
+											"lhs": { "variablePlaceholder": { "name": "Enable Fire Elemental?" } },
+											"rhs": { "variableRef": { "name": "Yes" } }
+										}
+									},
+									{ "spellIsReady": { "spellId": { "spellId": 2894, "rank": 1 } } }
+								]
 							}
 						},
 						"strictSequence": {


### PR DESCRIPTION
**Core**
* Weapon stones weren't dealt with properly for hunters
* Allow entering a strict sequence as long as the first action is ready
  * Previously required the *whole* sequence to be ready which meant you couldn't have one sequence instantly repeat if any sub action had a cooldown that wasn't ready when the sequence was reset
  * There was already a guard for this happening when executing the sequence which just exits the sequence if the GCD is ready and then next spell in line isn't

**UI**
* Add display of eWS (effective weapon speed) on the Ranged Haste tooltip
* Show the rating of hunter scopes properly on the character stats instead of just a % increase
* Allow copying actions inside an APL sequence