### PR TITLE
[Core/UI] Add toggle to show GCD blocks on the timeline

### DIFF
--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -1944,6 +1944,7 @@
 					"dps": "DPS",
 					"threat": "Threat"
 				},
+				"show_gcd": "Show GCD",
 				"chart_options": {
 					"time_axis": "Time (s)",
 					"waiting_for_data": "Waiting for data..."

--- a/schemas/translation.schema.json
+++ b/schemas/translation.schema.json
@@ -8149,6 +8149,9 @@
                     "threat"
                   ]
                 },
+                "show_gcd": {
+                  "type": "string"
+                },
                 "chart_options": {
                   "type": "object",
                   "properties": {
@@ -8215,6 +8218,7 @@
                 "disclaimer",
                 "note",
                 "chart_types",
+                "show_gcd",
                 "chart_options",
                 "tooltips"
               ]

--- a/sim/core/apl.go
+++ b/sim/core/apl.go
@@ -464,6 +464,21 @@ func (apl *APLRotation) getNextAction(sim *Simulation) *APLAction {
 	return nil
 }
 
+// HasBlockingControllingAction reports whether the rotation is currently parked
+// in a controlling action that has set the rotation timer to a specific wake
+// time and must not be cut short by reaction-time-based shrinks (Wait, WaitUntil).
+// Cooperative controllers like StrictSequence return false.
+func (apl *APLRotation) HasBlockingControllingAction() bool {
+	if apl == nil || len(apl.controllingActions) == 0 {
+		return false
+	}
+	switch apl.controllingActions[len(apl.controllingActions)-1].(type) {
+	case *APLActionWait, *APLActionWaitUntil:
+		return true
+	}
+	return false
+}
+
 func (apl *APLRotation) pushControllingAction(ca APLActionImpl) {
 	apl.controllingActions = append(apl.controllingActions, ca)
 }

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -518,6 +518,15 @@ func (unit *Unit) EnableAutoAttacks(agent Agent, options AutoAttackOptions) {
 
 			ModifyCast: func(sim *Simulation, spell *Spell, cast *Cast) {
 				cast.CastTime = spell.CastTime()
+
+				// Emit an "auto delayed" log line whenever the ranged auto fired
+				// later than it would have in an uncontested rotation. Below 1ms
+				// is treated as rounding noise so the common case stays silent.
+				delay := unit.AutoAttacks.RangedPendingSwingDelay()
+				readyAt := sim.CurrentTime - delay
+				if sim.Log != nil && delay > time.Millisecond && readyAt > 0 {
+					spell.Unit.Log(sim, "%s delayed by %s, was ready at %s", spell.ActionID, delay, readyAt)
+				}
 			},
 
 			CastTime: func(spell *Spell) time.Duration {
@@ -532,13 +541,6 @@ func (unit *Unit) EnableAutoAttacks(agent Agent, options AutoAttackOptions) {
 		BonusCoefficient:         1,
 
 		ApplyEffects: func(sim *Simulation, target *Unit, spell *Spell) {
-			// Emit an "auto delayed" log line whenever the ranged auto fired
-			// later than it would have in an uncontested rotation. Below 1ms
-			// is treated as rounding noise so the common case stays silent.
-			if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) && unit.AutoAttacks.ranged.pendingSwingDelay > time.Millisecond {
-				spell.Unit.Log(sim, "%s delayed by %s", spell.ActionID, unit.AutoAttacks.ranged.pendingSwingDelay)
-			}
-
 			baseDamage := spell.Unit.RangedWeaponDamage(sim, spell.RangedAttackPower(target))
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHitAndCrit)
@@ -602,6 +604,7 @@ func (aa *AutoAttacks) reset(_ *Simulation) {
 		aa.mh.updateSwingDuration(aa.mh.unit.TotalMeleeHasteMultiplier())
 		aa.mh.previousSwing = -aa.MainhandSwingSpeed()
 		aa.mh.swingAt = 0
+		aa.mh.naturalReadyAt = 0
 
 		if aa.IsDualWielding {
 			aa.oh.updateSwingDuration(aa.oh.unit.TotalMeleeHasteMultiplier())
@@ -638,6 +641,7 @@ func (aa *AutoAttacks) startPull(sim *Simulation) {
 	if aa.AutoSwingMelee {
 		if aa.mh.swingAt == NeverExpires {
 			aa.mh.swingAt = 0
+			aa.mh.naturalReadyAt = 0
 		}
 
 		if aa.IsDualWielding {
@@ -665,7 +669,6 @@ func (aa *AutoAttacks) startPull(sim *Simulation) {
 			aa.ranged.enabled = true
 			aa.ranged.addWeaponAttack(sim, aa.ranged.unit.TotalRangedHasteMultiplier())
 		}
-
 	}
 }
 
@@ -770,6 +773,14 @@ func (aa *AutoAttacks) OffhandSwingSpeed() time.Duration {
 // The amount of time between two Ranged swings.
 func (aa *AutoAttacks) RangedSwingSpeed() time.Duration {
 	return aa.ranged.curSwingDuration
+}
+
+func (aa *AutoAttacks) MainHandPendingSwingDelay() time.Duration {
+	return aa.mh.pendingSwingDelay
+}
+
+func (aa *AutoAttacks) RangedPendingSwingDelay() time.Duration {
+	return aa.ranged.pendingSwingDelay
 }
 
 // Optionally replaces the given swing spell with an Agent-specified MH Swing replacer.

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -58,7 +58,7 @@ type Cast struct {
 	NonEmpty bool
 }
 
-func (cast *Cast) EffectiveTime() time.Duration {
+func (cast *Cast) GCDTime() time.Duration {
 	gcd := max(0, cast.GCD)
 	if cast.GCD > 0 {
 		if cast.GCDMin != 0 {
@@ -67,7 +67,11 @@ func (cast *Cast) EffectiveTime() time.Duration {
 			gcd = max(GCDMin, gcd)
 		}
 	}
-	return max(gcd, cast.CastTime)
+	return gcd
+}
+
+func (cast *Cast) EffectiveTime() time.Duration {
+	return max(cast.GCDTime(), cast.CastTime)
 }
 
 type CastFunc func(*Simulation, *Unit)
@@ -173,8 +177,8 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 		// Hardcasts
 		if spell.CurCast.CastTime > 0 {
 			if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
-				spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
-					spell.ActionID, max(0, spell.CurCast.Cost), spell.CurCast.CastTime, spell.CurCast.EffectiveTime())
+				spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, GCD = %s, Effective Time = %s)",
+					spell.ActionID, max(0, spell.CurCast.Cost), spell.CurCast.CastTime, max(0, spell.CurCast.GCDTime()), spell.CurCast.EffectiveTime())
 			}
 
 			spell.Unit.Hardcast = Hardcast{
@@ -220,8 +224,8 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 		}
 
 		if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
-			spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
-				spell.ActionID, max(0, spell.CurCast.Cost), spell.CurCast.CastTime, spell.CurCast.EffectiveTime())
+			spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, GCD = %s, Effective Time = %s)",
+				spell.ActionID, max(0, spell.CurCast.Cost), spell.CurCast.CastTime, max(0, spell.CurCast.GCDTime()), spell.CurCast.EffectiveTime())
 			spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
 		}
 
@@ -304,8 +308,8 @@ func (spell *Spell) makeCastFuncSimple() CastSuccessFunc {
 		}
 
 		if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
-			spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
-				spell.ActionID, 0.0, "0s", "0s")
+			spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, GCD = %s, Effective Time = %s)",
+				spell.ActionID, 0.0, "0s", "0s", "0s")
 			spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
 		}
 
@@ -334,8 +338,8 @@ func (spell *Spell) makeCastFuncSimple() CastSuccessFunc {
 func (spell *Spell) makeCastFuncAutosOrProcs() CastSuccessFunc {
 	return func(sim *Simulation, target *Unit) bool {
 		if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
-			spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
-				spell.ActionID, 0.0, "0s", "0s")
+			spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, GCD = %s, Effective Time = %s)",
+				spell.ActionID, 0.0, "0s", "0s", "0s")
 			spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
 		}
 
@@ -354,8 +358,8 @@ func (spell *Spell) makeCastFuncAutosOrProcs() CastSuccessFunc {
 // Can be used for spells that proc off other spells and are the same spell id
 func (spell *Spell) Proc(sim *Simulation, target *Unit) {
 	if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
-		spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, Effective Time = %s)",
-			spell.ActionID, 0.0, "0s", "0s")
+		spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s, GCD = %s, Effective Time = %s)",
+			spell.ActionID, 0.0, "0s", "0s", "0s")
 		spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
 	}
 

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -159,8 +159,11 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 			return spell.castFailureHelper(sim, "casting/channeling %v for %s, curTime = %s", hc.ActionID, hc.Expires-sim.CurrentTime, sim.CurrentTime)
 		}
 
-		if effectiveTime := spell.CurCast.EffectiveTime(); effectiveTime != 0 {
+		if (spell.Flags&SpellFlagCanCastWhileMoving == 0) && (spell.CurCast.CastTime > 0) && spell.Unit.Moving {
+			return spell.castFailureHelper(sim, "casting/channeling while moving not allowed!")
+		}
 
+		if effectiveTime := spell.CurCast.EffectiveTime(); effectiveTime != 0 {
 			// do not add channeled time here as they have variable cast length
 			// cast time for channels is handled in dot.OnExpire
 			if !spell.Flags.Matches(SpellFlagChanneled) {
@@ -168,10 +171,6 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 			}
 
 			spell.Unit.SetGCDTimer(sim, max(sim.CurrentTime+effectiveTime, spell.Unit.NextGCDAt()))
-		}
-
-		if (spell.Flags&SpellFlagCanCastWhileMoving == 0) && (spell.CurCast.CastTime > 0) && spell.Unit.Moving {
-			return spell.castFailureHelper(sim, "casting/channeling while moving not allowed!")
 		}
 
 		// Hardcasts

--- a/sim/core/gcd.go
+++ b/sim/core/gcd.go
@@ -70,6 +70,12 @@ func (unit *Unit) ReactToEvent(sim *Simulation, randomizeReactionTime bool, addR
 	// If the next rotation action was already scheduled for this timestep then execute it now
 	unit.Rotation.DoNextAction(sim)
 
+	// A blocking controlling action (Wait / WaitUntil) has set the rotation timer
+	// to when it wants to wake; don't shrink it based on reaction time.
+	if unit.Rotation.HasBlockingControllingAction() {
+		return
+	}
+
 	// Otherwise schedule an evaluation based on reaction time
 	newEvaluationTime := sim.CurrentTime
 	if addReactionTime {

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -55,1482 +55,1482 @@ character_stats_results: {
 dps_results: {
  key: "TestHunter-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 3114.68375
-  tps: 2099.78414
-  dtps: 13.12842
+  dps: 3110.2566
+  tps: 2088.59576
+  dtps: 12.79398
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 3145.77764
-  tps: 2130.36587
-  dtps: 13.09299
+  dps: 3150.68754
+  tps: 2133.17353
+  dtps: 12.93103
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 3047.7892
-  tps: 2043.20448
-  dtps: 13.56131
+  dps: 3049.83809
+  tps: 2051.95089
+  dtps: 13.64003
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 3079.30661
-  tps: 2070.73622
-  dtps: 13.1369
+  dps: 3079.84456
+  tps: 2078.04214
+  dtps: 13.14349
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Annihilator-12798"
  value: {
-  dps: 2888.30758
-  tps: 1881.04672
-  dtps: 12.86822
+  dps: 2899.48056
+  tps: 1899.93146
+  dtps: 12.67942
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 2846.64169
-  tps: 1864.10935
-  dtps: 13.30387
+  dps: 2847.34156
+  tps: 1867.25062
+  dtps: 13.14873
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 3099.26736
-  tps: 2086.26188
-  dtps: 13.13388
+  dps: 3103.37225
+  tps: 2097.69429
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 3086.22211
-  tps: 2076.91506
-  dtps: 13.1369
+  dps: 3090.33214
+  tps: 2087.41925
+  dtps: 13.14349
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 3084.61701
-  tps: 2078.89057
-  dtps: 13.13388
+  dps: 3089.01934
+  tps: 2090.49112
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 3165.98592
-  tps: 2148.71013
-  dtps: 13.09299
+  dps: 3177.7212
+  tps: 2158.38774
+  dtps: 12.88676
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 3099.68058
-  tps: 2090.71192
-  dtps: 13.09299
+  dps: 3109.34823
+  tps: 2097.53995
+  dtps: 12.88676
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 3099.68058
-  tps: 2090.9308
-  dtps: 13.57619
+  dps: 3109.34823
+  tps: 2097.77074
+  dtps: 13.36401
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BattlecastGarb"
  value: {
-  dps: 2790.76854
-  tps: 1812.45712
-  dtps: 12.93398
+  dps: 2782.78994
+  tps: 1801.33646
+  dtps: 12.77321
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 3039.71976
-  tps: 2033.88783
-  dtps: 13.08664
+  dps: 3042.08139
+  tps: 2028.36997
+  dtps: 13.18245
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 3039.71976
-  tps: 2033.88783
-  dtps: 13.08664
+  dps: 3042.08139
+  tps: 2028.36997
+  dtps: 13.18245
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 3085.89914
-  tps: 2078.14424
-  dtps: 13.1369
+  dps: 3088.86018
+  tps: 2086.77333
+  dtps: 13.1417
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.56131
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.64003
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 3085.72674
-  tps: 2075.20979
-  dtps: 13.13388
+  dps: 3090.78452
+  tps: 2086.74223
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 3106.81009
-  tps: 2041.78534
-  dtps: 12.97758
+  dps: 3112.99984
+  tps: 2049.69406
+  dtps: 12.82498
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeastLordArmor"
  value: {
-  dps: 2860.69198
-  tps: 1882.71573
-  dtps: 12.63512
+  dps: 2850.57119
+  tps: 1865.96092
+  dtps: 12.45906
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 3127.37853
-  tps: 2111.12443
-  dtps: 13.13388
+  dps: 3132.54382
+  tps: 2122.67601
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 3136.47051
-  tps: 2121.05874
-  dtps: 13.09299
+  dps: 3141.39522
+  tps: 2123.8812
+  dtps: 12.93103
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 3135.28306
-  tps: 2145.47734
-  dtps: 12.97525
+  dps: 3130.25951
+  tps: 2135.94864
+  dtps: 12.91525
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 3129.34858
-  tps: 2110.685
-  dtps: 13.45017
+  dps: 3151.82194
+  tps: 2134.40685
+  dtps: 12.57703
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 3085.69137
-  tps: 2075.98686
-  dtps: 13.1369
+  dps: 3086.60469
+  tps: 2083.66815
+  dtps: 13.14349
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 2892.28857
-  tps: 1886.96347
-  dtps: 12.83516
+  dps: 2895.5696
+  tps: 1895.36611
+  dtps: 12.82256
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Blinkstrike-31332"
  value: {
-  dps: 3172.37852
-  tps: 2168.37132
-  dtps: 12.77423
+  dps: 3159.38211
+  tps: 2158.4371
+  dtps: 13.14159
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 3116.98418
-  tps: 2107.02522
-  dtps: 13.09299
+  dps: 3130.29286
+  tps: 2116.78134
+  dtps: 12.88676
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 3102.37798
-  tps: 2097.32808
-  dtps: 13.05875
+  dps: 3106.27612
+  tps: 2097.63326
+  dtps: 12.95037
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 3049.39452
-  tps: 2043.66808
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 2942.22768
-  tps: 1939.90362
-  dtps: 12.89699
+  dps: 2936.84808
+  tps: 1933.5006
+  dtps: 12.8181
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 3093.28363
-  tps: 2081.90809
-  dtps: 13.13388
+  dps: 3098.3255
+  tps: 2093.35966
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 2942.22768
-  tps: 1939.93876
-  dtps: 12.89699
+  dps: 2936.84808
+  tps: 1933.53873
+  dtps: 12.8181
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CryptstalkerArmor"
  value: {
-  dps: 2850.88884
-  tps: 1851.12664
-  dtps: 12.82861
+  dps: 2861.55767
+  tps: 1863.46956
+  dtps: 12.58447
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 3076.66377
-  tps: 2069.39694
-  dtps: 13.13388
+  dps: 3081.35066
+  tps: 2080.57106
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 3102.6819
-  tps: 2089.11128
-  dtps: 13.13388
+  dps: 3107.00729
+  tps: 2100.70632
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 3075.23022
-  tps: 2064.86773
-  dtps: 13.1369
+  dps: 3079.20549
+  tps: 2075.27984
+  dtps: 13.1417
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DemonStalkerArmor"
  value: {
-  dps: 2873.73238
-  tps: 1883.43713
-  dtps: 13.4527
+  dps: 2870.82159
+  tps: 1879.86186
+  dtps: 13.26556
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Despair-28573"
  value: {
-  dps: 3226.83697
-  tps: 2218.71641
-  dtps: 12.86419
+  dps: 3215.8537
+  tps: 2215.65982
+  dtps: 13.07785
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DirebrewHops-38288"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DonSantos'FamousHuntingRifle-31323"
  value: {
-  dps: 3077.91752
-  tps: 2068.14866
-  dtps: 12.99686
+  dps: 3094.44549
+  tps: 2073.28334
+  dtps: 12.91163
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Earthstrike-21180"
  value: {
-  dps: 3077.35913
-  tps: 2068.47162
-  dtps: 13.13388
+  dps: 3082.30266
+  tps: 2079.77957
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 3110.58988
-  tps: 2096.73368
-  dtps: 13.13388
+  dps: 3115.69524
+  tps: 2108.23802
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantBoots-Boar'sSpeed-2940"
  value: {
-  dps: 3129.76454
-  tps: 2119.29688
-  dtps: 13.28853
+  dps: 3133.46788
+  tps: 2124.34689
+  dtps: 13.2283
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 3134.2682
-  tps: 2123.34107
-  dtps: 13.28853
+  dps: 3136.90221
+  tps: 2127.32191
+  dtps: 13.2283
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 3136.3753
-  tps: 2080.99989
-  dtps: 13.09299
+  dps: 3149.85045
+  tps: 2090.7022
+  dtps: 12.88676
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 3133.18966
-  tps: 2161.72379
-  dtps: 13.09299
+  dps: 3146.2136
+  tps: 2171.36216
+  dtps: 12.88676
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 3119.05981
-  tps: 2108.10743
-  dtps: 13.02866
+  dps: 3127.37361
+  tps: 2112.61092
+  dtps: 12.94727
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 3131.30749
-  tps: 2120.48657
-  dtps: 12.1378
+  dps: 3137.93688
+  tps: 2123.13035
+  dtps: 12.35278
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 3140.36458
-  tps: 2128.4048
-  dtps: 13.09299
+  dps: 3147.91492
+  tps: 2133.0062
+  dtps: 12.93103
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 3140.30644
-  tps: 2119.87213
-  dtps: 13.06469
+  dps: 3137.24877
+  tps: 2123.36782
+  dtps: 13.01981
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeofMoam-21473"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 3102.37798
-  tps: 2097.28237
-  dtps: 13.94201
+  dps: 3106.27612
+  tps: 2097.58446
+  dtps: 13.83818
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FelSkin"
  value: {
-  dps: 2933.05595
-  tps: 1940.36567
-  dtps: 13.08697
+  dps: 2941.70761
+  tps: 1942.14591
+  dtps: 12.93103
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FelscaleArmor"
  value: {
-  dps: 2906.06426
-  tps: 1916.62757
-  dtps: 12.86347
+  dps: 2897.03486
+  tps: 1906.54462
+  dtps: 12.68971
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 3084.93926
-  tps: 2074.52828
-  dtps: 13.13388
+  dps: 3089.79985
+  tps: 2085.91433
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 3207.06929
-  tps: 2191.10502
-  dtps: 13.43312
+  dps: 3198.03304
+  tps: 2182.41744
+  dtps: 13.22332
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HandofJustice-11815"
  value: {
-  dps: 3057.86312
-  tps: 2051.5101
-  dtps: 13.13388
+  dps: 3062.78565
+  tps: 2062.87891
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 3043.36696
-  tps: 2038.75043
-  dtps: 13.07576
+  dps: 3039.58739
+  tps: 2037.47727
+  dtps: 13.11949
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 12.60978
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 12.6542
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Heartrazor-29962"
  value: {
-  dps: 3156.83467
-  tps: 2143.43545
-  dtps: 13.5461
+  dps: 3197.1583
+  tps: 2186.83958
+  dtps: 13.07665
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 3048.57525
-  tps: 2043.39201
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.72894
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 3095.76126
-  tps: 2084.9958
-  dtps: 13.1369
+  dps: 3098.99413
+  tps: 2094.32179
+  dtps: 13.1417
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IceGuard-2682"
  value: {
-  dps: 3122.11562
-  tps: 2111.99402
-  dtps: 13.02939
+  dps: 3121.25861
+  tps: 2109.55503
+  dtps: 12.91164
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 3066.55545
-  tps: 2061.5904
-  dtps: 13.13388
+  dps: 3071.34893
+  tps: 2072.82071
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImbuedNetherweave"
  value: {
-  dps: 2773.63806
-  tps: 1802.85538
-  dtps: 13.33025
+  dps: 2758.35019
+  tps: 1787.48294
+  dtps: 13.08914
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-JomGabbar-23570"
  value: {
-  dps: 3085.45068
-  tps: 2075.83657
-  dtps: 13.14213
+  dps: 3090.6328
+  tps: 2087.36993
+  dtps: 13.14872
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KhoriumScope-2723"
  value: {
-  dps: 3147.63907
-  tps: 2132.22729
-  dtps: 13.09299
+  dps: 3152.546
+  tps: 2135.03199
+  dtps: 12.93103
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 3081.11273
-  tps: 2076.89983
-  dtps: 13.41039
+  dps: 3081.73773
+  tps: 2080.37004
+  dtps: 13.35133
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartChampion-28429"
  value: {
-  dps: 3278.12077
-  tps: 2259.65885
-  dtps: 12.68626
+  dps: 3262.69939
+  tps: 2244.97292
+  dtps: 13.02021
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 3280.87904
-  tps: 2262.41712
-  dtps: 12.68626
+  dps: 3265.51646
+  tps: 2247.78998
+  dtps: 13.02021
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 11.76057
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 11.81207
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 3109.3337
-  tps: 2098.56638
-  dtps: 13.13388
+  dps: 3114.56215
+  tps: 2110.27138
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 2593.32423
-  tps: 1638.30864
-  dtps: 13.81297
+  dps: 2581.77147
+  tps: 1625.51338
+  dtps: 13.57305
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 3011.97106
-  tps: 2003.36182
-  dtps: 13.09299
+  dps: 3016.61246
+  tps: 2005.82477
+  dtps: 12.93103
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 3044.03394
-  tps: 2036.77247
-  dtps: 13.0745
+  dps: 3055.19138
+  tps: 2048.75931
+  dtps: 13.08109
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 3049.36731
-  tps: 2043.66808
-  dtps: 13.13388
+  dps: 3053.42547
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherscaleArmor"
  value: {
-  dps: 3015.08976
-  tps: 2008.07632
-  dtps: 13.09299
+  dps: 3028.10282
+  tps: 2017.55141
+  dtps: 12.88676
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherstrikeArmor"
  value: {
-  dps: 2880.50525
-  tps: 1892.38295
-  dtps: 13.87785
+  dps: 2896.48539
+  tps: 1906.8352
+  dtps: 13.60992
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherweaveVestments"
  value: {
-  dps: 2592.32366
-  tps: 1635.74627
-  dtps: 12.97447
+  dps: 2592.62937
+  tps: 1633.81546
+  dtps: 12.75617
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 3085.3827
-  tps: 2075.13779
-  dtps: 13.13388
+  dps: 3090.3557
+  tps: 2086.58584
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 3102.37798
-  tps: 2097.28237
-  dtps: 12.07896
+  dps: 3106.27612
+  tps: 2097.58446
+  dtps: 11.99041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 3102.37798
-  tps: 2097.28237
-  dtps: 13.05875
+  dps: 3106.27612
+  tps: 2097.58446
+  dtps: 12.95037
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofThawing-24093"
  value: {
-  dps: 3102.37798
-  tps: 2097.28237
-  dtps: 13.05875
+  dps: 3106.27612
+  tps: 2097.58446
+  dtps: 12.95037
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofWithering-24095"
  value: {
-  dps: 3102.37798
-  tps: 2097.28237
-  dtps: 13.05875
+  dps: 3106.27612
+  tps: 2097.58446
+  dtps: 12.95037
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 3102.37798
-  tps: 2097.28237
-  dtps: 13.05875
+  dps: 3106.27612
+  tps: 2097.58446
+  dtps: 12.95037
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 3048.57525
-  tps: 2043.70906
-  dtps: 13.48918
+  dps: 3053.45269
+  tps: 2055.05382
+  dtps: 13.49578
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrimalIntent"
  value: {
-  dps: 3072.62589
-  tps: 2056.96295
-  dtps: 13.09299
+  dps: 3083.17047
+  tps: 2061.36211
+  dtps: 12.93103
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrimalMooncloth"
  value: {
-  dps: 2858.2487
-  tps: 1873.09169
-  dtps: 13.39466
+  dps: 2869.73431
+  tps: 1884.63881
+  dtps: 13.11051
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Prismcharm-15867"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 12.92878
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 12.9732
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 3040.48168
-  tps: 2037.95406
-  dtps: 13.16698
+  dps: 3044.57015
+  tps: 2048.47652
+  dtps: 13.17357
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RiftStalkerArmor"
  value: {
-  dps: 2982.45507
-  tps: 1977.10214
-  dtps: 13.25117
+  dps: 3000.77715
+  tps: 1988.97254
+  dtps: 13.13735
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 3011.97106
-  tps: 2003.35465
-  dtps: 13.57619
+  dps: 3016.61246
+  tps: 2005.81595
+  dtps: 13.40829
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 3064.52562
-  tps: 2059.26373
-  dtps: 12.83043
+  dps: 3070.55824
+  tps: 2071.8146
+  dtps: 12.67382
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RuneofForce-25994"
  value: {
-  dps: 3057.99139
-  tps: 2051.76231
-  dtps: 13.13388
+  dps: 3062.86063
+  tps: 2063.07844
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SavageGuard-2681"
  value: {
-  dps: 3122.11562
-  tps: 2111.99402
-  dtps: 13.02939
+  dps: 3121.25861
+  tps: 2109.55503
+  dtps: 12.91164
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 3029.0881
-  tps: 2027.22715
-  dtps: 13.13388
+  dps: 3033.91192
+  tps: 2038.44568
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 3085.63064
-  tps: 2077.34313
-  dtps: 13.04301
+  dps: 3085.75967
+  tps: 2076.93983
+  dtps: 13.06947
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 3047.7892
-  tps: 2043.20448
-  dtps: 13.13388
+  dps: 3049.83809
+  tps: 2051.95089
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.56131
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.64003
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 2824.12817
-  tps: 1840.90632
-  dtps: 13.30387
+  dps: 2824.72232
+  tps: 1846.02783
+  dtps: 13.14873
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShardofContempt-34472"
  value: {
-  dps: 3100.04909
-  tps: 2085.16206
-  dtps: 13.23013
+  dps: 3109.39979
+  tps: 2096.07862
+  dtps: 13.24838
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.56131
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.64003
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 3042.43207
-  tps: 2026.71954
-  dtps: 12.95428
+  dps: 3047.80903
+  tps: 2022.03214
+  dtps: 12.9845
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 3105.02433
-  tps: 2091.97548
-  dtps: 13.13388
+  dps: 3110.10741
+  tps: 2103.45842
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SoulclothEmbrace"
  value: {
-  dps: 2856.60334
-  tps: 1872.96036
-  dtps: 13.39466
+  dps: 2868.3163
+  tps: 1884.77426
+  dtps: 13.11051
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2790.76854
-  tps: 1812.36992
-  dtps: 13.09096
+  dps: 2782.78994
+  tps: 1801.24596
+  dtps: 12.97071
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.37573
+  tps: 2054.89133
+  dtps: 13.14047
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 3181.99338
-  tps: 2172.7864
-  dtps: 12.78312
+  dps: 3175.84475
+  tps: 2171.67614
+  dtps: 12.80884
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 3047.7892
-  tps: 2043.20448
-  dtps: 13.13388
+  dps: 3049.83809
+  tps: 2051.95089
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 3056.47984
-  tps: 2046.16467
-  dtps: 13.23013
+  dps: 3064.49196
+  tps: 2049.04049
+  dtps: 13.24838
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 2773.63806
-  tps: 1803.33273
-  dtps: 12.84706
+  dps: 2758.77999
+  tps: 1785.71786
+  dtps: 12.61188
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3099.16774
-  tps: 2087.30772
-  dtps: 13.14815
+  dps: 3102.61292
+  tps: 2092.1001
+  dtps: 13.08249
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 3047.7892
-  tps: 2043.20448
-  dtps: 13.13388
+  dps: 3049.83809
+  tps: 2051.95089
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalonofAl'ar-30448"
  value: {
-  dps: 3070.3861
-  tps: 2065.42106
-  dtps: 13.13388
+  dps: 3075.3559
+  tps: 2076.82769
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 3059.14608
-  tps: 2052.81137
-  dtps: 13.13388
+  dps: 3061.19019
+  tps: 2061.60231
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 3047.7892
-  tps: 2043.20448
-  dtps: 13.13388
+  dps: 3049.83809
+  tps: 2051.95089
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheBladefist-29348"
  value: {
-  dps: 2940.24505
-  tps: 1939.50532
-  dtps: 12.9326
+  dps: 2942.73051
+  tps: 1941.96557
+  dtps: 12.83133
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheNightBlade-31331"
  value: {
-  dps: 3122.14849
-  tps: 2111.44946
-  dtps: 13.56697
+  dps: 3165.47262
+  tps: 2159.03468
+  dtps: 13.07665
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 3048.57525
-  tps: 2043.6102
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.92447
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 3046.18821
-  tps: 2036.22941
-  dtps: 13.04841
+  dps: 3053.41841
+  tps: 2048.82794
+  dtps: 13.07945
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 3030.15616
-  tps: 2014.89559
-  dtps: 12.98012
+  dps: 3046.00456
+  tps: 2040.06221
+  dtps: 12.82107
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThickDraenicArmor"
  value: {
-  dps: 2877.71714
-  tps: 1886.81881
-  dtps: 13.38088
+  dps: 2879.83304
+  tps: 1893.37881
+  dtps: 13.21149
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Thori'dal,theStars'Fury-34334"
  value: {
-  dps: 3371.89969
-  tps: 2367.1266
-  dtps: 13.01647
+  dps: 3382.67968
+  tps: 2368.84155
+  dtps: 12.91163
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 3127.34563
-  tps: 2110.05419
-  dtps: 12.30429
+  dps: 3159.14635
+  tps: 2146.02574
+  dtps: 12.60731
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 3048.57525
-  tps: 2043.20452
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.54877
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 3111.60221
-  tps: 2098.92312
-  dtps: 13.1369
+  dps: 3114.15603
+  tps: 2107.95206
+  dtps: 13.1417
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-UnitingCharm-25633"
  value: {
-  dps: 3085.3827
-  tps: 2075.13779
-  dtps: 13.13388
+  dps: 3090.3557
+  tps: 2086.58584
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 3047.7892
-  tps: 2043.20448
-  dtps: 13.56131
+  dps: 3049.83809
+  tps: 2051.95089
+  dtps: 13.64003
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 3048.57525
-  tps: 2043.32649
-  dtps: 13.13388
+  dps: 3053.45269
+  tps: 2054.66676
+  dtps: 13.14047
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WastewalkerArmor"
  value: {
-  dps: 2862.13817
-  tps: 1872.22583
-  dtps: 13.252
+  dps: 2878.14585
+  tps: 1885.85988
+  dtps: 13.06969
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WhitemendWisdom"
  value: {
-  dps: 2790.76854
-  tps: 1811.93028
-  dtps: 12.63512
+  dps: 2782.78994
+  tps: 1800.80063
+  dtps: 12.45906
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WindhawkArmor"
  value: {
-  dps: 2879.91144
-  tps: 1892.17241
-  dtps: 13.87785
+  dps: 2895.89158
+  tps: 1906.62769
+  dtps: 13.60992
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 3099.68058
-  tps: 2090.86682
-  dtps: 13.09299
+  dps: 3109.34823
+  tps: 2097.69518
+  dtps: 12.88676
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WrathofSpellfire"
  value: {
-  dps: 2868.87239
-  tps: 1879.99808
-  dtps: 13.87785
+  dps: 2880.87392
+  tps: 1893.79907
+  dtps: 13.60992
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 3043.36696
-  tps: 2038.75043
-  dtps: 13.07576
+  dps: 3039.58739
+  tps: 2037.47727
+  dtps: 13.11949
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 3047.7892
-  tps: 2043.20448
-  dtps: 13.56131
+  dps: 3049.83809
+  tps: 2051.95089
+  dtps: 13.64003
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 3138.27834
-  tps: 2130.77577
-  dtps: 12.64579
+  dps: 3139.25724
+  tps: 2131.82393
+  dtps: 12.62392
  }
 }
 dps_results: {
@@ -1581,46 +1581,46 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 5823.72446
-  tps: 5683.66586
-  dtps: 11.05131
+  dps: 5816.64144
+  tps: 5659.4519
+  dtps: 10.84803
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 3079.14939
-  tps: 2118.01289
-  dtps: 13.06796
+  dps: 3081.10877
+  tps: 2116.34531
+  dtps: 12.88676
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3539.06386
-  tps: 2460.49408
-  dtps: 27.07236
+  dps: 3533.20199
+  tps: 2461.77112
+  dtps: 26.51345
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1030.60207
-  tps: 989.06502
+  dps: 1009.73962
+  tps: 967.35632
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 707.32729
-  tps: 511.85589
+  dps: 707.13895
+  tps: 511.71469
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 1018.38907
-  tps: 777.5762
+  dps: 1019.05606
+  tps: 779.33907
  }
 }
 dps_results: {
@@ -1671,8 +1671,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 5989.13136
-  tps: 6372.80567
+  dps: 5990.92758
+  tps: 6375.18169
   dtps: 10.49476
  }
 }
@@ -1695,15 +1695,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1019.09385
-  tps: 1106.7121
+  dps: 1019.85003
+  tps: 1108.62726
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 627.89556
-  tps: 514.85686
+  dps: 627.91398
+  tps: 514.87053
  }
 }
 dps_results: {
@@ -1761,46 +1761,46 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 5899.2643
-  tps: 5712.59262
-  dtps: 11.05131
+  dps: 5902.66408
+  tps: 5708.12732
+  dtps: 10.84803
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 3145.62959
-  tps: 2131.20154
-  dtps: 13.09299
+  dps: 3158.94614
+  tps: 2140.9812
+  dtps: 12.88676
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3637.50475
-  tps: 2497.48733
-  dtps: 27.07236
+  dps: 3635.21208
+  tps: 2505.71574
+  dtps: 26.51345
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1046.33933
-  tps: 988.27093
+  dps: 1028.2031
+  tps: 969.03071
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 726.67275
-  tps: 517.00002
+  dps: 725.66057
+  tps: 518.35613
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 1047.85259
-  tps: 790.97654
+  dps: 1043.02242
+  tps: 787.73439
  }
 }
 dps_results: {
@@ -1851,8 +1851,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 6044.41033
-  tps: 6406.37391
+  dps: 6044.77139
+  tps: 6405.58448
   dtps: 10.4604
  }
 }
@@ -1875,15 +1875,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1022.44928
-  tps: 1102.37607
+  dps: 1024.19531
+  tps: 1104.15727
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 641.95367
-  tps: 520.68752
+  dps: 642.03764
+  tps: 520.84657
  }
 }
 dps_results: {
@@ -1896,8 +1896,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2947.76589
-  tps: 2092.89362
-  dtps: 12.91288
+  dps: 2956.60075
+  tps: 2098.79594
+  dtps: 13.02754
  }
 }

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -55,1482 +55,1482 @@ character_stats_results: {
 dps_results: {
  key: "TestHunter-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 3118.57384
-  tps: 2102.38764
-  dtps: 12.87762
+  dps: 3158.5398
+  tps: 2147.51224
+  dtps: 13.17688
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 3142.39137
-  tps: 2131.62132
-  dtps: 12.93549
+  dps: 3205.61127
+  tps: 2200.89161
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 3055.56114
-  tps: 2051.71765
-  dtps: 13.54287
+  dps: 3106.74779
+  tps: 2101.30503
+  dtps: 13.1511
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 3085.57211
-  tps: 2077.7222
-  dtps: 13.04633
+  dps: 3140.44851
+  tps: 2135.7549
+  dtps: 12.76308
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Annihilator-12798"
  value: {
-  dps: 2894.81901
-  tps: 1896.13526
-  dtps: 12.92287
+  dps: 2984.21391
+  tps: 1992.08462
+  dtps: 12.88285
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 2853.16817
-  tps: 1873.49112
-  dtps: 13.09809
+  dps: 2909.00665
+  tps: 1922.84523
+  dtps: 13.38275
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 3106.40136
-  tps: 2095.40274
-  dtps: 13.04331
+  dps: 3153.30391
+  tps: 2141.11133
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 3095.23182
-  tps: 2087.74263
-  dtps: 13.04633
+  dps: 3141.24851
+  tps: 2132.61411
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 3091.90777
-  tps: 2088.14815
-  dtps: 13.04331
+  dps: 3144.04226
+  tps: 2138.33181
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 3168.50332
-  tps: 2155.97806
-  dtps: 12.89121
+  dps: 3238.59212
+  tps: 2229.91137
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 3101.58775
-  tps: 2096.55785
-  dtps: 12.89121
+  dps: 3170.40209
+  tps: 2169.96062
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 3101.58775
-  tps: 2096.78368
-  dtps: 13.41291
+  dps: 3170.40209
+  tps: 2170.21183
+  dtps: 13.57077
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BattlecastGarb"
  value: {
-  dps: 2782.37908
-  tps: 1805.54151
-  dtps: 12.74459
+  dps: 2851.73718
+  tps: 1869.60212
+  dtps: 13.30666
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 3048.11423
-  tps: 2035.29739
-  dtps: 13.02898
+  dps: 3088.74032
+  tps: 2089.08955
+  dtps: 12.57313
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 3048.11423
-  tps: 2035.29739
-  dtps: 13.02898
+  dps: 3088.74032
+  tps: 2089.08955
+  dtps: 12.57313
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 3090.73351
-  tps: 2083.97022
-  dtps: 13.04633
+  dps: 3142.52415
+  tps: 2146.15436
+  dtps: 12.78782
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.54287
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 13.1511
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 3093.72443
-  tps: 2083.92672
-  dtps: 13.04331
+  dps: 3145.98154
+  tps: 2134.72248
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 3117.33184
-  tps: 2059.67253
-  dtps: 12.82943
+  dps: 3190.13211
+  tps: 2127.04419
+  dtps: 12.86458
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeastLordArmor"
  value: {
-  dps: 2851.53958
-  tps: 1871.55841
-  dtps: 12.4094
+  dps: 2921.92686
+  tps: 1934.00999
+  dtps: 12.97147
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 3135.33139
-  tps: 2119.69947
-  dtps: 13.04331
+  dps: 3190.96026
+  tps: 2173.77281
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 3133.06573
-  tps: 2122.29569
-  dtps: 12.93549
+  dps: 3196.697
+  tps: 2191.97735
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 3136.66115
-  tps: 2139.64555
-  dtps: 12.86442
+  dps: 3233.46472
+  tps: 2226.01008
+  dtps: 12.94186
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 3152.30641
-  tps: 2137.12918
-  dtps: 12.49128
+  dps: 3214.25349
+  tps: 2202.43464
+  dtps: 12.73756
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 3092.33223
-  tps: 2083.34821
-  dtps: 13.04633
+  dps: 3146.40672
+  tps: 2143.44183
+  dtps: 12.76308
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 2894.81853
-  tps: 1900.59922
-  dtps: 12.99977
+  dps: 2978.76061
+  tps: 1985.97155
+  dtps: 13.22898
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Blinkstrike-31332"
  value: {
-  dps: 3173.07114
-  tps: 2169.84372
-  dtps: 12.65991
+  dps: 3176.09721
+  tps: 2165.16124
+  dtps: 12.70355
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 3121.7037
-  tps: 2114.89897
-  dtps: 12.89121
+  dps: 3189.15222
+  tps: 2187.79797
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 3100.24509
-  tps: 2099.79391
-  dtps: 12.81806
+  dps: 3151.46993
+  tps: 2154.83164
+  dtps: 13.27482
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 3056.58705
-  tps: 2052.82743
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 2930.72375
-  tps: 1935.51989
-  dtps: 12.69435
+  dps: 2987.69419
+  tps: 1993.73415
+  dtps: 13.12876
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 3101.19627
-  tps: 2090.48437
-  dtps: 13.04331
+  dps: 3154.73646
+  tps: 2142.51118
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 2930.72375
-  tps: 1935.55087
-  dtps: 12.69435
+  dps: 2987.69419
+  tps: 1993.75447
+  dtps: 13.12876
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CryptstalkerArmor"
  value: {
-  dps: 2855.32907
-  tps: 1859.54859
-  dtps: 12.69299
+  dps: 2920.27063
+  tps: 1927.37802
+  dtps: 12.48254
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 3084.34247
-  tps: 2077.80972
-  dtps: 13.04331
+  dps: 3136.88024
+  tps: 2128.81079
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 3110.1043
-  tps: 2098.51998
-  dtps: 13.04331
+  dps: 3162.86129
+  tps: 2149.29339
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 3084.90175
-  tps: 2076.00121
-  dtps: 13.19059
+  dps: 3128.79883
+  tps: 2133.57713
+  dtps: 13.09983
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DemonStalkerArmor"
  value: {
-  dps: 2880.70251
-  tps: 1889.48377
-  dtps: 13.36317
+  dps: 2945.72449
+  tps: 1941.61746
+  dtps: 13.65071
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Despair-28573"
  value: {
-  dps: 3210.24219
-  tps: 2207.31612
-  dtps: 13.24196
+  dps: 3378.27103
+  tps: 2366.93646
+  dtps: 13.05657
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DirebrewHops-38288"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DonSantos'FamousHuntingRifle-31323"
  value: {
-  dps: 3101.29493
-  tps: 2073.79154
-  dtps: 13.07124
+  dps: 3191.91276
+  tps: 2178.4912
+  dtps: 13.11055
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Earthstrike-21180"
  value: {
-  dps: 3085.1646
-  tps: 2076.91646
-  dtps: 13.04331
+  dps: 3138.50051
+  tps: 2128.71853
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 3118.52476
-  tps: 2105.31207
-  dtps: 13.04331
+  dps: 3173.10913
+  tps: 2158.36248
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantBoots-Boar'sSpeed-2940"
  value: {
-  dps: 3137.20349
-  tps: 2130.75363
-  dtps: 13.08958
+  dps: 3214.52212
+  tps: 2208.31844
+  dtps: 12.92851
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 3140.64197
-  tps: 2133.73436
-  dtps: 13.08958
+  dps: 3219.32888
+  tps: 2212.66725
+  dtps: 12.92851
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 3141.22599
-  tps: 2088.85126
-  dtps: 12.89121
+  dps: 3207.35177
+  tps: 2159.0423
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 3137.58942
-  tps: 2169.43512
-  dtps: 12.89121
+  dps: 3204.64862
+  tps: 2243.40968
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 3119.04225
-  tps: 2111.27733
-  dtps: 12.82356
+  dps: 3184.96318
+  tps: 2183.37657
+  dtps: 12.96751
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 3129.67861
-  tps: 2121.69153
-  dtps: 12.30872
+  dps: 3189.55108
+  tps: 2191.16975
+  dtps: 12.7078
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 3143.73534
-  tps: 2136.72048
-  dtps: 12.91459
+  dps: 3214.85317
+  tps: 2212.98429
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 3134.37351
-  tps: 2119.5078
-  dtps: 12.88568
+  dps: 3220.79613
+  tps: 2210.52648
+  dtps: 12.72899
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeofMoam-21473"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 3100.24509
-  tps: 2099.75556
-  dtps: 13.81131
+  dps: 3151.46993
+  tps: 2154.79921
+  dtps: 14.1913
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FelSkin"
  value: {
-  dps: 2932.95196
-  tps: 1939.94289
-  dtps: 12.93549
+  dps: 2984.64969
+  tps: 2000.44906
+  dtps: 13.04847
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FelscaleArmor"
  value: {
-  dps: 2901.13607
-  tps: 1915.49068
-  dtps: 12.63461
+  dps: 2973.1163
+  tps: 1974.64962
+  dtps: 13.15205
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 3092.62493
-  tps: 2082.99784
-  dtps: 13.04331
+  dps: 3145.58938
+  tps: 2134.49726
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 3198.52879
-  tps: 2187.70986
-  dtps: 13.18097
+  dps: 3252.14046
+  tps: 2246.99174
+  dtps: 13.6703
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HandofJustice-11815"
  value: {
-  dps: 3065.75325
-  tps: 2060.11647
-  dtps: 13.04331
+  dps: 3116.95518
+  tps: 2109.85758
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 3049.49716
-  tps: 2044.23161
-  dtps: 12.98352
+  dps: 3112.31769
+  tps: 2105.27623
+  dtps: 12.56977
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 12.53516
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.23034
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Heartrazor-29962"
  value: {
-  dps: 3197.37844
-  tps: 2187.34379
-  dtps: 12.50758
+  dps: 3364.76351
+  tps: 2351.19641
+  dtps: 12.97398
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 3056.42953
-  tps: 2051.9751
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.33077
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 3101.2552
-  tps: 2092.42979
-  dtps: 13.04633
+  dps: 3155.25825
+  tps: 2154.58831
+  dtps: 12.76308
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IceGuard-2682"
  value: {
-  dps: 3115.65119
-  tps: 2112.17146
-  dtps: 12.77933
+  dps: 3165.69916
+  tps: 2166.20154
+  dtps: 13.26597
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 3074.28038
-  tps: 2070.03058
-  dtps: 13.04331
+  dps: 3126.63105
+  tps: 2120.9206
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImbuedNetherweave"
  value: {
-  dps: 2764.908
-  tps: 1794.87849
-  dtps: 13.12978
+  dps: 2828.51697
+  tps: 1843.5039
+  dtps: 13.60311
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-JomGabbar-23570"
  value: {
-  dps: 3093.54799
-  tps: 2084.47496
-  dtps: 13.05156
+  dps: 3146.83491
+  tps: 2136.04594
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KhoriumScope-2723"
  value: {
-  dps: 3144.25649
-  tps: 2133.48645
-  dtps: 12.93549
+  dps: 3207.39412
+  tps: 2202.67446
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 3081.82383
-  tps: 2082.80379
-  dtps: 13.28508
+  dps: 3128.2704
+  tps: 2126.92421
+  dtps: 12.85083
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartChampion-28429"
  value: {
-  dps: 3263.76611
-  tps: 2248.52066
-  dtps: 13.04793
+  dps: 3407.69814
+  tps: 2397.43149
+  dtps: 12.49486
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 3266.53843
-  tps: 2251.29297
-  dtps: 13.04793
+  dps: 3414.65348
+  tps: 2403.43792
+  dtps: 12.49486
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 11.69303
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 11.23822
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 3117.40086
-  tps: 2107.35298
-  dtps: 13.04331
+  dps: 3170.66719
+  tps: 2159.1307
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 2588.34955
-  tps: 1634.45746
-  dtps: 13.73745
+  dps: 2650.62566
+  tps: 1691.83326
+  dtps: 14.08591
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 3008.87266
-  tps: 2004.87816
-  dtps: 12.93549
+  dps: 3065.51618
+  tps: 2069.79485
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 3060.32675
-  tps: 2054.41892
-  dtps: 12.98393
+  dps: 3090.34348
+  tps: 2087.33245
+  dtps: 12.86872
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 3056.55984
-  tps: 2052.82743
-  dtps: 13.04331
+  dps: 3107.23454
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherscaleArmor"
  value: {
-  dps: 3019.5918
-  tps: 2015.72254
-  dtps: 12.89121
+  dps: 3085.65708
+  tps: 2087.14733
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherstrikeArmor"
  value: {
-  dps: 2887.79509
-  tps: 1899.52186
-  dtps: 13.75451
+  dps: 2947.13638
+  tps: 1961.21904
+  dtps: 13.63527
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherweaveVestments"
  value: {
-  dps: 2597.77171
-  tps: 1646.17776
-  dtps: 12.76774
+  dps: 2649.35749
+  tps: 1693.36236
+  dtps: 12.9867
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 3093.26033
-  tps: 2083.69978
-  dtps: 13.04331
+  dps: 3146.25173
+  tps: 2135.13074
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 3100.24509
-  tps: 2099.75556
-  dtps: 11.86303
+  dps: 3151.46993
+  tps: 2154.79921
+  dtps: 12.13161
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 3100.24509
-  tps: 2099.75556
-  dtps: 12.81806
+  dps: 3151.46993
+  tps: 2154.79921
+  dtps: 13.27482
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofThawing-24093"
  value: {
-  dps: 3100.24509
-  tps: 2099.75556
-  dtps: 12.81806
+  dps: 3151.46993
+  tps: 2154.79921
+  dtps: 13.27482
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofWithering-24095"
  value: {
-  dps: 3100.24509
-  tps: 2099.75556
-  dtps: 12.81806
+  dps: 3151.46993
+  tps: 2154.79921
+  dtps: 13.27482
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 3100.24509
-  tps: 2099.75556
-  dtps: 12.81806
+  dps: 3151.46993
+  tps: 2154.79921
+  dtps: 13.27482
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 3056.42953
-  tps: 2052.29998
-  dtps: 13.39862
+  dps: 3107.27973
+  tps: 2101.62935
+  dtps: 12.99482
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrimalIntent"
  value: {
-  dps: 3075.01748
-  tps: 2060.13185
-  dtps: 12.93549
+  dps: 3132.50139
+  tps: 2126.05686
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrimalMooncloth"
  value: {
-  dps: 2859.966
-  tps: 1876.31777
-  dtps: 13.2328
+  dps: 2923.74171
+  tps: 1935.05755
+  dtps: 13.04056
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Prismcharm-15867"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 12.85415
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.45036
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 3047.54935
-  tps: 2045.73664
-  dtps: 13.07641
+  dps: 3102.3123
+  tps: 2096.8638
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RiftStalkerArmor"
  value: {
-  dps: 2985.56329
-  tps: 1979.37002
-  dtps: 13.09487
+  dps: 3060.5784
+  tps: 2056.6662
+  dtps: 13.22402
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 3008.87266
-  tps: 2004.87265
-  dtps: 13.45719
+  dps: 3065.51618
+  tps: 2069.78784
+  dtps: 13.57077
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 3073.63189
-  tps: 2069.20774
-  dtps: 12.55798
+  dps: 3125.88382
+  tps: 2119.74369
+  dtps: 12.13948
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RuneofForce-25994"
  value: {
-  dps: 3065.80501
-  tps: 2060.26957
-  dtps: 13.04331
+  dps: 3117.49654
+  tps: 2110.43601
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SavageGuard-2681"
  value: {
-  dps: 3115.65119
-  tps: 2112.17146
-  dtps: 12.77933
+  dps: 3165.69916
+  tps: 2166.20154
+  dtps: 13.26597
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 3036.91757
-  tps: 2035.72572
-  dtps: 13.04331
+  dps: 3087.59892
+  tps: 2084.95497
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 3086.03246
-  tps: 2078.9976
-  dtps: 12.93478
+  dps: 3108.3692
+  tps: 2097.91754
+  dtps: 13.14943
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 3055.56114
-  tps: 2051.71765
-  dtps: 13.04331
+  dps: 3106.74779
+  tps: 2101.30503
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.54287
+  dps: 3107.45441
+  tps: 2102.10991
+  dtps: 13.1511
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 2829.24611
-  tps: 1851.02539
-  dtps: 13.09809
+  dps: 2897.82918
+  tps: 1910.65148
+  dtps: 13.30529
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShardofContempt-34472"
  value: {
-  dps: 3108.30228
-  tps: 2096.6242
-  dtps: 13.14909
+  dps: 3163.6694
+  tps: 2151.05376
+  dtps: 12.67665
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.54287
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 13.1511
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 3049.21041
-  tps: 2026.86384
-  dtps: 12.79223
+  dps: 3098.28851
+  tps: 2098.77855
+  dtps: 12.42251
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 3112.94802
-  tps: 2100.54715
-  dtps: 13.04331
+  dps: 3167.2319
+  tps: 2153.30186
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SoulclothEmbrace"
  value: {
-  dps: 2858.74591
-  tps: 1876.62971
-  dtps: 13.2328
+  dps: 2924.58947
+  tps: 1937.4776
+  dtps: 13.04056
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2782.37908
-  tps: 1805.47026
-  dtps: 12.89203
+  dps: 2851.73718
+  tps: 1869.55726
+  dtps: 13.50417
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 3174.78296
-  tps: 2172.33016
-  dtps: 12.90673
+  dps: 3226.7482
+  tps: 2220.80375
+  dtps: 12.76954
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 3055.56114
-  tps: 2051.71765
-  dtps: 13.04331
+  dps: 3106.74779
+  tps: 2101.30503
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 3063.52734
-  tps: 2049.75735
-  dtps: 13.14909
+  dps: 3120.03969
+  tps: 2114.15611
+  dtps: 12.67665
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 2764.908
-  tps: 1795.36693
-  dtps: 12.6182
+  dps: 2828.51697
+  tps: 1844.16882
+  dtps: 13.03845
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3105.96134
-  tps: 2098.12435
-  dtps: 12.95234
+  dps: 3183.33772
+  tps: 2175.74631
+  dtps: 12.79363
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 3055.56114
-  tps: 2051.71765
-  dtps: 13.04331
+  dps: 3106.74779
+  tps: 2101.30503
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalonofAl'ar-30448"
  value: {
-  dps: 3078.33827
-  tps: 2074.08847
-  dtps: 13.04331
+  dps: 3128.24716
+  tps: 2122.53671
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 3066.87442
-  tps: 2061.26641
-  dtps: 13.04331
+  dps: 3118.78767
+  tps: 2111.55564
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 3055.56114
-  tps: 2051.71765
-  dtps: 13.04331
+  dps: 3106.74779
+  tps: 2101.30503
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheBladefist-29348"
  value: {
-  dps: 2943.57153
-  tps: 1938.39112
-  dtps: 12.90692
+  dps: 2962.16633
+  tps: 1965.18059
+  dtps: 13.24781
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheNightBlade-31331"
  value: {
-  dps: 3164.46434
-  tps: 2159.04091
-  dtps: 12.50758
+  dps: 3310.41163
+  tps: 2303.41756
+  dtps: 12.97398
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 3056.42953
-  tps: 2052.17972
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.56928
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 3060.56136
-  tps: 2053.10566
-  dtps: 12.98229
+  dps: 3106.83734
+  tps: 2095.28136
+  dtps: 12.67375
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 3068.63583
-  tps: 2063.68791
-  dtps: 13.08777
+  dps: 3020.95264
+  tps: 2022.30454
+  dtps: 12.82248
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThickDraenicArmor"
  value: {
-  dps: 2895.48774
-  tps: 1904.18517
-  dtps: 13.26172
+  dps: 2934.65073
+  tps: 1931.20133
+  dtps: 13.16601
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Thori'dal,theStars'Fury-34334"
  value: {
-  dps: 3394.47429
-  tps: 2372.53645
-  dtps: 13.07124
+  dps: 3466.33488
+  tps: 2456.53606
+  dtps: 13.11055
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 3141.59675
-  tps: 2137.1555
-  dtps: 12.30603
+  dps: 3247.923
+  tps: 2229.61032
+  dtps: 11.86968
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 3056.42953
-  tps: 2051.79958
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.14762
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 3116.05793
-  tps: 2105.62487
-  dtps: 13.04633
+  dps: 3168.16548
+  tps: 2166.43615
+  dtps: 12.76308
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-UnitingCharm-25633"
  value: {
-  dps: 3093.26033
-  tps: 2083.69978
-  dtps: 13.04331
+  dps: 3146.25173
+  tps: 2135.13074
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 3055.56114
-  tps: 2051.71765
-  dtps: 13.54287
+  dps: 3106.74779
+  tps: 2101.30503
+  dtps: 13.1511
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 3056.42953
-  tps: 2051.91292
-  dtps: 13.04331
+  dps: 3107.27973
+  tps: 2101.25995
+  dtps: 12.63952
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WastewalkerArmor"
  value: {
-  dps: 2869.00032
-  tps: 1878.59333
-  dtps: 13.09328
+  dps: 2930.89982
+  tps: 1941.17312
+  dtps: 12.93576
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WhitemendWisdom"
  value: {
-  dps: 2782.37908
-  tps: 1805.01639
-  dtps: 12.4094
+  dps: 2851.73718
+  tps: 1869.03686
+  dtps: 12.97147
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WindhawkArmor"
  value: {
-  dps: 2887.20128
-  tps: 1899.28989
-  dtps: 13.75451
+  dps: 2946.54257
+  tps: 1961.0219
+  dtps: 13.63527
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 3101.58775
-  tps: 2096.72873
-  dtps: 12.89121
+  dps: 3170.40209
+  tps: 2170.18339
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WrathofSpellfire"
  value: {
-  dps: 2871.26325
-  tps: 1885.58729
-  dtps: 13.75451
+  dps: 2934.85625
+  tps: 1945.86777
+  dtps: 13.60521
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 3049.49716
-  tps: 2044.23161
-  dtps: 12.98352
+  dps: 3112.31769
+  tps: 2105.27623
+  dtps: 12.56977
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 3055.56114
-  tps: 2051.71765
-  dtps: 13.54287
+  dps: 3106.74779
+  tps: 2101.30503
+  dtps: 13.1511
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 3141.19654
-  tps: 2133.63998
-  dtps: 12.6525
+  dps: 3220.61684
+  tps: 2213.09368
+  dtps: 12.67729
  }
 }
 dps_results: {
@@ -1581,46 +1581,46 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 5849.63895
-  tps: 5699.42823
-  dtps: 10.93219
+  dps: 5834.04706
+  tps: 5680.41234
+  dtps: 11.0918
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 3075.74222
-  tps: 2116.00175
-  dtps: 12.89121
+  dps: 3130.9043
+  tps: 2170.90088
+  dtps: 13.0896
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3534.96639
-  tps: 2468.52745
-  dtps: 26.63294
+  dps: 3607.20723
+  tps: 2527.14127
+  dtps: 26.82427
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1028.82517
-  tps: 986.28037
+  dps: 1060.20127
+  tps: 1018.85344
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 711.32087
-  tps: 514.90568
+  dps: 781.52152
+  tps: 586.07699
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 1023.30868
-  tps: 781.36326
+  dps: 1037.13998
+  tps: 806.78225
  }
 }
 dps_results: {
@@ -1671,46 +1671,46 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 5989.41202
-  tps: 6372.26278
-  dtps: 10.49476
+  dps: 5913.10891
+  tps: 6274.80932
+  dtps: 10.20217
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 2660.77685
-  tps: 2131.49749
-  dtps: 12.53135
+  dps: 2775.53458
+  tps: 2255.17294
+  dtps: 11.76737
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3012.38698
-  tps: 2448.9446
-  dtps: 24.80145
+  dps: 3108.44116
+  tps: 2560.39319
+  dtps: 23.83601
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1019.85003
-  tps: 1108.62726
+  dps: 1091.74593
+  tps: 1174.92524
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 627.91398
-  tps: 514.87053
+  dps: 725.9236
+  tps: 613.61345
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 904.91967
-  tps: 774.9317
+  dps: 958.98254
+  tps: 829.69827
  }
 }
 dps_results: {
@@ -1761,46 +1761,46 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 5932.15044
-  tps: 5740.75672
-  dtps: 10.93219
+  dps: 5902.48929
+  tps: 5698.37344
+  dtps: 10.9474
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 3150.39865
-  tps: 2139.17768
-  dtps: 12.89121
+  dps: 3217.14237
+  tps: 2211.39801
+  dtps: 13.00612
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3642.11688
-  tps: 2518.73713
-  dtps: 26.63294
+  dps: 3710.11412
+  tps: 2573.81159
+  dtps: 26.82427
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1048.51899
-  tps: 988.77051
+  dps: 1088.91197
+  tps: 1032.40879
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 727.04533
-  tps: 519.25347
+  dps: 799.87384
+  tps: 593.53695
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 1049.73045
-  tps: 791.92337
+  dps: 1067.87382
+  tps: 822.29373
  }
 }
 dps_results: {
@@ -1851,53 +1851,53 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 6044.75928
-  tps: 6405.60868
-  dtps: 10.4604
+  dps: 6008.58063
+  tps: 6352.56436
+  dtps: 10.33102
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 2714.79514
-  tps: 2159.35097
-  dtps: 12.48388
+  dps: 2815.93032
+  tps: 2271.47565
+  dtps: 11.74838
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3082.70302
-  tps: 2492.25203
-  dtps: 24.80145
+  dps: 3171.60572
+  tps: 2597.92371
+  dtps: 23.83601
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1024.19531
-  tps: 1104.15727
+  dps: 1106.9261
+  tps: 1179.26908
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 642.03764
-  tps: 520.84657
+  dps: 732.7366
+  tps: 613.96695
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 928.55694
-  tps: 789.08102
+  dps: 985.07734
+  tps: 847.39432
  }
 }
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2960.98006
-  tps: 2100.72357
-  dtps: 13.00075
+  dps: 2988.39754
+  tps: 2137.10128
+  dtps: 13.2172
  }
 }

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -55,1482 +55,1482 @@ character_stats_results: {
 dps_results: {
  key: "TestHunter-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 3110.2566
-  tps: 2088.59576
-  dtps: 12.79398
+  dps: 3118.57384
+  tps: 2102.38764
+  dtps: 12.87762
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 3150.68754
-  tps: 2133.17353
-  dtps: 12.93103
+  dps: 3142.39137
+  tps: 2131.62132
+  dtps: 12.93549
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 3049.83809
-  tps: 2051.95089
-  dtps: 13.64003
+  dps: 3055.56114
+  tps: 2051.71765
+  dtps: 13.54287
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 3079.84456
-  tps: 2078.04214
-  dtps: 13.14349
+  dps: 3085.57211
+  tps: 2077.7222
+  dtps: 13.04633
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Annihilator-12798"
  value: {
-  dps: 2899.48056
-  tps: 1899.93146
-  dtps: 12.67942
+  dps: 2894.81901
+  tps: 1896.13526
+  dtps: 12.92287
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 2847.34156
-  tps: 1867.25062
-  dtps: 13.14873
+  dps: 2853.16817
+  tps: 1873.49112
+  dtps: 13.09809
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 3103.37225
-  tps: 2097.69429
-  dtps: 13.14047
+  dps: 3106.40136
+  tps: 2095.40274
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 3090.33214
-  tps: 2087.41925
-  dtps: 13.14349
+  dps: 3095.23182
+  tps: 2087.74263
+  dtps: 13.04633
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 3089.01934
-  tps: 2090.49112
-  dtps: 13.14047
+  dps: 3091.90777
+  tps: 2088.14815
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 3177.7212
-  tps: 2158.38774
-  dtps: 12.88676
+  dps: 3168.50332
+  tps: 2155.97806
+  dtps: 12.89121
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 3109.34823
-  tps: 2097.53995
-  dtps: 12.88676
+  dps: 3101.58775
+  tps: 2096.55785
+  dtps: 12.89121
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 3109.34823
-  tps: 2097.77074
-  dtps: 13.36401
+  dps: 3101.58775
+  tps: 2096.78368
+  dtps: 13.41291
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BattlecastGarb"
  value: {
-  dps: 2782.78994
-  tps: 1801.33646
-  dtps: 12.77321
+  dps: 2782.37908
+  tps: 1805.54151
+  dtps: 12.74459
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 3042.08139
-  tps: 2028.36997
-  dtps: 13.18245
+  dps: 3048.11423
+  tps: 2035.29739
+  dtps: 13.02898
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 3042.08139
-  tps: 2028.36997
-  dtps: 13.18245
+  dps: 3048.11423
+  tps: 2035.29739
+  dtps: 13.02898
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 3088.86018
-  tps: 2086.77333
-  dtps: 13.1417
+  dps: 3090.73351
+  tps: 2083.97022
+  dtps: 13.04633
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.64003
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.54287
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 3090.78452
-  tps: 2086.74223
-  dtps: 13.14047
+  dps: 3093.72443
+  tps: 2083.92672
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 3112.99984
-  tps: 2049.69406
-  dtps: 12.82498
+  dps: 3117.33184
+  tps: 2059.67253
+  dtps: 12.82943
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeastLordArmor"
  value: {
-  dps: 2850.57119
-  tps: 1865.96092
-  dtps: 12.45906
+  dps: 2851.53958
+  tps: 1871.55841
+  dtps: 12.4094
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 3132.54382
-  tps: 2122.67601
-  dtps: 13.14047
+  dps: 3135.33139
+  tps: 2119.69947
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 3141.39522
-  tps: 2123.8812
-  dtps: 12.93103
+  dps: 3133.06573
+  tps: 2122.29569
+  dtps: 12.93549
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 3130.25951
-  tps: 2135.94864
-  dtps: 12.91525
+  dps: 3136.66115
+  tps: 2139.64555
+  dtps: 12.86442
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 3151.82194
-  tps: 2134.40685
-  dtps: 12.57703
+  dps: 3152.30641
+  tps: 2137.12918
+  dtps: 12.49128
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 3086.60469
-  tps: 2083.66815
-  dtps: 13.14349
+  dps: 3092.33223
+  tps: 2083.34821
+  dtps: 13.04633
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 2895.5696
-  tps: 1895.36611
-  dtps: 12.82256
+  dps: 2894.81853
+  tps: 1900.59922
+  dtps: 12.99977
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Blinkstrike-31332"
  value: {
-  dps: 3159.38211
-  tps: 2158.4371
-  dtps: 13.14159
+  dps: 3173.07114
+  tps: 2169.84372
+  dtps: 12.65991
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 3130.29286
-  tps: 2116.78134
-  dtps: 12.88676
+  dps: 3121.7037
+  tps: 2114.89897
+  dtps: 12.89121
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 3106.27612
-  tps: 2097.63326
-  dtps: 12.95037
+  dps: 3100.24509
+  tps: 2099.79391
+  dtps: 12.81806
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.58705
+  tps: 2052.82743
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 2936.84808
-  tps: 1933.5006
-  dtps: 12.8181
+  dps: 2930.72375
+  tps: 1935.51989
+  dtps: 12.69435
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 3098.3255
-  tps: 2093.35966
-  dtps: 13.14047
+  dps: 3101.19627
+  tps: 2090.48437
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 2936.84808
-  tps: 1933.53873
-  dtps: 12.8181
+  dps: 2930.72375
+  tps: 1935.55087
+  dtps: 12.69435
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CryptstalkerArmor"
  value: {
-  dps: 2861.55767
-  tps: 1863.46956
-  dtps: 12.58447
+  dps: 2855.32907
+  tps: 1859.54859
+  dtps: 12.69299
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 3081.35066
-  tps: 2080.57106
-  dtps: 13.14047
+  dps: 3084.34247
+  tps: 2077.80972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 3107.00729
-  tps: 2100.70632
-  dtps: 13.14047
+  dps: 3110.1043
+  tps: 2098.51998
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 3079.20549
-  tps: 2075.27984
-  dtps: 13.1417
+  dps: 3084.90175
+  tps: 2076.00121
+  dtps: 13.19059
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DemonStalkerArmor"
  value: {
-  dps: 2870.82159
-  tps: 1879.86186
-  dtps: 13.26556
+  dps: 2880.70251
+  tps: 1889.48377
+  dtps: 13.36317
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Despair-28573"
  value: {
-  dps: 3215.8537
-  tps: 2215.65982
-  dtps: 13.07785
+  dps: 3210.24219
+  tps: 2207.31612
+  dtps: 13.24196
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DirebrewHops-38288"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DonSantos'FamousHuntingRifle-31323"
  value: {
-  dps: 3094.44549
-  tps: 2073.28334
-  dtps: 12.91163
+  dps: 3101.29493
+  tps: 2073.79154
+  dtps: 13.07124
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Earthstrike-21180"
  value: {
-  dps: 3082.30266
-  tps: 2079.77957
-  dtps: 13.14047
+  dps: 3085.1646
+  tps: 2076.91646
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 3115.69524
-  tps: 2108.23802
-  dtps: 13.14047
+  dps: 3118.52476
+  tps: 2105.31207
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantBoots-Boar'sSpeed-2940"
  value: {
-  dps: 3133.46788
-  tps: 2124.34689
-  dtps: 13.2283
+  dps: 3137.20349
+  tps: 2130.75363
+  dtps: 13.08958
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 3136.90221
-  tps: 2127.32191
-  dtps: 13.2283
+  dps: 3140.64197
+  tps: 2133.73436
+  dtps: 13.08958
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 3149.85045
-  tps: 2090.7022
-  dtps: 12.88676
+  dps: 3141.22599
+  tps: 2088.85126
+  dtps: 12.89121
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 3146.2136
-  tps: 2171.36216
-  dtps: 12.88676
+  dps: 3137.58942
+  tps: 2169.43512
+  dtps: 12.89121
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 3127.37361
-  tps: 2112.61092
-  dtps: 12.94727
+  dps: 3119.04225
+  tps: 2111.27733
+  dtps: 12.82356
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 3137.93688
-  tps: 2123.13035
-  dtps: 12.35278
+  dps: 3129.67861
+  tps: 2121.69153
+  dtps: 12.30872
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 3147.91492
-  tps: 2133.0062
-  dtps: 12.93103
+  dps: 3143.73534
+  tps: 2136.72048
+  dtps: 12.91459
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 3137.24877
-  tps: 2123.36782
-  dtps: 13.01981
+  dps: 3134.37351
+  tps: 2119.5078
+  dtps: 12.88568
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeofMoam-21473"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 3106.27612
-  tps: 2097.58446
-  dtps: 13.83818
+  dps: 3100.24509
+  tps: 2099.75556
+  dtps: 13.81131
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FelSkin"
  value: {
-  dps: 2941.70761
-  tps: 1942.14591
-  dtps: 12.93103
+  dps: 2932.95196
+  tps: 1939.94289
+  dtps: 12.93549
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FelscaleArmor"
  value: {
-  dps: 2897.03486
-  tps: 1906.54462
-  dtps: 12.68971
+  dps: 2901.13607
+  tps: 1915.49068
+  dtps: 12.63461
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 3089.79985
-  tps: 2085.91433
-  dtps: 13.14047
+  dps: 3092.62493
+  tps: 2082.99784
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 3198.03304
-  tps: 2182.41744
-  dtps: 13.22332
+  dps: 3198.52879
+  tps: 2187.70986
+  dtps: 13.18097
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HandofJustice-11815"
  value: {
-  dps: 3062.78565
-  tps: 2062.87891
-  dtps: 13.14047
+  dps: 3065.75325
+  tps: 2060.11647
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 3039.58739
-  tps: 2037.47727
-  dtps: 13.11949
+  dps: 3049.49716
+  tps: 2044.23161
+  dtps: 12.98352
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 12.6542
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 12.53516
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Heartrazor-29962"
  value: {
-  dps: 3197.1583
-  tps: 2186.83958
-  dtps: 13.07665
+  dps: 3197.37844
+  tps: 2187.34379
+  dtps: 12.50758
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 3053.45269
-  tps: 2054.72894
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2051.9751
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 3098.99413
-  tps: 2094.32179
-  dtps: 13.1417
+  dps: 3101.2552
+  tps: 2092.42979
+  dtps: 13.04633
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IceGuard-2682"
  value: {
-  dps: 3121.25861
-  tps: 2109.55503
-  dtps: 12.91164
+  dps: 3115.65119
+  tps: 2112.17146
+  dtps: 12.77933
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 3071.34893
-  tps: 2072.82071
-  dtps: 13.14047
+  dps: 3074.28038
+  tps: 2070.03058
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImbuedNetherweave"
  value: {
-  dps: 2758.35019
-  tps: 1787.48294
-  dtps: 13.08914
+  dps: 2764.908
+  tps: 1794.87849
+  dtps: 13.12978
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-JomGabbar-23570"
  value: {
-  dps: 3090.6328
-  tps: 2087.36993
-  dtps: 13.14872
+  dps: 3093.54799
+  tps: 2084.47496
+  dtps: 13.05156
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KhoriumScope-2723"
  value: {
-  dps: 3152.546
-  tps: 2135.03199
-  dtps: 12.93103
+  dps: 3144.25649
+  tps: 2133.48645
+  dtps: 12.93549
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 3081.73773
-  tps: 2080.37004
-  dtps: 13.35133
+  dps: 3081.82383
+  tps: 2082.80379
+  dtps: 13.28508
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartChampion-28429"
  value: {
-  dps: 3262.69939
-  tps: 2244.97292
-  dtps: 13.02021
+  dps: 3263.76611
+  tps: 2248.52066
+  dtps: 13.04793
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 3265.51646
-  tps: 2247.78998
-  dtps: 13.02021
+  dps: 3266.53843
+  tps: 2251.29297
+  dtps: 13.04793
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 11.81207
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 11.69303
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 3114.56215
-  tps: 2110.27138
-  dtps: 13.14047
+  dps: 3117.40086
+  tps: 2107.35298
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 2581.77147
-  tps: 1625.51338
-  dtps: 13.57305
+  dps: 2588.34955
+  tps: 1634.45746
+  dtps: 13.73745
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 3016.61246
-  tps: 2005.82477
-  dtps: 12.93103
+  dps: 3008.87266
+  tps: 2004.87816
+  dtps: 12.93549
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 3055.19138
-  tps: 2048.75931
-  dtps: 13.08109
+  dps: 3060.32675
+  tps: 2054.41892
+  dtps: 12.98393
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 3053.42547
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.55984
+  tps: 2052.82743
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherscaleArmor"
  value: {
-  dps: 3028.10282
-  tps: 2017.55141
-  dtps: 12.88676
+  dps: 3019.5918
+  tps: 2015.72254
+  dtps: 12.89121
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherstrikeArmor"
  value: {
-  dps: 2896.48539
-  tps: 1906.8352
-  dtps: 13.60992
+  dps: 2887.79509
+  tps: 1899.52186
+  dtps: 13.75451
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherweaveVestments"
  value: {
-  dps: 2592.62937
-  tps: 1633.81546
-  dtps: 12.75617
+  dps: 2597.77171
+  tps: 1646.17776
+  dtps: 12.76774
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 3090.3557
-  tps: 2086.58584
-  dtps: 13.14047
+  dps: 3093.26033
+  tps: 2083.69978
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 3106.27612
-  tps: 2097.58446
-  dtps: 11.99041
+  dps: 3100.24509
+  tps: 2099.75556
+  dtps: 11.86303
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 3106.27612
-  tps: 2097.58446
-  dtps: 12.95037
+  dps: 3100.24509
+  tps: 2099.75556
+  dtps: 12.81806
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofThawing-24093"
  value: {
-  dps: 3106.27612
-  tps: 2097.58446
-  dtps: 12.95037
+  dps: 3100.24509
+  tps: 2099.75556
+  dtps: 12.81806
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofWithering-24095"
  value: {
-  dps: 3106.27612
-  tps: 2097.58446
-  dtps: 12.95037
+  dps: 3100.24509
+  tps: 2099.75556
+  dtps: 12.81806
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 3106.27612
-  tps: 2097.58446
-  dtps: 12.95037
+  dps: 3100.24509
+  tps: 2099.75556
+  dtps: 12.81806
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 3053.45269
-  tps: 2055.05382
-  dtps: 13.49578
+  dps: 3056.42953
+  tps: 2052.29998
+  dtps: 13.39862
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrimalIntent"
  value: {
-  dps: 3083.17047
-  tps: 2061.36211
-  dtps: 12.93103
+  dps: 3075.01748
+  tps: 2060.13185
+  dtps: 12.93549
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrimalMooncloth"
  value: {
-  dps: 2869.73431
-  tps: 1884.63881
-  dtps: 13.11051
+  dps: 2859.966
+  tps: 1876.31777
+  dtps: 13.2328
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Prismcharm-15867"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 12.9732
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 12.85415
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 3044.57015
-  tps: 2048.47652
-  dtps: 13.17357
+  dps: 3047.54935
+  tps: 2045.73664
+  dtps: 13.07641
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RiftStalkerArmor"
  value: {
-  dps: 3000.77715
-  tps: 1988.97254
-  dtps: 13.13735
+  dps: 2985.56329
+  tps: 1979.37002
+  dtps: 13.09487
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 3016.61246
-  tps: 2005.81595
-  dtps: 13.40829
+  dps: 3008.87266
+  tps: 2004.87265
+  dtps: 13.45719
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 3070.55824
-  tps: 2071.8146
-  dtps: 12.67382
+  dps: 3073.63189
+  tps: 2069.20774
+  dtps: 12.55798
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RuneofForce-25994"
  value: {
-  dps: 3062.86063
-  tps: 2063.07844
-  dtps: 13.14047
+  dps: 3065.80501
+  tps: 2060.26957
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SavageGuard-2681"
  value: {
-  dps: 3121.25861
-  tps: 2109.55503
-  dtps: 12.91164
+  dps: 3115.65119
+  tps: 2112.17146
+  dtps: 12.77933
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 3033.91192
-  tps: 2038.44568
-  dtps: 13.14047
+  dps: 3036.91757
+  tps: 2035.72572
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 3085.75967
-  tps: 2076.93983
-  dtps: 13.06947
+  dps: 3086.03246
+  tps: 2078.9976
+  dtps: 12.93478
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 3049.83809
-  tps: 2051.95089
-  dtps: 13.14047
+  dps: 3055.56114
+  tps: 2051.71765
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.64003
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.54287
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 2824.72232
-  tps: 1846.02783
-  dtps: 13.14873
+  dps: 2829.24611
+  tps: 1851.02539
+  dtps: 13.09809
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShardofContempt-34472"
  value: {
-  dps: 3109.39979
-  tps: 2096.07862
-  dtps: 13.24838
+  dps: 3108.30228
+  tps: 2096.6242
+  dtps: 13.14909
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.64003
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.54287
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 3047.80903
-  tps: 2022.03214
-  dtps: 12.9845
+  dps: 3049.21041
+  tps: 2026.86384
+  dtps: 12.79223
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 3110.10741
-  tps: 2103.45842
-  dtps: 13.14047
+  dps: 3112.94802
+  tps: 2100.54715
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SoulclothEmbrace"
  value: {
-  dps: 2868.3163
-  tps: 1884.77426
-  dtps: 13.11051
+  dps: 2858.74591
+  tps: 1876.62971
+  dtps: 13.2328
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 2782.78994
-  tps: 1801.24596
-  dtps: 12.97071
+  dps: 2782.37908
+  tps: 1805.47026
+  dtps: 12.89203
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 3053.37573
-  tps: 2054.89133
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 3175.84475
-  tps: 2171.67614
-  dtps: 12.80884
+  dps: 3174.78296
+  tps: 2172.33016
+  dtps: 12.90673
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 3049.83809
-  tps: 2051.95089
-  dtps: 13.14047
+  dps: 3055.56114
+  tps: 2051.71765
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 3064.49196
-  tps: 2049.04049
-  dtps: 13.24838
+  dps: 3063.52734
+  tps: 2049.75735
+  dtps: 13.14909
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 2758.77999
-  tps: 1785.71786
-  dtps: 12.61188
+  dps: 2764.908
+  tps: 1795.36693
+  dtps: 12.6182
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3102.61292
-  tps: 2092.1001
-  dtps: 13.08249
+  dps: 3105.96134
+  tps: 2098.12435
+  dtps: 12.95234
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 3049.83809
-  tps: 2051.95089
-  dtps: 13.14047
+  dps: 3055.56114
+  tps: 2051.71765
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalonofAl'ar-30448"
  value: {
-  dps: 3075.3559
-  tps: 2076.82769
-  dtps: 13.14047
+  dps: 3078.33827
+  tps: 2074.08847
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 3061.19019
-  tps: 2061.60231
-  dtps: 13.14047
+  dps: 3066.87442
+  tps: 2061.26641
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 3049.83809
-  tps: 2051.95089
-  dtps: 13.14047
+  dps: 3055.56114
+  tps: 2051.71765
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheBladefist-29348"
  value: {
-  dps: 2942.73051
-  tps: 1941.96557
-  dtps: 12.83133
+  dps: 2943.57153
+  tps: 1938.39112
+  dtps: 12.90692
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheNightBlade-31331"
  value: {
-  dps: 3165.47262
-  tps: 2159.03468
-  dtps: 13.07665
+  dps: 3164.46434
+  tps: 2159.04091
+  dtps: 12.50758
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 3053.45269
-  tps: 2054.92447
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2052.17972
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 3053.41841
-  tps: 2048.82794
-  dtps: 13.07945
+  dps: 3060.56136
+  tps: 2053.10566
+  dtps: 12.98229
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 3046.00456
-  tps: 2040.06221
-  dtps: 12.82107
+  dps: 3068.63583
+  tps: 2063.68791
+  dtps: 13.08777
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThickDraenicArmor"
  value: {
-  dps: 2879.83304
-  tps: 1893.37881
-  dtps: 13.21149
+  dps: 2895.48774
+  tps: 1904.18517
+  dtps: 13.26172
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Thori'dal,theStars'Fury-34334"
  value: {
-  dps: 3382.67968
-  tps: 2368.84155
-  dtps: 12.91163
+  dps: 3394.47429
+  tps: 2372.53645
+  dtps: 13.07124
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 3159.14635
-  tps: 2146.02574
-  dtps: 12.60731
+  dps: 3141.59675
+  tps: 2137.1555
+  dtps: 12.30603
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 3053.45269
-  tps: 2054.54877
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2051.79958
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 3114.15603
-  tps: 2107.95206
-  dtps: 13.1417
+  dps: 3116.05793
+  tps: 2105.62487
+  dtps: 13.04633
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-UnitingCharm-25633"
  value: {
-  dps: 3090.3557
-  tps: 2086.58584
-  dtps: 13.14047
+  dps: 3093.26033
+  tps: 2083.69978
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 3049.83809
-  tps: 2051.95089
-  dtps: 13.64003
+  dps: 3055.56114
+  tps: 2051.71765
+  dtps: 13.54287
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 3053.45269
-  tps: 2054.66676
-  dtps: 13.14047
+  dps: 3056.42953
+  tps: 2051.91292
+  dtps: 13.04331
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WastewalkerArmor"
  value: {
-  dps: 2878.14585
-  tps: 1885.85988
-  dtps: 13.06969
+  dps: 2869.00032
+  tps: 1878.59333
+  dtps: 13.09328
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WhitemendWisdom"
  value: {
-  dps: 2782.78994
-  tps: 1800.80063
-  dtps: 12.45906
+  dps: 2782.37908
+  tps: 1805.01639
+  dtps: 12.4094
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WindhawkArmor"
  value: {
-  dps: 2895.89158
-  tps: 1906.62769
-  dtps: 13.60992
+  dps: 2887.20128
+  tps: 1899.28989
+  dtps: 13.75451
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 3109.34823
-  tps: 2097.69518
-  dtps: 12.88676
+  dps: 3101.58775
+  tps: 2096.72873
+  dtps: 12.89121
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WrathofSpellfire"
  value: {
-  dps: 2880.87392
-  tps: 1893.79907
-  dtps: 13.60992
+  dps: 2871.26325
+  tps: 1885.58729
+  dtps: 13.75451
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 3039.58739
-  tps: 2037.47727
-  dtps: 13.11949
+  dps: 3049.49716
+  tps: 2044.23161
+  dtps: 12.98352
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 3049.83809
-  tps: 2051.95089
-  dtps: 13.64003
+  dps: 3055.56114
+  tps: 2051.71765
+  dtps: 13.54287
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 3139.25724
-  tps: 2131.82393
-  dtps: 12.62392
+  dps: 3141.19654
+  tps: 2133.63998
+  dtps: 12.6525
  }
 }
 dps_results: {
@@ -1581,46 +1581,46 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 5816.64144
-  tps: 5659.4519
-  dtps: 10.84803
+  dps: 5849.63895
+  tps: 5699.42823
+  dtps: 10.93219
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 3081.10877
-  tps: 2116.34531
-  dtps: 12.88676
+  dps: 3075.74222
+  tps: 2116.00175
+  dtps: 12.89121
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3533.20199
-  tps: 2461.77112
-  dtps: 26.51345
+  dps: 3534.96639
+  tps: 2468.52745
+  dtps: 26.63294
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1009.73962
-  tps: 967.35632
+  dps: 1028.82517
+  tps: 986.28037
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 707.13895
-  tps: 511.71469
+  dps: 711.32087
+  tps: 514.90568
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 1019.05606
-  tps: 779.33907
+  dps: 1023.30868
+  tps: 781.36326
  }
 }
 dps_results: {
@@ -1671,8 +1671,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 5990.92758
-  tps: 6375.18169
+  dps: 5989.41202
+  tps: 6372.26278
   dtps: 10.49476
  }
 }
@@ -1761,46 +1761,46 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 5902.66408
-  tps: 5708.12732
-  dtps: 10.84803
+  dps: 5932.15044
+  tps: 5740.75672
+  dtps: 10.93219
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 3158.94614
-  tps: 2140.9812
-  dtps: 12.88676
+  dps: 3150.39865
+  tps: 2139.17768
+  dtps: 12.89121
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3635.21208
-  tps: 2505.71574
-  dtps: 26.51345
+  dps: 3642.11688
+  tps: 2518.73713
+  dtps: 26.63294
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1028.2031
-  tps: 969.03071
+  dps: 1048.51899
+  tps: 988.77051
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 725.66057
-  tps: 518.35613
+  dps: 727.04533
+  tps: 519.25347
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 1043.02242
-  tps: 787.73439
+  dps: 1049.73045
+  tps: 791.92337
  }
 }
 dps_results: {
@@ -1851,8 +1851,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 6044.77139
-  tps: 6405.58448
+  dps: 6044.75928
+  tps: 6405.60868
   dtps: 10.4604
  }
 }
@@ -1896,8 +1896,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2956.60075
-  tps: 2098.79594
-  dtps: 13.02754
+  dps: 2960.98006
+  tps: 2100.72357
+  dtps: 13.00075
  }
 }

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -126,6 +126,20 @@ func NewHunter(character *core.Character, options *proto.Player, hunterOptions *
 		AutoSwingMelee:  true,
 	})
 
+	mhConfig := hunter.AutoAttacks.MHConfig()
+	applyEffects := mhConfig.ApplyEffects
+	mhConfig.ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+		// Emit an "auto delayed" log line whenever the mh auto fired
+		// later than it would have in an uncontested rotation. Below 1ms
+		// is treated as rounding noise so the common case stays silent.
+		delay := hunter.AutoAttacks.MainHandPendingSwingDelay()
+		if sim.Log != nil && spell.ActionID.Tag == 1 && delay > time.Millisecond {
+			hunter.Log(sim, "%s delayed by %s, was ready at %s", spell.ActionID, delay, sim.CurrentTime-delay)
+		}
+
+		applyEffects(sim, target, spell)
+	}
+
 	rangedConfig := hunter.AutoAttacks.RangedConfig()
 	rangedConfig.MaxRange = HunterBaseMaxRange
 

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -216,7 +216,7 @@ func (hunter *Hunter) RegisterRangedSpell(config core.SpellConfig, canCrit bool)
 		config.MissileSpeed = 40
 	}
 
-	config.MinRange = core.MaxMeleeRange
+	config.MinRange = core.MaxMeleeRange + 0.01
 	config.MaxRange = HunterBaseMaxRange
 	config.Cast.DefaultCast.GCD = core.GCDDefault
 	config.Cast.IgnoreHaste = true

--- a/sim/hunter/raptor_strike.go
+++ b/sim/hunter/raptor_strike.go
@@ -35,6 +35,15 @@ func (hunter *Hunter) registerRaptorStrikeSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			// Emit an "auto delayed" log line whenever the mh auto fired
+			// later than it would have in an uncontested rotation. Below 1ms
+			// is treated as rounding noise so the common case stays silent.
+			delay := hunter.AutoAttacks.MainHandPendingSwingDelay()
+			readyAt := sim.CurrentTime - delay
+			if sim.Log != nil && delay > time.Millisecond && readyAt > 0 {
+				hunter.Log(sim, "%s delayed by %s, was ready at %s", spell.ActionID, delay, readyAt)
+			}
+
 			baseDamage := hunter.MHWeaponDamage(sim, spell.MeleeAttackPower(target)) + 170
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
 		},

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -1309,22 +1309,22 @@ dps_results: {
 dps_results: {
  key: "TestRogue-Settings-Human-p1-Rogue-swords-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 808.95022
-  tps: 574.35466
+  dps: 808.85301
+  tps: 574.28564
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-p1-Rogue-swords-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 669.94876
-  tps: 475.66362
+  dps: 670.12026
+  tps: 475.78538
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-p1-Rogue-swords-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 700.13183
-  tps: 497.0936
+  dps: 700.06904
+  tps: 497.04902
  }
 }
 dps_results: {
@@ -1351,15 +1351,15 @@ dps_results: {
 dps_results: {
  key: "TestRogue-Settings-Human-preraid-Rogue-swords-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 728.4606
-  tps: 517.20703
+  dps: 728.51554
+  tps: 517.24603
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-preraid-Rogue-swords-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 599.86437
-  tps: 425.90371
+  dps: 599.92773
+  tps: 425.94869
  }
 }
 dps_results: {
@@ -1393,22 +1393,22 @@ dps_results: {
 dps_results: {
  key: "TestRogue-Settings-Orc-p1-Rogue-swords-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 818.64551
-  tps: 581.23831
+  dps: 819.25473
+  tps: 581.67086
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-p1-Rogue-swords-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 671.01138
-  tps: 476.41808
+  dps: 671.12405
+  tps: 476.49807
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-p1-Rogue-swords-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 704.96631
-  tps: 500.52608
+  dps: 704.90341
+  tps: 500.48142
  }
 }
 dps_results: {
@@ -1435,22 +1435,22 @@ dps_results: {
 dps_results: {
  key: "TestRogue-Settings-Orc-preraid-Rogue-swords-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 738.80366
-  tps: 524.5506
+  dps: 738.91032
+  tps: 524.62633
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-preraid-Rogue-swords-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 603.0945
-  tps: 428.19709
+  dps: 603.25881
+  tps: 428.31375
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-preraid-Rogue-swords-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 636.59092
-  tps: 451.97955
+  dps: 635.92618
+  tps: 451.50759
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestDpsWarrior.results
+++ b/sim/warrior/dps/TestDpsWarrior.results
@@ -1471,8 +1471,8 @@ dps_results: {
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 906.39158
-  tps: 817.66792
+  dps: 911.27589
+  tps: 820.98406
  }
 }
 dps_results: {
@@ -1831,8 +1831,8 @@ dps_results: {
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-preraid_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 578.00783
-  tps: 535.02642
+  dps: 570.68666
+  tps: 528.20167
  }
 }
 dps_results: {
@@ -2011,8 +2011,8 @@ dps_results: {
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 923.65377
-  tps: 832.22141
+  dps: 920.35498
+  tps: 829.7096
  }
 }
 dps_results: {
@@ -2371,8 +2371,8 @@ dps_results: {
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-preraid_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 571.12739
-  tps: 530.38027
+  dps: 570.17356
+  tps: 527.89966
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestDpsWarrior.results
+++ b/sim/warrior/dps/TestDpsWarrior.results
@@ -159,8 +159,8 @@ dps_results: {
 dps_results: {
  key: "TestDpsWarrior-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 2014.93323
-  tps: 1522.60131
+  dps: 2014.92834
+  tps: 1522.59703
   dtps: 7.2778
  }
 }
@@ -1439,8 +1439,8 @@ dps_results: {
 dps_results: {
  key: "TestDpsWarrior-Average-Default"
  value: {
-  dps: 2004.55064
-  tps: 1513.01227
+  dps: 2004.48511
+  tps: 1512.96424
   dtps: 7.30748
  }
 }

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -15,6 +15,7 @@ import { TypedEvent } from '../../typed_event';
 import { bucket, distinct, fragmentToString, maxIndex, stringComparator } from '../../utils';
 import { actionColors } from './color_settings';
 import i18n from '../../../i18n/config';
+import { BooleanPicker } from '../pickers/boolean_picker';
 import { ResultComponent, ResultComponentConfig, SimResultData } from './result_component';
 import { APLActionItemSwap_SwapSet } from '../../proto/apl';
 
@@ -38,7 +39,8 @@ export class Timeline extends ResultComponent {
 	private rotationTimelineTimeRulerElem: HTMLCanvasElement | null = null;
 	private readonly rotationHiddenIdsContainer: HTMLElement;
 	private readonly chartPicker: HTMLSelectElement;
-	private readonly showGcdToggle: HTMLInputElement;
+	private showGcd = false;
+	private readonly showGcdChangeEmitter = new TypedEvent<void>();
 
 	private prevResultData: SimResultData | null;
 	private resultData: SimResultData | null;
@@ -66,6 +68,7 @@ export class Timeline extends ResultComponent {
 		this.hiddenIds = [];
 		this.hiddenIdsChangeEmitter = new TypedEvent<void>();
 
+		const showGcdContainerRef = ref<HTMLDivElement>();
 		this.rootElem.appendChild(
 			<div className="timeline-disclaimer">
 				<div className="d-flex flex-column">
@@ -76,10 +79,7 @@ export class Timeline extends ResultComponent {
 					<p>{i18n.t('results_tab.details.timeline.note')}</p>
 				</div>
 				<div className="timeline-controls">
-					<label className="timeline-show-gcd form-check m-0">
-						<input className="form-check-input" type="checkbox" />
-						<span className="form-check-label">{i18n.t('results_tab.details.timeline.show_gcd')}</span>
-					</label>
+					<div className="timeline-show-gcd" ref={showGcdContainerRef} />
 					<select className="timeline-chart-picker form-select">
 						<option className="rotation-option" value="rotation">
 							{i18n.t('results_tab.details.timeline.chart_types.rotation')}
@@ -147,12 +147,18 @@ export class Timeline extends ResultComponent {
 		this.rotationTimeline = this.rootElem.querySelector('.rotation-timeline')!;
 		this.rotationHiddenIdsContainer = this.rootElem.querySelector('.rotation-hidden-ids')!;
 
-		this.showGcdToggle = this.rootElem.querySelector('.timeline-show-gcd input')!;
-		const syncShowGcd = () => {
-			this.rotationPlotElem.classList.toggle('show-gcd', this.showGcdToggle.checked);
-		};
-		this.showGcdToggle.addEventListener('change', syncShowGcd);
-		syncShowGcd();
+		new BooleanPicker<null>(showGcdContainerRef.value!, null, {
+			id: 'timeline-show-gcd',
+			label: i18n.t('results_tab.details.timeline.show_gcd'),
+			inline: true,
+			changedEvent: () => this.showGcdChangeEmitter,
+			getValue: () => this.showGcd,
+			setValue: (eventID, _, newValue) => {
+				this.showGcd = newValue;
+				this.rotationPlotElem.classList.toggle('show-gcd', newValue);
+				this.showGcdChangeEmitter.emit(eventID);
+			},
+		});
 
 		let isMouseDown = false;
 		let startX = 0;

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -38,6 +38,7 @@ export class Timeline extends ResultComponent {
 	private rotationTimelineTimeRulerElem: HTMLCanvasElement | null = null;
 	private readonly rotationHiddenIdsContainer: HTMLElement;
 	private readonly chartPicker: HTMLSelectElement;
+	private readonly showGcdToggle: HTMLInputElement;
 
 	private prevResultData: SimResultData | null;
 	private resultData: SimResultData | null;
@@ -74,17 +75,23 @@ export class Timeline extends ResultComponent {
 					</p>
 					<p>{i18n.t('results_tab.details.timeline.note')}</p>
 				</div>
-				<select className="timeline-chart-picker form-select">
-					<option className="rotation-option" value="rotation">
-						{i18n.t('results_tab.details.timeline.chart_types.rotation')}
-					</option>
-					<option className="dps-option" value="dps">
-						{i18n.t('results_tab.details.timeline.chart_types.dps')}
-					</option>
-					<option className="threat-option" value="threat">
-						{i18n.t('results_tab.details.timeline.chart_types.threat')}
-					</option>
-				</select>
+				<div className="timeline-controls">
+					<label className="timeline-show-gcd form-check m-0">
+						<input className="form-check-input" type="checkbox" />
+						<span className="form-check-label">{i18n.t('results_tab.details.timeline.show_gcd')}</span>
+					</label>
+					<select className="timeline-chart-picker form-select">
+						<option className="rotation-option" value="rotation">
+							{i18n.t('results_tab.details.timeline.chart_types.rotation')}
+						</option>
+						<option className="dps-option" value="dps">
+							{i18n.t('results_tab.details.timeline.chart_types.dps')}
+						</option>
+						<option className="threat-option" value="threat">
+							{i18n.t('results_tab.details.timeline.chart_types.threat')}
+						</option>
+					</select>
+				</div>
 			</div>,
 		);
 
@@ -139,6 +146,13 @@ export class Timeline extends ResultComponent {
 		this.rotationLabels = this.rootElem.querySelector('.rotation-labels')!;
 		this.rotationTimeline = this.rootElem.querySelector('.rotation-timeline')!;
 		this.rotationHiddenIdsContainer = this.rootElem.querySelector('.rotation-hidden-ids')!;
+
+		this.showGcdToggle = this.rootElem.querySelector('.timeline-show-gcd input')!;
+		const syncShowGcd = () => {
+			this.rotationPlotElem.classList.toggle('show-gcd', this.showGcdToggle.checked);
+		};
+		this.showGcdToggle.addEventListener('change', syncShowGcd);
+		syncShowGcd();
 
 		let isMouseDown = false;
 		let startX = 0;
@@ -583,6 +597,8 @@ export class Timeline extends ResultComponent {
 			}
 		});
 
+		this.addGcdStripRow(player, duration);
+
 		const playerCastsByAbility = this.getSortedCastsByAbility(player);
 		playerCastsByAbility.forEach(castLogs => this.addCastRow(castLogs, buffsAndDebuffsById, duration));
 
@@ -605,6 +621,7 @@ export class Timeline extends ResultComponent {
 				this.addSeparatorRow(duration);
 				this.addPetRow(pet.name, duration);
 				orderedResourceTypes.forEach(resourceType => this.addResourceRow(resourceType, pet.groupedResourceLogs[resourceType], duration));
+				this.addGcdStripRow(pet, duration);
 				const petCastsByAbility = this.getSortedCastsByAbility(pet);
 				petCastsByAbility.forEach(castLogs => this.addCastRow(castLogs, buffsAndDebuffsById, duration));
 			});
@@ -789,6 +806,58 @@ export class Timeline extends ResultComponent {
 		this.rotationTimeline.appendChild(rowElem);
 	}
 
+	private addGcdStripRow(player: UnitMetrics, duration: number) {
+		const gcdCasts = player.castLogs
+			.filter(c => c.gcd > 0 && !c.castCancelledLog)
+			.sort((a, b) => a.timestamp - b.timestamp);
+		if (gcdCasts.length === 0) return;
+
+		this.rotationLabels.appendChild(
+			<div className="rotation-label rotation-row" dataset={{ row: 'gcd' }}>
+				<a className="rotation-label-icon rotation-label-icon-empty" />
+				<span className="rotation-label-text">GCD</span>
+			</div>,
+		);
+
+		const rowElem = (
+			<div
+				className="rotation-timeline-row rotation-row rotation-timeline-gcd-strip"
+				dataset={{ row: 'gcd' }}
+				style={{ width: this.timeToPx(duration) }}
+			/>
+		) as HTMLElement;
+
+		gcdCasts.forEach(c => {
+			const visibleGcd = Math.min(c.gcd, duration - c.timestamp);
+			if (visibleGcd <= 0) return;
+
+			const segElem = (
+				<div
+					className="rotation-timeline-gcd-segment"
+					style={{
+						left: this.timeToPx(c.timestamp),
+						width: this.timeToPx(visibleGcd),
+					}}
+				/>
+			) as HTMLElement;
+			rowElem.appendChild(segElem);
+
+			const segTip = tippy(segElem, {
+				placement: 'bottom',
+				content: (
+					<div className="timeline-tooltip">
+						<span>
+							{c.actionId!.name} — {c.gcd.toFixed(2)}s GCD ({c.timestamp.toFixed(2)}s → {(c.timestamp + c.gcd).toFixed(2)}s)
+						</span>
+					</div>
+				),
+			});
+			this.addOnResetCallback(() => segTip.destroy());
+		});
+
+		this.rotationTimeline.appendChild(rowElem);
+	}
+
 	private addSeparatorRow(duration: number) {
 		const separatorElem = <div className="rotation-timeline-separator"></div>;
 		this.rotationLabels.appendChild(separatorElem.cloneNode());
@@ -909,6 +978,21 @@ export class Timeline extends ResultComponent {
 			);
 			rowElem.appendChild(castElem);
 
+			const extensionStart = castLog.timestamp + castLog.castTime;
+			const gcdOverhead = Math.min(castLog.timestamp + castLog.gcd, duration) - extensionStart;
+			if (gcdOverhead > 0 && !castLog.castCancelledLog) {
+				const gcdExtensionElem = (
+					<div
+						className="rotation-timeline-gcd-extension"
+						style={{
+							left: this.timeToPx(extensionStart),
+							width: this.timeToPx(gcdOverhead),
+						}}
+					/>
+				) as HTMLElement;
+				rowElem.appendChild(gcdExtensionElem);
+			}
+
 			if (castLog.cancelTime) {
 				castElem.classList.add('cast-cancelled');
 			} else if (castLog.travelTime != 0) {
@@ -950,14 +1034,22 @@ export class Timeline extends ResultComponent {
 			const travelTimeStr = castLog.travelTime == 0 ? '' : ` + ${castLog.travelTime.toFixed(2)}s travel time`;
 			const totalDamage = castLog.totalDamage();
 
+			let timingStr = '';
+			if (castLog.castCancelledLog?.timestamp) {
+				timingStr = ` (Cancelled after ${castLog.cancelTime.toFixed(2)}s)`;
+			} else {
+				const parts: string[] = [];
+				if (castLog.castTime > 0) parts.push(`${castLog.castTime.toFixed(2)}s cast`);
+				if (castLog.gcd > 0) parts.push(`${castLog.gcd.toFixed(2)}s GCD`);
+				if (parts.length > 0) timingStr = ` (${parts.join(', ')})`;
+			}
+
 			const tt = (
 				<div className="timeline-tooltip">
 					<span>
 						{castLog.actionId!.name} from {castLog.timestamp.toFixed(2)}s to{' '}
 						{(castLog.castCancelledLog?.timestamp || castLog.timestamp + castLog.castTime).toFixed(2)}s
-						{castLog.castCancelledLog?.timestamp
-							? ` (Cancelled after ${castLog.cancelTime.toFixed(2)}s)`
-							: ` (${castLog.castTime > 0 ? `${castLog.castTime.toFixed(2)}s, ` : ''}${castLog.effectiveTime.toFixed(2)}s GCD Time)`}
+						{timingStr}
 						{travelTimeStr.length > 0 && travelTimeStr}
 					</span>
 					{totalDamage > 0 && (

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -960,7 +960,7 @@ export class Timeline extends ResultComponent {
 					placement: 'bottom',
 					content: (
 						<div className="timeline-tooltip">
-							<span>Auto delayed by {castLog.delayText}</span>
+							<span>Auto delayed by {castLog.delayText}, was ready at {castLog.readyAtText}</span>
 						</div>
 					),
 				});

--- a/ui/core/proto_utils/logs_parser.tsx
+++ b/ui/core/proto_utils/logs_parser.tsx
@@ -960,12 +960,14 @@ export class MajorCooldownUsedLog extends SimLog {
 export class CastBeganLog extends SimLog {
 	readonly manaCost: number;
 	readonly castTime: number;
+	readonly gcd: number;
 	readonly effectiveTime: number;
 
-	constructor(params: SimLogParams, manaCost: number, castTime: number, effectiveTime: number) {
+	constructor(params: SimLogParams, manaCost: number, castTime: number, gcd: number, effectiveTime: number) {
 		super(params);
 		this.manaCost = manaCost;
 		this.castTime = castTime;
+		this.gcd = gcd;
 		this.effectiveTime = effectiveTime;
 	}
 
@@ -979,21 +981,27 @@ export class CastBeganLog extends SimLog {
 	}
 
 	static parse(params: SimLogParams): Promise<CastBeganLog> | null {
-		const match = params.raw.match(/Casting (.*) \(Cost = (\d+\.?\d*), Cast Time = (\d+\.?\d*)(m?s), Effective Time = (\d+\.?\d*)(m?s)\)/);
+		const match = params.raw.match(
+			/Casting (.*) \(Cost = (\d+\.?\d*), Cast Time = (\d+\.?\d*)(m?s), GCD = (\d+\.?\d*)(m?s), Effective Time = (\d+\.?\d*)(m?s)\)/,
+		);
 		if (match) {
 			let castTime = parseFloat(match[3]);
 			if (match[4] == 'ms') {
 				castTime /= 1000;
 			}
-			let effectiveTime = parseFloat(match[5]);
+			let gcd = parseFloat(match[5]);
 			if (match[6] == 'ms') {
+				gcd /= 1000;
+			}
+			let effectiveTime = parseFloat(match[7]);
+			if (match[8] == 'ms') {
 				effectiveTime /= 1000;
 			}
 			return ActionId.fromLogString(match[1])
 				.fill(params.source?.index)
 				.then(castId => {
 					params.actionId = castId;
-					return new CastBeganLog(params, parseFloat(match[2]), castTime, effectiveTime);
+					return new CastBeganLog(params, parseFloat(match[2]), castTime, gcd, effectiveTime);
 				});
 		} else {
 			return null;
@@ -1108,6 +1116,7 @@ export class AutoDelayLog extends SimLog {
 
 export class CastLog extends SimLog {
 	readonly castTime: number;
+	readonly gcd: number;
 	readonly effectiveTime: number;
 	readonly travelTime: number;
 	readonly cancelTime: number;
@@ -1139,6 +1148,7 @@ export class CastLog extends SimLog {
 			threat: castCompletedLog?.threat || castCancelledLog?.threat || castBeganLog.threat,
 		});
 		this.castTime = castBeganLog.castTime;
+		this.gcd = castBeganLog.gcd;
 		this.effectiveTime = castBeganLog.effectiveTime;
 		this.cancelTime = castCancelledLog?.cancelTime || 0;
 		this.delay = autoDelayLog?.delay ?? 0;
@@ -1151,7 +1161,6 @@ export class CastLog extends SimLog {
 
 		if (this.castCompletedLog && this.castBeganLog) {
 			this.castTime = this.castCompletedLog.timestamp - this.castBeganLog.timestamp;
-			this.effectiveTime = this.castCompletedLog.timestamp - this.castBeganLog.timestamp;
 		}
 		if (this.castCancelledLog) {
 			this.cancelTime = this.castCancelledLog.cancelTime;

--- a/ui/core/proto_utils/logs_parser.tsx
+++ b/ui/core/proto_utils/logs_parser.tsx
@@ -1072,41 +1072,55 @@ export class CastCompletedLog extends SimLog {
 	}
 }
 
-// AutoDelayLog records the gap between when a ranged auto-attack would
-// naturally have fired and when it actually did, emitted from the ranged
-// auto's ApplyEffects when the delay exceeds 1ms. Attached to the matching
+// AutoDelayLog records the gap between when an auto-attack would
+// naturally have fired and when it actually did, emitted from the auto's
+// ApplyEffects when the delay exceeds 1ms. Attached to the matching
 // CastLog at construction time.
 export class AutoDelayLog extends SimLog {
 	readonly delay: number; // seconds, used for block width math
 	readonly delayText: string; // pre-formatted for display: rounded ms below 1s, 2-decimal s at 1s+
+	readonly readyAtLogText: string; // pre-formatted for display in log view
+	readonly readyAtTooltip: string; // pre-formatted for display in tooltip
 
-	constructor(params: SimLogParams, delay: number, delayText: string) {
+	constructor(params: SimLogParams, delay: number, delayText: string, readyAtLogText: string, readyAtTooltip: string) {
 		super(params);
 		this.delay = delay;
 		this.delayText = delayText;
+		this.readyAtLogText = readyAtLogText;
+		this.readyAtTooltip = readyAtTooltip;
 	}
 
 	toHTML(includeTimestamp = true) {
 		return this.cacheOutput(includeTimestamp, () => (
 			<>
-				{this.toPrefix(includeTimestamp)} {this.newActionIdLink()} delayed by {this.delayText}.
+				{this.toPrefix(includeTimestamp)} {this.newActionIdLink()} delayed by {this.delayText}, was ready at {this.readyAtLogText}.
 			</>
 		));
 	}
 
 	static parse(params: SimLogParams): Promise<AutoDelayLog> | null {
-		const match = params.raw.match(/] (.*?) delayed by (\d+\.?\d*)(m?s)/);
+		const match = params.raw.match(/] (.*?) delayed by (\d+\.?\d*)(m?s), was ready at (\d*?m?)(\d+\.?\d*)(m?s)/);
 		if (match) {
 			let delay = parseFloat(match[2]);
 			if (match[3] == 'ms') {
 				delay /= 1000;
 			}
 			const delayText = delay >= 1 ? `${delay.toFixed(2)}s` : `${Math.round(delay * 1000)}ms`;
+
+			let readyAtMinute = match[4];
+			let readyAtSeconds = parseFloat(match[5]);
+			let readyAtTotal = readyAtSeconds;
+			if (readyAtMinute && readyAtMinute.endsWith('m')) {
+				readyAtTotal = parseFloat(readyAtMinute.slice(0, -1)) * 60 + readyAtSeconds;
+			}
+			const readyAtLogText = readyAtTotal >= 1 ? `${readyAtMinute}${readyAtSeconds.toFixed(2)}s` : `${Math.round(readyAtTotal * 1000)}ms`;
+			const readyAtTooltip = readyAtTotal >= 1 ? `${readyAtTotal.toFixed(2)}s` : `${Math.round(readyAtTotal * 1000)}ms`;
+
 			return ActionId.fromLogString(match[1])
 				.fill(params.source?.index)
 				.then(castId => {
 					params.actionId = castId;
-					return new AutoDelayLog(params, delay, delayText);
+					return new AutoDelayLog(params, delay, delayText, readyAtLogText, readyAtTooltip);
 				});
 		} else {
 			return null;
@@ -1122,6 +1136,7 @@ export class CastLog extends SimLog {
 	readonly cancelTime: number;
 	readonly delay: number;
 	readonly delayText: string;
+	readonly readyAtText: string;
 
 	readonly castBeganLog: CastBeganLog;
 	readonly castCancelledLog: CastCancelledLog | null;
@@ -1153,6 +1168,7 @@ export class CastLog extends SimLog {
 		this.cancelTime = castCancelledLog?.cancelTime || 0;
 		this.delay = autoDelayLog?.delay ?? 0;
 		this.delayText = autoDelayLog?.delayText ?? '';
+		this.readyAtText = autoDelayLog?.readyAtTooltip ?? '';
 
 		this.castBeganLog = castBeganLog;
 		this.castCompletedLog = castCompletedLog;
@@ -1202,6 +1218,9 @@ export class CastLog extends SimLog {
 				// spell than it started (if stacks drop).
 				// Also handle Shadow's Cascade for bouncing
 				return actionId.toStringIgnoringTag();
+			} else if (actionId.spellId === 27014) {
+				// Raptor Strike should be grouped with regular melee swings
+				return 'other-3-1';
 			} else {
 				return actionId.toString();
 			}

--- a/ui/hunter/dps/apls/default.apl.json
+++ b/ui/hunter/dps/apls/default.apl.json
@@ -13,13 +13,13 @@
 			}
 		},
 		{ "action": { "castSpell": { "spellId": { "spellId": 34026 } } } },
-		{ "action": { "condition": { "variableRef": { "name": "Melee weave" } }, "groupReference": { "groupName": "Weave" } } },
 		{
 			"action": {
 				"condition": { "cmp": { "op": "OpLe", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "0.5s" } } } },
 				"castSpell": { "spellId": { "spellId": 34120, "rank": 1 } }
 			}
 		},
+		{ "action": { "condition": { "variableRef": { "name": "Melee weave" } }, "groupReference": { "groupName": "Weave" } } },
 		{
 			"action": {
 				"condition": {
@@ -91,10 +91,37 @@
 		{
 			"action": {
 				"condition": {
-					"cmp": {
-						"op": "OpLe",
-						"lhs": { "spellCastTime": { "spellId": { "spellId": 34120, "rank": 1 } } },
-						"rhs": { "variableRef": { "name": "Time until auto with buffer" } }
+					"and": {
+						"vals": [
+							{
+								"cmp": {
+									"op": "OpLe",
+									"lhs": { "spellCastTime": { "spellId": { "spellId": 34120, "rank": 1 } } },
+									"rhs": { "variableRef": { "name": "Time until auto with buffer" } }
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "not": { "val": { "variableRef": { "name": "Melee weave" } } } },
+										{
+											"and": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpLe",
+															"lhs": { "spellCastTime": { "spellId": { "spellId": 34120, "rank": 1 } } },
+															"rhs": { "autoTimeToNext": { "autoType": "MeleeAuto" } }
+														}
+													},
+													{ "cmp": { "op": "OpGt", "lhs": { "unitDistance": {} }, "rhs": { "variableRef": { "name": "Melee range" } } } }
+												]
+											}
+										}
+									]
+								}
+							}
+						]
 					}
 				},
 				"castSpell": { "spellId": { "spellId": 34120, "rank": 1 } }
@@ -111,6 +138,27 @@
 									"op": "OpLe",
 									"lhs": { "spellCastTime": { "spellId": { "spellId": 27021, "rank": 6 } } },
 									"rhs": { "variableRef": { "name": "Time until auto with buffer" } }
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "not": { "val": { "variableRef": { "name": "Melee weave" } } } },
+										{
+											"and": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpLe",
+															"lhs": { "spellCastTime": { "spellId": { "spellId": 27021, "rank": 6 } } },
+															"rhs": { "autoTimeToNext": { "autoType": "MeleeAuto" } }
+														}
+													},
+													{ "cmp": { "op": "OpGt", "lhs": { "unitDistance": {} }, "rhs": { "variableRef": { "name": "Melee range" } } } }
+												]
+											}
+										}
+									]
 								}
 							}
 						]
@@ -184,7 +232,28 @@
 			"actions": [
 				{
 					"action": {
-						"condition": { "cmp": { "op": "OpGe", "lhs": { "autoTimeSinceLast": { "autoType": "MeleeAuto" } }, "rhs": { "inputDelay": {} } } },
+						"condition": { "cmp": { "op": "OpLt", "lhs": { "autoTimeSinceLast": { "autoType": "MeleeAuto" } }, "rhs": { "variableRef": { "name": "Wait at melee" } } } },
+						"wait": {
+							"duration": {
+								"math": {
+									"op": "OpSub",
+									"lhs": { "variableRef": { "name": "Wait at melee" } },
+									"rhs": { "autoTimeSinceLast": { "autoType": "MeleeAuto" } }
+								}
+							}
+						}
+					}
+				},
+				{
+					"action": {
+						"condition": {
+							"and": {
+								"vals": [
+									{ "cmp": { "op": "OpGe", "lhs": { "autoTimeSinceLast": { "autoType": "MeleeAuto" } }, "rhs": { "variableRef": { "name": "Wait at melee" } } } },
+									{ "cmp": { "op": "OpGt", "lhs": { "autoTimeToNext": { "autoType": "MeleeAuto" } }, "rhs": { "const": { "val": "0ms" } } } }
+								]
+							}
+						},
 						"move": { "rangeFromTarget": { "variableRef": { "name": "Starting weave distance" } } }
 					}
 				},
@@ -195,40 +264,59 @@
 								"vals": [
 									{
 										"cmp": {
-											"op": "OpGe",
-											"lhs": { "autoTimeToNext": { "autoType": "RangedAuto" } },
-											"rhs": { "variableRef": { "name": "Weave ranged threshold" } }
-										}
-									},
-									{
-										"cmp": {
 											"op": "OpLe",
 											"lhs": { "autoTimeToNext": { "autoType": "MeleeAuto" } },
-											"rhs": { "variableRef": { "name": "Closing time" } }
+											"rhs": { "variableRef": { "name": "Move duration" } }
 										}
 									},
 									{
 										"or": {
 											"vals": [
 												{
-													"cmp": {
-														"op": "OpGe",
-														"lhs": { "gcdTimeToReady": {} },
-														"rhs": { "variableRef": { "name": "Actual time to weave" } }
-													}
-												},
-												{
 													"and": {
 														"vals": [
-															{ "gcdIsReady": {} },
 															{
 																"cmp": {
 																	"op": "OpGe",
 																	"lhs": { "autoTimeToNext": { "autoType": "RangedAuto" } },
-																	"rhs": { "variableRef": { "name": "Weave before cast threshold" } }
+																	"rhs": { "variableRef": { "name": "Weave ranged threshold" } }
+																}
+															},
+															{
+																"or": {
+																	"vals": [
+																		{
+																			"cmp": {
+																				"op": "OpGe",
+																				"lhs": { "gcdTimeToReady": {} },
+																				"rhs": { "variableRef": { "name": "Move duration" } }
+																			}
+																		},
+																		{
+																			"and": {
+																				"vals": [
+																					{ "gcdIsReady": {} },
+																					{
+																						"cmp": {
+																							"op": "OpGe",
+																							"lhs": { "autoTimeToNext": { "autoType": "RangedAuto" } },
+																							"rhs": { "variableRef": { "name": "Weave before cast threshold" } }
+																						}
+																					}
+																				]
+																			}
+																		}
+																	]
 																}
 															}
 														]
+													}
+												},
+												{
+													"cmp": {
+														"op": "OpGt",
+														"lhs": { "autoTimeSinceLast": { "autoType": "MeleeAuto" } },
+														"rhs": { "autoSwingTime": { "autoType": "MainHand" } }
 													}
 												}
 											]
@@ -280,6 +368,7 @@
 		{ "name": "Melee weave", "value": { "const": { "val": "true" } } },
 		{ "name": "Raptor only", "value": { "const": { "val": "false" } } },
 		{ "name": "Time to weave", "value": { "const": { "val": "400ms" } } },
+		{ "name": "Move duration", "value": { "const": { "val": "100ms" } } },
 		{ "name": "Use Multi-Shot", "value": { "const": { "val": "true" } } },
 		{ "name": "Use Arcane Shot", "value": { "const": { "val": "true" } } },
 		{ "name": "Melee range", "value": { "const": { "val": "5.00" } } },
@@ -288,18 +377,37 @@
 			"value": {
 				"math": {
 					"op": "OpAdd",
-					"lhs": { "math": { "op": "OpMul", "lhs": { "variableRef": { "name": "Closing time" } }, "rhs": { "const": { "val": "7" } } } },
+					"lhs": {
+						"math": {
+							"op": "OpMul",
+							"lhs": {
+								"math": {
+									"op": "OpDiv",
+									"lhs": { "variableRef": { "name": "Move duration" } },
+									"rhs": { "const": { "val": "1s" } }
+								}
+							},
+							"rhs": { "const": { "val": "7" } }
+						}
+					},
 					"rhs": { "variableRef": { "name": "Melee range" } }
 				}
 			}
 		},
 		{
-			"name": "Closing time",
+			"name": "Wait at melee",
 			"value": {
-				"math": {
-					"op": "OpDiv",
-					"lhs": { "math": { "op": "OpSub", "lhs": { "variableRef": { "name": "Actual time to weave" } }, "rhs": { "inputDelay": {} } } },
-					"rhs": { "const": { "val": "2s" } }
+				"max": {
+					"vals": [
+						{ "inputDelay": {} },
+						{
+							"math": {
+								"op": "OpSub",
+								"lhs": { "variableRef": { "name": "Time to weave" } },
+								"rhs": { "math": { "op": "OpMul", "lhs": { "variableRef": { "name": "Move duration" } }, "rhs": { "const": { "val": "2" } } } }
+							}
+						}
+					]
 				}
 			}
 		},
@@ -340,13 +448,12 @@
 				}
 			}
 		},
-		{ "name": "Actual time to weave", "value": { "max": { "vals": [{ "variableRef": { "name": "Time to weave" } }, { "const": { "val": "101ms" } }] } } },
 		{
 			"name": "Weave ranged threshold",
 			"value": {
 				"math": {
 					"op": "OpAdd",
-					"lhs": { "variableRef": { "name": "Actual time to weave" } },
+					"lhs": { "variableRef": { "name": "Move duration" } },
 					"rhs": { "spellCastTime": { "spellId": { "spellId": 27021, "rank": 6 } } }
 				}
 			}

--- a/ui/hunter/dps/sim.ts
+++ b/ui/hunter/dps/sim.ts
@@ -261,13 +261,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 			value: { const: { val: `${timeToWeave}ms` } },
 		});
 
-		rotation.valueVariables[0] = viperStartManaPercentValue;
-		rotation.valueVariables[1] = viperStopManaPercentValue;
-		rotation.valueVariables[2] = meleeWeaveValue;
-		rotation.valueVariables[3] = weaveOnlyRaptorValue;
-		rotation.valueVariables[4] = timeToWeaveValue;
-		rotation.valueVariables[5] = useMultiValue;
-		rotation.valueVariables[6] = useArcaneValue;
+		const overrides: Record<string, APLValueVariable> = {
+			'Viper start': viperStartManaPercentValue,
+			'Viper stop': viperStopManaPercentValue,
+			'Melee weave': meleeWeaveValue,
+			'Raptor only': weaveOnlyRaptorValue,
+			'Time to weave': timeToWeaveValue,
+			'Use Multi-Shot': useMultiValue,
+			'Use Arcane Shot': useArcaneValue,
+		};
+		rotation.valueVariables = rotation.valueVariables.map(v => overrides[v.name] ?? v);
 
 		return APLRotation.create({
 			prepullActions: rotation.prepullActions,

--- a/ui/hunter/dps/sim.ts
+++ b/ui/hunter/dps/sim.ts
@@ -53,6 +53,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 		[
 			PseudoStat.PseudoStatMeleeHitPercent,
 			PseudoStat.PseudoStatMeleeCritPercent,
+			PseudoStat.PseudoStatMeleeHastePercent,
 			PseudoStat.PseudoStatRangedHitPercent,
 			PseudoStat.PseudoStatRangedCritPercent,
 			PseudoStat.PseudoStatRangedHastePercent,

--- a/ui/scss/core/components/detailed_results/_timeline.scss
+++ b/ui/scss/core/components/detailed_results/_timeline.scss
@@ -73,7 +73,7 @@
 		margin-left: auto;
 		display: flex;
 		align-items: center;
-		gap: 0.75rem;
+		gap: var(--spacer-3);
 	}
 
 	.timeline-chart-picker {
@@ -81,19 +81,13 @@
 	}
 
 	.timeline-show-gcd {
-		display: flex;
-		align-items: center;
-		gap: 0.4rem;
-		cursor: pointer;
-		white-space: nowrap;
+		.boolean-picker-root {
+			width: unset;
+			white-space: nowrap;
 
-		.form-check-input {
-			margin: 0;
-			float: none;
-		}
-
-		.form-check-label {
-			margin: 0;
+			label {
+				margin-left: var(--spacer-2);
+			}
 		}
 	}
 }

--- a/ui/scss/core/components/detailed_results/_timeline.scss
+++ b/ui/scss/core/components/detailed_results/_timeline.scss
@@ -5,6 +5,9 @@
 	--timeline-aura-bg: rgba(0, 0, 255, 0.52);
 	--timeline-travel-time-bg: rgb(249, 192, 255, 0.6);
 	--timeline-cast-delay-bg: rgba(220, 80, 80, 0.35);
+	--timeline-gcd-bg: rgba(80, 180, 235, 0.55);
+	--timeline-gcd-extension-bg: rgba(80, 180, 235, 0.22);
+	--timeline-gcd-strip-empty-bg: rgba(255, 255, 255, 0.04);
 }
 
 .threat .series-color,
@@ -67,9 +70,32 @@
 	display: flex;
 	align-items: flex-start;
 
+	.timeline-controls {
+		margin-left: auto;
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
 	.timeline-chart-picker {
 		width: 8rem;
-		margin-left: auto;
+	}
+
+	.timeline-show-gcd {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		cursor: pointer;
+		white-space: nowrap;
+
+		.form-check-input {
+			margin: 0;
+			float: none;
+		}
+
+		.form-check-label {
+			margin: 0;
+		}
 	}
 }
 
@@ -301,6 +327,36 @@
 	height: 24px;
 	background-color: var(--timeline-cast-delay-bg);
 	z-index: 0;
+}
+
+// Muted-color extension after the cast block to the end of the GCD.
+.rotation-timeline-gcd-extension {
+	position: absolute;
+	height: 24px;
+	background-color: var(--timeline-gcd-extension-bg);
+	z-index: 0;
+}
+
+// Continuous strip near the top of the timeline showing every GCD.
+// Height is inherited from .rotation-row (28px) so the corresponding label
+// cell stays aligned with the rest of the timeline.
+.rotation-timeline-gcd-strip {
+	background-color: var(--timeline-gcd-strip-empty-bg);
+}
+
+.rotation-timeline-gcd-segment {
+	position: absolute;
+	top: 6px;
+	height: 16px;
+	background-color: var(--timeline-gcd-bg);
+	border-right: 1px solid rgba(0, 0, 0, 0.35);
+	z-index: 1;
+}
+
+// Toggled by the "Show GCD" checkbox; visible only when .show-gcd is set.
+.rotation-plot:not(.show-gcd) .rotation-timeline-gcd-extension,
+.rotation-plot:not(.show-gcd) [data-row='gcd'] {
+	display: none;
 }
 
 .rotation-timeline-tick {

--- a/ui/scss/core/components/detailed_results/_timeline.scss
+++ b/ui/scss/core/components/detailed_results/_timeline.scss
@@ -7,7 +7,6 @@
 	--timeline-cast-delay-bg: rgba(220, 80, 80, 0.35);
 	--timeline-gcd-bg: rgba(80, 180, 235, 0.55);
 	--timeline-gcd-extension-bg: rgba(80, 180, 235, 0.22);
-	--timeline-gcd-strip-empty-bg: rgba(255, 255, 255, 0.04);
 }
 
 .threat .series-color,
@@ -337,17 +336,10 @@
 	z-index: 0;
 }
 
-// Continuous strip near the top of the timeline showing every GCD.
-// Height is inherited from .rotation-row (28px) so the corresponding label
-// cell stays aligned with the rest of the timeline.
-.rotation-timeline-gcd-strip {
-	background-color: var(--timeline-gcd-strip-empty-bg);
-}
-
 .rotation-timeline-gcd-segment {
 	position: absolute;
 	top: 6px;
-	height: 16px;
+	height: 12px;
 	background-color: var(--timeline-gcd-bg);
 	border-right: 1px solid rgba(0, 0, 0, 0.35);
 	z-index: 1;


### PR DESCRIPTION
Also adds the auto delay blocks for MH-swings for Hunters alongside the ranged-swings
The GCD toggle as well as the swing delays are nice features for debugging ability usage / ineffectiveness, especially for Hunter melee weave rotations.

**This one also updates the hunter APL as well as fixes an issue where ReactToEvent could overwrite an ongoing Wait APL action, resulting in unwanted behavior. (The rogue/warrior test results are just noise)**

<img width="1112" height="432" alt="image" src="https://github.com/user-attachments/assets/cc598b1a-9f45-4766-8d71-91e4011f4c10" />
<img width="473" height="240" alt="image" src="https://github.com/user-attachments/assets/2bc302c4-bf7e-4a4e-b468-ddc6c33485f5" />
<img width="400" height="123" alt="image" src="https://github.com/user-attachments/assets/25b36090-ba3a-49fc-8627-5083402c0df2" />
<img width="540" height="274" alt="image" src="https://github.com/user-attachments/assets/3742b0d0-7a66-4012-9bb4-1915edf13ba4" />
