### PR TITLE
[Core] Add spell pushback for tanks

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -470,6 +470,7 @@ message PartyBuffs {
 	TristateEffect sanctity_aura = 5;
 	TristateEffect devotion_aura = 6;
 	TristateEffect retribution_aura = 7;
+	TristateEffect concentration_aura = 45;
 	bool trueshot_aura = 8;
 	bool draenei_racial_melee = 9;
 	bool draenei_racial_caster = 10;

--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -202,7 +202,7 @@ func (aura *Aura) SetStacks(sim *Simulation, newStacks int32) {
 		return
 	}
 
-	if sim.Log != nil {
+	if sim.Log != nil && !aura.ActionID.IsEmptyAction() {
 		aura.Unit.Log(sim, "%s stacks: %d --> %d", aura.ActionID, oldStacks, newStacks)
 	}
 	aura.stacks = newStacks

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -263,6 +263,10 @@ func applyBuffEffects(agent Agent, raidBuffs *proto.RaidBuffs, partyBuffs *proto
 		MakePermanent(RetributionAuraBuff(char, false, GetTristateValueInt32(partyBuffs.RetributionAura, 0, 2)))
 	}
 
+	if partyBuffs.ConcentrationAura != proto.TristateEffect_TristateEffectMissing {
+		MakePermanent(ConcentrationAura(char, false, GetTristateValueInt32(partyBuffs.ConcentrationAura, 0, 3)))
+	}
+
 	if partyBuffs.SanctityAura != proto.TristateEffect_TristateEffectMissing {
 		MakePermanent(SanctityAuraBuff(char, false, GetTristateValueInt32(partyBuffs.SanctityAura, 0, 2)))
 	}
@@ -744,6 +748,7 @@ func CommandingShoutAura(char *Character, isPlayer bool, boomingVoicePoints int3
 
 var (
 	PaladinAuraCategory          = "PaladinAura"
+	ConcentrationAuraCategory    = "ConcentrationAura"
 	DevotionAuraCategory         = "DevotionAura"
 	RetributionAuraCategory      = "RetributionAura"
 	SanctityAuraCategory         = "SanctityAura"
@@ -870,6 +875,34 @@ func RetributionAuraBuff(char *Character, isPlayer bool, impRetributionAuraRank 
 	// Self and external share RetributionAuraCategory (SingleAura) so only one
 	// variant's proc trigger fires at a time; self wins via higher priority.
 	aura.NewExclusiveEffect(RetributionAuraCategory, true, ExclusiveEffect{
+		Priority: paladinAuraPriority(isPlayer),
+	})
+
+	if isPlayer {
+		aura.NewExclusiveEffect(PaladinAuraCategory, true, ExclusiveEffect{})
+	}
+
+	return aura
+}
+
+func ConcentrationAura(char *Character, isPlayer bool, impConcentrationAuraRank int32) *Aura {
+	actionID := ActionID{SpellID: 19746}.WithTag(TernaryInt32(isPlayer, 0, -1))
+
+	pushbackReduction := -0.3
+	if impConcentrationAuraRank > 0 {
+		pushbackReduction -= 0.05 * float64(impConcentrationAuraRank)
+	}
+
+	aura := char.GetOrRegisterAura(Aura{
+		Label:      fmt.Sprintf("Concentration Aura (%s)", Ternary(isPlayer, "Player", "External")),
+		ActionID:   actionID,
+		Duration:   NeverExpires,
+		BuildPhase: Ternary(isPlayer, CharacterBuildPhaseNone, CharacterBuildPhaseBuffs),
+	}).AttachAdditivePseudoStatBuff(
+		&char.PseudoStats.PushbackChance, pushbackReduction,
+	)
+
+	aura.NewExclusiveEffect(ConcentrationAuraCategory, true, ExclusiveEffect{
 		Priority: paladinAuraPriority(isPlayer),
 	})
 

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -15,11 +15,13 @@ import (
 type OnCastComplete func(aura *Aura, sim *Simulation, spell *Spell)
 
 type Hardcast struct {
-	Expires    time.Duration
-	ActionID   ActionID
-	OnComplete func(*Simulation, *Unit)
-	Target     *Unit
-	CanMove    bool
+	Expires     time.Duration
+	ActionID    ActionID
+	OnComplete  func(*Simulation, *Unit)
+	Target      *Unit
+	CanMove     bool
+	IsChanneled bool
+	CastTime    time.Duration
 }
 
 // Input for constructing the CastSpell function for a spell.
@@ -163,10 +165,11 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 			return spell.castFailureHelper(sim, "casting/channeling while moving not allowed!")
 		}
 
+		isChanneled := spell.Flags.Matches(SpellFlagChanneled)
 		if effectiveTime := spell.CurCast.EffectiveTime(); effectiveTime != 0 {
 			// do not add channeled time here as they have variable cast length
 			// cast time for channels is handled in dot.OnExpire
-			if !spell.Flags.Matches(SpellFlagChanneled) {
+			if !isChanneled {
 				spell.SpellMetrics[target.UnitIndex].TotalCastTime += effectiveTime
 			}
 
@@ -216,8 +219,10 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 						spell.Unit.OnCastComplete(sim, spell)
 					}
 				},
-				Target:  target,
-				CanMove: spell.Flags&SpellFlagCanCastWhileMoving > 0,
+				Target:      target,
+				CanMove:     spell.Flags&SpellFlagCanCastWhileMoving > 0,
+				IsChanneled: isChanneled,
+				CastTime:    spell.CurCast.CastTime,
 			}
 
 			spell.Unit.newHardcastAction(sim)

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -421,16 +421,57 @@ func (character *Character) Finalize() {
 
 	character.PseudoStats.ParryHaste = character.PseudoStats.CanParry
 
-	character.HardcastAvoidanceAura = character.RegisterAura(Aura{
-		Label:    "Reduced avoidance",
-		Duration: NeverExpires,
-		OnGain: func(aura *Aura, sim *Simulation) {
-			character.PseudoStats.Stunned = true
-		},
-		OnExpire: func(aura *Aura, sim *Simulation) {
-			character.PseudoStats.Stunned = false
-		},
-	})
+	if character.Unit.Metrics.isTanking {
+		character.HardcastAvoidanceAura = character.RegisterAura(Aura{
+			Label:    "Reduced avoidance",
+			Duration: NeverExpires,
+			OnGain: func(aura *Aura, sim *Simulation) {
+				character.PseudoStats.Stunned = true
+			},
+			OnExpire: func(aura *Aura, sim *Simulation) {
+				character.PseudoStats.Stunned = false
+			},
+		})
+
+		character.MakeProcTriggerAura(ProcTrigger{
+			Name:               "Pushback trigger",
+			Callback:           CallbackOnSpellHitTaken,
+			Outcome:            OutcomeLanded,
+			RequireDamageDealt: true,
+
+			ExtraCondition: func(sim *Simulation, spell *Spell, result *SpellResult) bool {
+				return character.Hardcast.Expires > sim.CurrentTime &&
+					// Dots will not trigger pushback
+					!(spell.dots != nil || spell.aoeDot != nil || (spell.RelatedDotSpell != nil && (spell.RelatedDotSpell.dots != nil || spell.RelatedDotSpell.aoeDot != nil)))
+			},
+
+			Handler: func(sim *Simulation, spell *Spell, result *SpellResult) {
+				if !sim.Proc(character.PseudoStats.PushbackChance, "Pushback") {
+					return
+				}
+
+				if character.Hardcast.IsChanneled {
+					// Channeled spells will lose 25% of their total duration
+					pushback := character.Hardcast.CastTime / 4
+					character.Hardcast.Expires = max(sim.CurrentTime, character.Hardcast.Expires-pushback)
+
+					if sim.Log != nil {
+						character.Log(sim, "%s pushed back %s while channeling", character.Hardcast.ActionID, pushback)
+					}
+				} else {
+					// Non-channeled spells will be pushed back by 0.5s
+					character.Hardcast.Expires += SpellPushbackDuration
+
+					if sim.Log != nil {
+						character.Log(sim, "%s pushed back %s while casting", character.Hardcast.ActionID, SpellPushbackDuration)
+					}
+				}
+
+				// Re-schedule the cast at the new Expires time
+				character.newHardcastAction(sim)
+			},
+		})
+	}
 
 	character.Unit.finalize()
 

--- a/sim/core/constants.go
+++ b/sim/core/constants.go
@@ -16,6 +16,7 @@ const BossGCD = time.Millisecond * 1620
 const MaxSpellQueueWindow = time.Millisecond * 400
 const SpellBatchWindow = time.Millisecond * 10
 const PetUpdateInterval = time.Millisecond * 5250
+const SpellPushbackDuration = time.Millisecond * 500
 const MaxMeleeRange = 5.0 // in yards
 
 const DefaultAttackPowerPerDPS = 14.0

--- a/sim/core/gcd.go
+++ b/sim/core/gcd.go
@@ -6,8 +6,10 @@ import (
 
 // Note that this is only used when the hardcast and GCD actions happen at different times.
 func (unit *Unit) newHardcastAction(sim *Simulation) {
-	// While casting, the players dodge, parry and block gets reduced to 0
-	unit.HardcastAvoidanceAura.Activate(sim)
+	if unit.Metrics.isTanking {
+		// While casting, the players dodge, parry and block gets reduced to 0
+		unit.HardcastAvoidanceAura.Activate(sim)
+	}
 
 	if (unit.hardcastAction != nil) && !unit.hardcastAction.consumed {
 		unit.hardcastAction.Cancel(sim)

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -521,6 +521,7 @@ type PseudoStats struct {
 	ExternalHealingTakenMultiplier float64 // Modulates the output of the individual tank sim healing model
 	MovementSpeedMultiplier        float64 // Multiplier for movement speed, default to 1. Player base movement 7 yards/s. All effects affecting movements are multipliers.
 	SelfHealingMultiplier          float64 // Healing from spells and abilities, only-self
+	PushbackChance                 float64 // Chance of being pushed back by a spell cast, defaults to 1.
 }
 
 func NewPseudoStats() PseudoStats {
@@ -561,6 +562,7 @@ func NewPseudoStats() PseudoStats {
 		HealingTakenMultiplier:         1,
 		ExternalHealingTakenMultiplier: 1,
 		MovementSpeedMultiplier:        1,
+		PushbackChance:                 1,
 	}
 }
 

--- a/sim/core/test_utils.go
+++ b/sim/core/test_utils.go
@@ -69,6 +69,7 @@ var FullPartyBuffs = &proto.PartyBuffs{
 	SanctityAura:          proto.TristateEffect_TristateEffectImproved,
 	DevotionAura:          proto.TristateEffect_TristateEffectImproved,
 	RetributionAura:       proto.TristateEffect_TristateEffectImproved,
+	ConcentrationAura:     proto.TristateEffect_TristateEffectImproved,
 	TrueshotAura:          true,
 	DraeneiRacialMelee:    true,
 	DraeneiRacialCaster:   true,

--- a/sim/paladin/auras.go
+++ b/sim/paladin/auras.go
@@ -75,7 +75,7 @@ func (paladin *Paladin) registerSelfCastAura(label string, actionID core.ActionI
 // All party members within 30 yards lose 35% less casting or channeling time
 // when damaged. Players may only have one Aura on them per Paladin at any one time.
 func (paladin *Paladin) registerConcentrationAura() {
-	aura := paladin.registerSelfCastAura("Concentration Aura", core.ActionID{SpellID: 19746})
+	aura := core.ConcentrationAura(&paladin.Character, true, paladin.Talents.ImprovedConcentrationAura)
 	paladin.registerAuraSpell(aura, SpellMaskConcentrationAura)
 }
 

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -55,1667 +55,1667 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 908.79552
-  tps: 1621.248
-  dtps: 1305.49318
+  dps: 908.67173
+  tps: 1620.79988
+  dtps: 1295.48097
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 894.09589
-  tps: 1599.60506
-  dtps: 1236.14189
+  dps: 895.0941
+  tps: 1602.20105
+  dtps: 1246.84747
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 939.27701
-  tps: 1685.60517
-  dtps: 1268.70693
+  dps: 939.76509
+  tps: 1687.68369
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 900.58429
-  tps: 1611.26629
-  dtps: 1265.96402
+  dps: 900.3825
+  tps: 1611.99922
+  dtps: 1291.57463
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 897.40952
-  tps: 1604.26199
-  dtps: 1200.11429
+  dps: 897.921
+  tps: 1604.8389
+  dtps: 1202.47962
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 919.77163
-  tps: 1648.12266
-  dtps: 1268.70693
+  dps: 919.73327
+  tps: 1649.1811
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 909.15834
-  tps: 1627.71576
-  dtps: 1268.70693
+  dps: 909.21447
+  tps: 1628.94995
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 908.19662
-  tps: 1620.19241
-  dtps: 1268.70693
+  dps: 908.1354
+  tps: 1621.15282
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Annihilator-12798"
  value: {
-  dps: 832.97977
-  tps: 1483.56381
-  dtps: 1301.47787
+  dps: 832.09002
+  tps: 1483.16625
+  dtps: 1306.2087
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 922.69698
-  tps: 1654.28753
-  dtps: 1268.70693
+  dps: 921.66481
+  tps: 1653.63211
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 915.42924
-  tps: 1647.04798
-  dtps: 1521.28433
+  dps: 915.15195
+  tps: 1646.74089
+  dtps: 1518.66163
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 900.58429
-  tps: 1611.26314
-  dtps: 1265.91137
+  dps: 900.3825
+  tps: 1611.99938
+  dtps: 1291.43233
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 899.57609
-  tps: 1605.82377
-  dtps: 1201.90877
+  dps: 897.54221
+  tps: 1602.62963
+  dtps: 1224.69668
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 903.85501
-  tps: 1614.55591
-  dtps: 1268.70693
+  dps: 903.62581
+  tps: 1615.26148
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 948.98717
-  tps: 1694.77477
-  dtps: 1276.12544
+  dps: 948.29024
+  tps: 1694.40339
+  dtps: 1303.57219
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 948.9253
-  tps: 1705.42895
-  dtps: 1311.587
+  dps: 946.71555
+  tps: 1701.43376
+  dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 955.87756
-  tps: 1719.40936
-  dtps: 1311.587
+  dps: 953.7935
+  tps: 1715.61865
+  dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 901.98826
-  tps: 1613.75798
-  dtps: 1268.70693
+  dps: 901.77283
+  tps: 1614.46967
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BattlecastGarb"
  value: {
-  dps: 948.08569
-  tps: 1710.21894
-  dtps: 1535.63936
+  dps: 948.198
+  tps: 1710.85364
+  dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 896.77342
-  tps: 1605.69657
-  dtps: 1278.91703
+  dps: 897.53902
+  tps: 1607.48565
+  dtps: 1296.09458
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 896.77342
-  tps: 1605.69657
-  dtps: 1278.91703
+  dps: 897.53902
+  tps: 1607.48565
+  dtps: 1296.09458
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 918.74639
-  tps: 1646.18816
-  dtps: 1268.70693
+  dps: 918.55824
+  tps: 1646.95018
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 907.16972
-  tps: 1619.45583
-  dtps: 1268.70693
+  dps: 906.4206
+  tps: 1619.2028
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 900.76299
-  tps: 1611.62472
-  dtps: 1268.70693
+  dps: 900.56081
+  tps: 1612.35696
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 907.32173
-  tps: 1618.02263
-  dtps: 1268.70693
+  dps: 907.10805
+  tps: 1618.74372
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 912.17712
-  tps: 1633.56368
-  dtps: 1268.70693
+  dps: 911.98404
+  tps: 1634.3152
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 914.47678
-  tps: 1625.17768
-  dtps: 1268.70693
+  dps: 914.46706
+  tps: 1626.10273
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 939.1511
-  tps: 1685.36354
-  dtps: 1268.70693
+  dps: 940.60102
+  tps: 1689.26717
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 917.4062
-  tps: 1628.91486
-  dtps: 1278.86418
+  dps: 912.01227
+  tps: 1621.30021
+  dtps: 1288.02322
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 909.19856
-  tps: 1621.68325
-  dtps: 1268.70693
+  dps: 908.78249
+  tps: 1622.03616
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 899.95848
-  tps: 1610.19956
-  dtps: 1286.901
+  dps: 894.19284
+  tps: 1601.89431
+  dtps: 1308.24136
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Blinkstrike-31332"
  value: {
-  dps: 939.27701
-  tps: 1685.60517
-  dtps: 1268.70693
+  dps: 939.76509
+  tps: 1687.68369
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 911.52292
-  tps: 1622.22382
-  dtps: 1268.70693
+  dps: 911.46908
+  tps: 1623.10475
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 948.71675
-  tps: 1701.04359
-  dtps: 1341.8288
+  dps: 952.08692
+  tps: 1707.34693
+  dtps: 1335.7269
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 894.09589
-  tps: 1599.71355
-  dtps: 1249.14435
+  dps: 895.0941
+  tps: 1602.28651
+  dtps: 1259.82996
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofFortitude-35039"
  value: {
-  dps: 933.63005
-  tps: 1674.87595
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.94065
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofVengeance-35041"
  value: {
-  dps: 933.63721
-  tps: 1674.88955
-  dtps: 1268.70693
+  dps: 934.11801
+  tps: 1676.95425
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 932.37819
-  tps: 1674.10873
-  dtps: 1230.9735
+  dps: 933.24049
+  tps: 1676.85594
+  dtps: 1222.58641
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 934.15581
-  tps: 1660.28002
-  dtps: 1283.16886
+  dps: 933.04772
+  tps: 1658.02886
+  dtps: 1294.27042
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 936.13084
-  tps: 1662.43063
-  dtps: 1272.94348
+  dps: 934.22434
+  tps: 1659.56601
+  dtps: 1284.01685
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BurningRage"
  value: {
-  dps: 930.92497
-  tps: 1634.50175
-  dtps: 1534.06569
+  dps: 926.27597
+  tps: 1628.60449
+  dtps: 1546.20737
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 951.71484
-  tps: 1711.41037
-  dtps: 1311.587
+  dps: 949.65622
+  tps: 1707.66266
+  dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 898.42671
-  tps: 1608.40391
-  dtps: 1246.29855
+  dps: 898.42837
+  tps: 1608.51671
+  dtps: 1245.67488
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 934.27384
-  tps: 1678.98304
-  dtps: 1407.43539
+  dps: 931.5778
+  tps: 1673.00133
+  dtps: 1401.27151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CloudkeeperLegplates-14554"
  value: {
-  dps: 931.47579
-  tps: 1664.9621
-  dtps: 1335.0332
+  dps: 930.74621
+  tps: 1664.03241
+  dtps: 1349.43444
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 900.58429
-  tps: 1611.11792
-  dtps: 1249.98582
+  dps: 900.3825
+  tps: 1611.87549
+  dtps: 1275.54983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 908.47077
-  tps: 1619.17167
-  dtps: 1268.70693
+  dps: 908.37539
+  tps: 1620.01107
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 931.79844
-  tps: 1673.47365
-  dtps: 1407.43539
+  dps: 928.99077
+  tps: 1667.2757
+  dtps: 1401.27151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeArmor"
  value: {
-  dps: 915.54137
-  tps: 1644.26369
-  dtps: 1294.96572
+  dps: 914.07098
+  tps: 1641.29338
+  dtps: 1290.08496
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeBattlegear"
  value: {
-  dps: 938.47129
-  tps: 1625.15803
-  dtps: 1380.8635
-  hps: 1.16525
+  dps: 936.76198
+  tps: 1622.50967
+  dtps: 1405.86367
+  hps: 1.16609
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 908.07718
-  tps: 1618.77808
-  dtps: 1268.70693
+  dps: 907.79333
+  tps: 1619.429
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 895.19985
-  tps: 1602.09834
-  dtps: 1255.43361
+  dps: 895.49515
+  tps: 1603.21435
+  dtps: 1260.07345
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 930.82313
-  tps: 1669.34331
-  dtps: 1268.70693
+  dps: 930.86615
+  tps: 1670.56397
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 913.11706
-  tps: 1626.58259
-  dtps: 1268.70693
+  dps: 912.82572
+  tps: 1627.16034
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 897.28229
-  tps: 1607.71729
-  dtps: 1286.28842
+  dps: 897.53907
+  tps: 1607.38095
+  dtps: 1276.55653
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 916.93615
-  tps: 1633.17767
-  dtps: 1268.70693
+  dps: 915.20206
+  tps: 1631.13157
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DirebrewHops-38288"
  value: {
-  dps: 921.12405
-  tps: 1650.76428
-  dtps: 1268.70693
+  dps: 920.83599
+  tps: 1651.33059
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DoomplateBattlegear"
  value: {
-  dps: 921.6092
-  tps: 1614.53818
-  dtps: 1613.04419
+  dps: 920.56937
+  tps: 1614.13188
+  dtps: 1619.08265
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 908.88761
-  tps: 1627.21966
-  dtps: 1268.70693
+  dps: 908.48291
+  tps: 1627.56004
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonmaw-28438"
  value: {
-  dps: 908.37877
-  tps: 1567.29668
-  dtps: 1274.17813
+  dps: 905.69493
+  tps: 1562.48214
+  dtps: 1262.90409
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 914.50622
-  tps: 1629.28051
-  dtps: 1295.74897
+  dps: 910.83688
+  tps: 1622.27298
+  dtps: 1286.8966
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonstrike-28439"
  value: {
-  dps: 920.84064
-  tps: 1582.50103
-  dtps: 1273.49496
+  dps: 920.76938
+  tps: 1581.15575
+  dtps: 1264.15865
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 907.90843
-  tps: 1569.19421
-  dtps: 1267.34999
+  dps: 901.58446
+  tps: 1562.47669
+  dtps: 1282.27771
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 912.32563
-  tps: 1633.40223
-  dtps: 1268.70693
+  dps: 912.09876
+  tps: 1634.09561
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Earthstrike-21180"
  value: {
-  dps: 905.49429
-  tps: 1616.19519
-  dtps: 1268.70693
+  dps: 905.4523
+  tps: 1617.08797
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 901.45259
-  tps: 1613.50238
-  dtps: 1263.59201
+  dps: 901.18192
+  tps: 1612.15752
+  dtps: 1281.89069
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 911.52292
-  tps: 1622.22382
-  dtps: 1268.70693
+  dps: 911.46908
+  tps: 1623.10475
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 936.56536
-  tps: 1681.29043
-  dtps: 1270.2934
+  dps: 938.42805
+  tps: 1684.50366
+  dtps: 1278.88702
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 941.14766
-  tps: 1658.45763
-  dtps: 1297.26118
+  dps: 940.51226
+  tps: 1657.6743
+  dtps: 1310.99362
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 931.54845
-  tps: 1702.74309
-  dtps: 1268.70693
+  dps: 932.03073
+  tps: 1704.83397
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 927.85856
-  tps: 1660.07179
-  dtps: 1268.70693
+  dps: 928.43459
+  tps: 1662.31333
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 918.17835
-  tps: 1638.4248
-  dtps: 1226.85943
+  dps: 918.01048
+  tps: 1640.12382
+  dtps: 1236.86721
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 928.23329
-  tps: 1660.32035
-  dtps: 1268.70693
+  dps: 928.7962
+  tps: 1662.4606
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 922.56605
-  tps: 1648.32588
-  dtps: 1225.91043
+  dps: 924.03984
+  tps: 1650.80333
+  dtps: 1232.40893
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 921.12405
-  tps: 1650.76428
-  dtps: 1268.70693
+  dps: 920.83599
+  tps: 1651.33059
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeofMoam-21473"
  value: {
-  dps: 903.67066
-  tps: 1617.21849
-  dtps: 1268.70693
+  dps: 903.46948
+  tps: 1617.95192
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 931.20017
-  tps: 1670.08726
-  dtps: 1268.70693
+  dps: 931.0633
+  tps: 1670.9509
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 946.47371
-  tps: 1702.12031
-  dtps: 1325.74137
+  dps: 945.47833
+  tps: 1699.55256
+  dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelSkin"
  value: {
-  dps: 939.47311
-  tps: 1671.29112
-  dtps: 1560.72432
+  dps: 940.5623
+  tps: 1673.04104
+  dtps: 1591.51554
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelscaleArmor"
  value: {
-  dps: 905.25967
-  tps: 1594.83723
-  dtps: 1476.4793
+  dps: 906.45886
+  tps: 1597.38751
+  dtps: 1473.24399
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 892.9595
-  tps: 1596.63116
-  dtps: 1212.13595
+  dps: 891.02227
+  tps: 1594.98472
+  dtps: 1226.52683
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 889.43735
-  tps: 1591.15424
-  dtps: 1177.99695
+  dps: 889.03752
+  tps: 1591.31279
+  dtps: 1199.11718
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 907.42589
-  tps: 1618.12679
-  dtps: 1268.70693
+  dps: 907.23821
+  tps: 1618.87388
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
-  hps: 4.73333
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
+  hps: 4.7
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForceReactiveDisk-18168"
  value: {
-  dps: 936.93711
-  tps: 1680.39797
-  dtps: 1441.59573
+  dps: 938.95445
+  tps: 1686.73331
+  dtps: 1453.53081
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofFortitude-33936"
  value: {
-  dps: 933.63005
-  tps: 1674.87595
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.94065
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofVengeance-33948"
  value: {
-  dps: 933.63721
-  tps: 1674.88955
-  dtps: 1268.70693
+  dps: 934.11801
+  tps: 1676.95425
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 919.77163
-  tps: 1648.12266
-  dtps: 1268.70693
+  dps: 919.73327
+  tps: 1649.1811
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 900.58429
-  tps: 1611.1658
-  dtps: 1254.99665
+  dps: 900.3825
+  tps: 1611.92024
+  dtps: 1280.69983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 900.58429
-  tps: 1611.11792
-  dtps: 1249.98582
+  dps: 900.3825
+  tps: 1611.87549
+  dtps: 1275.54983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HandofJustice-11815"
  value: {
-  dps: 911.81978
-  tps: 1628.51188
-  dtps: 1281.14272
+  dps: 912.97163
+  tps: 1631.61794
+  dtps: 1293.43818
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 898.20445
-  tps: 1606.04179
-  dtps: 1275.71195
+  dps: 897.92938
+  tps: 1606.83676
+  dtps: 1305.00032
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 907.07957
-  tps: 1623.17287
-  dtps: 1268.70693
+  dps: 906.76962
+  tps: 1623.67808
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 939.60907
-  tps: 1686.2084
-  dtps: 1268.70693
+  dps: 939.73892
+  tps: 1687.60184
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 910.20389
-  tps: 1629.74352
-  dtps: 1268.70693
+  dps: 909.8419
+  tps: 1630.16716
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 908.22155
-  tps: 1620.50766
-  dtps: 1268.70693
+  dps: 907.43875
+  tps: 1620.22095
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IceGuard-2682"
  value: {
-  dps: 943.53556
-  tps: 1695.59047
-  dtps: 1311.88369
+  dps: 940.7619
+  tps: 1690.43873
+  dtps: 1312.25995
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 908.39415
-  tps: 1621.20425
-  dtps: 1284.84399
+  dps: 907.76988
+  tps: 1619.14447
+  dtps: 1283.53082
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImbuedNetherweave"
  value: {
-  dps: 936.27069
-  tps: 1686.56071
-  dtps: 1576.27999
+  dps: 936.69675
+  tps: 1688.05513
+  dtps: 1573.5504
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JomGabbar-23570"
  value: {
-  dps: 906.46269
-  tps: 1617.16359
-  dtps: 1268.70693
+  dps: 906.5661
+  tps: 1618.20177
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarArmor"
  value: {
-  dps: 926.1287
-  tps: 1663.56571
-  dtps: 1328.99946
+  dps: 926.2824
+  tps: 1662.93763
+  dtps: 1329.87036
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarBattlegear"
  value: {
-  dps: 927.08754
-  tps: 1616.02609
-  dtps: 1444.74556
+  dps: 926.08444
+  tps: 1613.70465
+  dtps: 1461.81743
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumScope-2723"
  value: {
-  dps: 939.27701
-  tps: 1685.60517
-  dtps: 1268.70693
+  dps: 939.76509
+  tps: 1687.68369
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumWard"
  value: {
-  dps: 966.8193
-  tps: 1744.45015
-  dtps: 1492.58655
+  dps: 962.62011
+  tps: 1737.98136
+  dtps: 1484.42037
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 913.67181
-  tps: 1632.30449
-  dtps: 1305.71821
+  dps: 909.46475
+  tps: 1625.8989
+  dtps: 1293.10578
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofAvengement-27484"
  value: {
-  dps: 938.7817
-  tps: 1681.41624
-  dtps: 1268.70693
+  dps: 939.29945
+  tps: 1683.71185
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 933.63005
-  tps: 1674.87595
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.94065
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivinePurpose-33504"
  value: {
-  dps: 955.30017
-  tps: 1716.04917
-  dtps: 1268.70693
+  dps: 955.82927
+  tps: 1718.20564
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofFervor-23203"
  value: {
-  dps: 933.63005
-  tps: 1674.87595
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.94065
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofHope-22401"
  value: {
-  dps: 933.63005
-  tps: 1674.17531
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.21183
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRepentance-29388"
  value: {
-  dps: 933.63005
-  tps: 1674.87595
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.94065
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRighteousPower-31033"
  value: {
-  dps: 933.63005
-  tps: 1674.87595
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.94065
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofWracking-28065"
  value: {
-  dps: 933.63005
-  tps: 1674.87595
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.94065
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27949"
  value: {
-  dps: 933.63005
-  tps: 1674.87595
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.94065
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27983"
  value: {
-  dps: 933.63005
-  tps: 1674.87595
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.94065
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerArmor"
  value: {
-  dps: 953.78666
-  tps: 1714.45453
-  dtps: 1063.94821
+  dps: 957.47556
+  tps: 1721.27257
+  dtps: 1061.24395
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1057.50829
-  tps: 1772.51664
-  dtps: 1699.80983
+  dps: 1052.61497
+  tps: 1765.86105
+  dtps: 1700.06334
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 912.41292
-  tps: 1623.2239
-  dtps: 1274.12727
+  dps: 913.81174
+  tps: 1626.6224
+  dtps: 1281.99271
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 920.54154
-  tps: 1662.05818
-  dtps: 1947.9673
+  dps: 917.97192
+  tps: 1659.13629
+  dtps: 1955.39544
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 925.11246
-  tps: 1660.4646
-  dtps: 1361.40613
+  dps: 923.81548
+  tps: 1658.70489
+  dtps: 1379.27527
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 914.88211
-  tps: 1638.09734
-  dtps: 1268.70693
+  dps: 914.69106
+  tps: 1638.75237
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofFortitude-33937"
  value: {
-  dps: 933.63005
-  tps: 1674.87595
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.94065
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofVengeance-33949"
  value: {
-  dps: 933.63721
-  tps: 1674.88955
-  dtps: 1268.70693
+  dps: 934.11801
+  tps: 1676.95425
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 901.62479
-  tps: 1612.61781
-  dtps: 1274.70261
+  dps: 898.39691
+  tps: 1607.7646
+  dtps: 1295.58137
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 885.84352
-  tps: 1585.50533
-  dtps: 1179.89518
+  dps: 887.05963
+  tps: 1588.72705
+  dtps: 1194.67222
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 906.06512
-  tps: 1622.36486
-  dtps: 1268.70693
+  dps: 905.45917
+  tps: 1622.36793
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 911.71444
-  tps: 1632.64076
-  dtps: 1268.70693
+  dps: 911.407
+  tps: 1633.16948
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherscaleArmor"
  value: {
-  dps: 956.29946
-  tps: 1698.85529
-  dtps: 1506.81623
+  dps: 950.7565
+  tps: 1691.14919
+  dtps: 1509.65126
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherstrikeArmor"
  value: {
-  dps: 966.97919
-  tps: 1744.46073
-  dtps: 1514.10315
+  dps: 962.8946
+  tps: 1738.46319
+  dtps: 1511.76151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherweaveVestments"
  value: {
-  dps: 967.98853
-  tps: 1753.10389
-  dtps: 2066.38378
+  dps: 964.48501
+  tps: 1748.36039
+  dtps: 2069.19023
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 907.18301
-  tps: 1617.88391
-  dtps: 1268.70693
+  dps: 906.97889
+  tps: 1618.61456
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 914.51074
-  tps: 1638.05323
-  dtps: 1268.70693
+  dps: 914.24648
+  tps: 1638.6654
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 944.43088
-  tps: 1697.99021
-  dtps: 1325.74137
+  dps: 943.07051
+  tps: 1694.65712
+  dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 944.43088
-  tps: 1697.99021
-  dtps: 1325.74137
+  dps: 943.07051
+  tps: 1694.65712
+  dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofThawing-24093"
  value: {
-  dps: 944.43088
-  tps: 1697.99021
-  dtps: 1325.74137
+  dps: 943.07051
+  tps: 1694.65712
+  dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofWithering-24095"
  value: {
-  dps: 944.43088
-  tps: 1697.99021
-  dtps: 1325.74137
+  dps: 943.07051
+  tps: 1694.65712
+  dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 944.43088
-  tps: 1697.99021
-  dtps: 1325.74137
+  dps: 943.07051
+  tps: 1694.65712
+  dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 900.76299
-  tps: 1610.87156
-  dtps: 1268.70693
+  dps: 900.56081
+  tps: 1611.57318
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalIntent"
  value: {
-  dps: 952.41664
-  tps: 1682.81589
-  dtps: 1441.85632
+  dps: 952.97975
+  tps: 1681.61962
+  dtps: 1458.1094
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalMooncloth"
  value: {
-  dps: 951.80959
-  tps: 1714.83157
-  dtps: 1602.78423
+  dps: 948.14279
+  tps: 1708.76213
+  dtps: 1606.88095
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Prismcharm-15867"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 912.98139
-  tps: 1635.29991
-  dtps: 1277.57729
+  dps: 908.45351
+  tps: 1628.36919
+  dtps: 1285.83994
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 899.07127
-  tps: 1610.53871
-  dtps: 1285.22281
+  dps: 897.68979
+  tps: 1608.68357
+  dtps: 1301.79137
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 896.41407
-  tps: 1604.73318
-  dtps: 1256.73954
+  dps: 896.47705
+  tps: 1605.23382
+  dtps: 1260.67102
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 934.08916
-  tps: 1677.69671
-  dtps: 1361.40613
+  dps: 932.71947
+  tps: 1675.79323
+  dtps: 1379.27527
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 939.27701
-  tps: 1685.60517
-  dtps: 1268.70693
+  dps: 939.76509
+  tps: 1687.68369
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 921.52459
-  tps: 1637.83721
-  dtps: 1278.65063
+  dps: 921.75536
+  tps: 1638.61916
+  dtps: 1290.34989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RuneofForce-25994"
  value: {
-  dps: 902.2424
-  tps: 1612.9433
-  dtps: 1268.70693
+  dps: 902.04373
+  tps: 1613.6794
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SavageGuard-2681"
  value: {
-  dps: 943.53556
-  tps: 1695.59047
-  dtps: 1311.88369
+  dps: 940.7619
+  tps: 1690.43873
+  dtps: 1312.25995
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 890.28227
-  tps: 1594.13727
-  dtps: 1220.45088
+  dps: 894.51767
+  tps: 1603.33083
+  dtps: 1241.83006
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 909.85855
-  tps: 1629.10798
-  dtps: 1268.70693
+  dps: 909.66373
+  tps: 1629.85579
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 906.39601
-  tps: 1620.31707
-  dtps: 1283.54279
+  dps: 902.21216
+  tps: 1614.20529
+  dtps: 1282.29274
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 919.05767
-  tps: 1647.43547
-  dtps: 1268.70693
+  dps: 917.76876
+  tps: 1646.29198
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 916.50074
-  tps: 1641.83796
-  dtps: 1268.70693
+  dps: 915.73574
+  tps: 1641.50351
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 904.65897
-  tps: 1625.31952
-  dtps: 1546.02904
+  dps: 903.83205
+  tps: 1625.32286
+  dtps: 1552.52139
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 893.08963
-  tps: 1597.7746
-  dtps: 1223.09561
+  dps: 892.32402
+  tps: 1596.82737
+  dtps: 1220.28564
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShardofContempt-34472"
  value: {
-  dps: 934.39639
-  tps: 1653.70716
-  dtps: 1266.68031
+  dps: 932.00193
+  tps: 1651.86464
+  dtps: 1286.42927
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 903.33908
-  tps: 1616.57013
-  dtps: 1268.70693
+  dps: 903.04084
+  tps: 1617.12304
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 920.85196
-  tps: 1650.37846
-  dtps: 1272.32788
+  dps: 917.51469
+  tps: 1645.04395
+  dtps: 1294.99466
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SkullflameShield-1168"
  value: {
-  dps: 948.43
-  tps: 1694.52502
-  dtps: 1461.70449
+  dps: 950.13383
+  tps: 1701.03057
+  dtps: 1473.80805
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 910.53353
-  tps: 1621.23443
-  dtps: 1268.70693
+  dps: 910.47061
+  tps: 1622.10628
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SoulclothEmbrace"
  value: {
-  dps: 889.09914
-  tps: 1596.10707
-  dtps: 1549.72801
+  dps: 887.65916
+  tps: 1594.61537
+  dtps: 1556.20338
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 953.56393
-  tps: 1722.34876
-  dtps: 1535.63936
+  dps: 954.06998
+  tps: 1723.49329
+  dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 900.58429
-  tps: 1611.28519
-  dtps: 1268.70693
+  dps: 900.3825
+  tps: 1612.01817
+  dtps: 1294.28455
   hps: 15.16667
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 941.11596
-  tps: 1689.09918
-  dtps: 1268.70693
+  dps: 941.09722
+  tps: 1690.21474
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 916.57786
-  tps: 1642.54146
-  dtps: 1268.70693
+  dps: 915.64103
+  tps: 1642.0546
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 905.69959
-  tps: 1621.08334
-  dtps: 1268.70693
+  dps: 905.6311
+  tps: 1622.07553
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 934.05033
-  tps: 1660.1343
-  dtps: 1267.42827
+  dps: 932.71218
+  tps: 1656.3908
+  dtps: 1261.67544
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 894.29719
-  tps: 1603.1922
-  dtps: 1450.15553
+  dps: 894.12517
+  tps: 1603.10711
+  dtps: 1460.21448
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 940.96137
-  tps: 1687.28953
-  dtps: 1268.70693
+  dps: 941.44647
+  tps: 1689.36508
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 939.27701
-  tps: 1685.60517
-  dtps: 1268.70693
+  dps: 939.76509
+  tps: 1687.68369
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 905.76697
-  tps: 1621.22887
-  dtps: 1268.70693
+  dps: 905.51175
+  tps: 1621.86203
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 912.73159
-  tps: 1634.57406
-  dtps: 1268.70693
+  dps: 912.76976
+  tps: 1635.77723
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 906.70142
-  tps: 1618.73709
-  dtps: 1274.80694
+  dps: 904.54592
+  tps: 1615.82947
+  dtps: 1288.19539
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 913.51813
-  tps: 1636.59925
-  dtps: 1268.70693
+  dps: 912.57432
+  tps: 1636.10889
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 903.07156
-  tps: 1606.39297
-  dtps: 1268.70693
+  dps: 902.89543
+  tps: 1607.34505
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 927.46668
-  tps: 1662.90165
-  dtps: 1268.70693
+  dps: 927.47135
+  tps: 1664.04609
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 928.93942
-  tps: 1667.64475
-  dtps: 1280.14818
+  dps: 928.41162
+  tps: 1667.14809
+  dtps: 1306.38861
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 867.27326
-  tps: 1431.56003
-  dtps: 1858.73743
+  dps: 863.74194
+  tps: 1426.81529
+  dtps: 1853.62548
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThickDraenicArmor"
  value: {
-  dps: 906.04749
-  tps: 1600.77554
-  dtps: 1534.81933
+  dps: 905.3915
+  tps: 1599.45033
+  dtps: 1541.01632
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 939.27701
-  tps: 1685.60517
-  dtps: 1268.70693
+  dps: 939.76509
+  tps: 1687.68369
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 913.544
-  tps: 1635.17331
-  dtps: 1268.70693
+  dps: 913.21636
+  tps: 1635.60845
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 909.80335
-  tps: 1621.05846
-  dtps: 1269.90971
+  dps: 912.77049
+  tps: 1626.89597
+  dtps: 1287.8636
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-UnitingCharm-25633"
  value: {
-  dps: 907.18301
-  tps: 1617.88391
-  dtps: 1268.70693
+  dps: 906.97889
+  tps: 1618.61456
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 909.15834
-  tps: 1627.71576
-  dtps: 1268.70693
+  dps: 909.21447
+  tps: 1628.94995
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofFortitude-33938"
  value: {
-  dps: 933.63005
-  tps: 1674.87595
-  dtps: 1268.70693
+  dps: 934.11085
+  tps: 1676.94065
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofVengeance-33950"
  value: {
-  dps: 933.63721
-  tps: 1674.88955
-  dtps: 1268.70693
+  dps: 934.11801
+  tps: 1676.95425
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 909.81318
-  tps: 1628.27953
-  dtps: 1268.70693
+  dps: 909.52176
+  tps: 1628.80874
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WastewalkerArmor"
  value: {
-  dps: 906.85999
-  tps: 1588.53778
-  dtps: 1658.0339
+  dps: 907.45704
+  tps: 1589.7666
+  dtps: 1680.99401
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WhitemendWisdom"
  value: {
-  dps: 931.85875
-  tps: 1677.71941
-  dtps: 1535.63936
+  dps: 931.95206
+  tps: 1678.36798
+  dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WindhawkArmor"
  value: {
-  dps: 969.31257
-  tps: 1749.95609
-  dtps: 1571.19319
+  dps: 965.22081
+  tps: 1743.926
+  dtps: 1568.72218
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 943.17488
-  tps: 1695.02045
-  dtps: 1311.587
+  dps: 941.226
+  tps: 1691.49153
+  dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofSpellfire"
  value: {
-  dps: 910.62847
-  tps: 1637.83491
-  dtps: 1580.43706
+  dps: 912.16525
+  tps: 1640.53808
+  dtps: 1578.32174
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 898.20445
-  tps: 1606.04179
-  dtps: 1275.71195
+  dps: 897.92938
+  tps: 1606.83676
+  dtps: 1305.00032
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 911.20486
-  tps: 1631.64185
-  dtps: 1268.70693
+  dps: 911.25098
+  tps: 1632.85871
+  dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 937.62989
-  tps: 1682.11384
-  dtps: 1256.15629
+  dps: 935.93137
+  tps: 1679.63843
+  dtps: 1257.99916
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 4716.60257
-  tps: 9399.00749
-  dtps: 23636.73867
+  dps: 2554.84492
+  tps: 4504.49145
+  dtps: 44358.6852
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 1009.96569
-  tps: 1782.87481
-  dtps: 1212.27481
+  dps: 1004.21677
+  tps: 1775.24805
+  dtps: 1253.73335
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1140.68805
-  tps: 1994.52234
+  dps: 1126.72443
+  tps: 1973.53922
   dtps: 1325.75557
  }
 }
@@ -1730,40 +1730,40 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 430.20448
-  tps: 896.91499
-  dtps: 2283.17124
+  dps: 434.3113
+  tps: 909.56477
+  dtps: 2281.36763
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 457.8672
-  tps: 951.89882
+  dps: 453.95986
+  tps: 945.69303
   dtps: 2347.11751
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 4738.09766
-  tps: 9423.14596
-  dtps: 23674.59356
+  dps: 2581.5004
+  tps: 4537.23235
+  dtps: 44367.41399
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 1027.8329
-  tps: 1810.32144
-  dtps: 1212.47599
+  dps: 1022.11977
+  tps: 1801.87864
+  dtps: 1253.94098
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1166.34181
-  tps: 2031.56949
+  dps: 1151.53457
+  tps: 2010.45216
   dtps: 1325.97528
  }
 }
@@ -1778,24 +1778,24 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 433.10702
-  tps: 901.58767
-  dtps: 2283.52605
+  dps: 436.40865
+  tps: 912.76743
+  dtps: 2281.72218
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 460.2091
-  tps: 955.54014
+  dps: 455.65422
+  tps: 948.2148
   dtps: 2347.48218
  }
 }
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1009.96569
-  tps: 1782.87481
-  dtps: 1212.27481
+  dps: 1004.21677
+  tps: 1775.24805
+  dtps: 1253.73335
  }
 }

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -173,7 +173,7 @@ func (paladin *Paladin) ApplyTalents() {
 	// TODO: Implement cooldown reduction
 
 	// Improved Concentration Aura (Tier 5) - Increases the effect of your Concentration Aura by an additional 5/10/15% and reduces the duration of all Silence and Interrupt effects used against the group by 10/20/30%
-	// TODO: Implement
+	// Implemented in auras.go
 
 	// Spell Warding (Tier 5) - All spell damage taken is reduced by 2/4%
 	if paladin.Talents.SpellWarding > 0 {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -55,1530 +55,1530 @@ character_stats_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 771.6286
-  tps: 1416.61023
-  dtps: 1301.91608
+  dps: 768.40855
+  tps: 1410.46471
+  dtps: 1298.10704
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 752.31131
-  tps: 1384.33025
-  dtps: 1253.54894
+  dps: 748.82206
+  tps: 1378.10366
+  dtps: 1235.63115
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 775.44334
-  tps: 1424.81153
-  dtps: 1290.81941
+  dps: 775.0039
+  tps: 1423.57408
+  dtps: 1294.99259
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 751.35895
-  tps: 1381.22692
-  dtps: 1211.51714
+  dps: 747.23618
+  tps: 1374.56318
+  dtps: 1206.63182
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 754.32723
-  tps: 1386.78987
-  dtps: 1296.43921
+  dps: 753.84721
+  tps: 1386.39982
+  dtps: 1297.44977
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Annihilator-12798"
  value: {
-  dps: 703.16391
-  tps: 1352.9617
-  dtps: 1370.1707
+  dps: 702.97799
+  tps: 1352.42224
+  dtps: 1367.07799
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 748.35153
-  tps: 1377.34523
-  dtps: 1297.61802
+  dps: 745.59608
+  tps: 1373.86165
+  dtps: 1295.93175
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 743.4216
-  tps: 1377.14031
-  dtps: 1515.84826
+  dps: 743.8939
+  tps: 1378.53862
+  dtps: 1513.91397
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 748.63988
-  tps: 1377.84566
-  dtps: 1293.34961
+  dps: 747.89258
+  tps: 1377.05734
+  dtps: 1294.31984
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 758.82178
-  tps: 1393.53863
-  dtps: 1254.0979
+  dps: 753.83267
+  tps: 1385.30065
+  dtps: 1252.71231
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 757.44154
-  tps: 1392.09288
-  dtps: 1304.02045
+  dps: 755.50659
+  tps: 1388.99048
+  dtps: 1306.13688
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 788.3869
-  tps: 1443.72802
-  dtps: 1287.17621
+  dps: 790.67179
+  tps: 1446.88326
+  dtps: 1291.23322
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 776.44308
-  tps: 1426.14229
-  dtps: 1314.56124
+  dps: 777.92492
+  tps: 1428.39186
+  dtps: 1318.83297
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 776.44308
-  tps: 1426.14229
-  dtps: 1314.56124
+  dps: 777.92492
+  tps: 1428.39186
+  dtps: 1318.83297
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BattlecastGarb"
  value: {
-  dps: 769.92843
-  tps: 1418.84896
-  dtps: 1465.03094
+  dps: 769.82522
+  tps: 1419.11318
+  dtps: 1460.96185
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 751.57108
-  tps: 1382.35276
-  dtps: 1290.70356
+  dps: 748.29209
+  tps: 1377.1147
+  dtps: 1292.98368
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 751.57108
-  tps: 1382.35276
-  dtps: 1290.70356
+  dps: 748.29209
+  tps: 1377.1147
+  dtps: 1292.98368
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 758.97582
-  tps: 1393.80575
-  dtps: 1298.85054
+  dps: 758.95337
+  tps: 1393.78206
+  dtps: 1299.19563
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 757.66591
-  tps: 1391.92402
-  dtps: 1295.36079
+  dps: 756.17413
+  tps: 1390.18337
+  dtps: 1296.28425
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 769.15412
-  tps: 1408.80551
-  dtps: 1302.42139
+  dps: 768.52004
+  tps: 1408.80033
+  dtps: 1303.99176
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 775.44334
-  tps: 1424.81153
-  dtps: 1290.81941
+  dps: 775.0039
+  tps: 1423.57408
+  dtps: 1294.99259
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 775.22862
-  tps: 1421.72412
-  dtps: 1293.84646
+  dps: 776.51074
+  tps: 1424.48537
+  dtps: 1299.31125
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 759.69216
-  tps: 1395.16198
-  dtps: 1293.47869
+  dps: 759.70552
+  tps: 1395.18993
+  dtps: 1297.02042
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 685.10658
-  tps: 1315.20951
-  dtps: 1352.96155
+  dps: 684.12388
+  tps: 1314.27885
+  dtps: 1357.00322
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Blinkstrike-31332"
  value: {
-  dps: 775.44334
-  tps: 1424.81153
-  dtps: 1290.81941
+  dps: 775.0039
+  tps: 1423.57408
+  dtps: 1294.99259
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 765.06457
-  tps: 1402.3135
-  dtps: 1299.14808
+  dps: 764.04603
+  tps: 1401.32987
+  dtps: 1302.84167
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BoldArmor"
  value: {
-  dps: 780.69859
-  tps: 1405.87884
-  dtps: 1390.27771
+  dps: 781.12355
+  tps: 1406.74318
+  dtps: 1386.93054
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 787.93783
-  tps: 1448.06768
-  dtps: 1313.92826
+  dps: 789.63308
+  tps: 1450.08909
+  dtps: 1313.68517
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 750.81186
-  tps: 1382.50868
-  dtps: 1271.8148
+  dps: 750.78534
+  tps: 1381.10314
+  dtps: 1254.81873
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 777.41035
-  tps: 1427.27339
-  dtps: 1201.40916
+  dps: 777.35078
+  tps: 1427.3016
+  dtps: 1206.57013
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 804.20403
-  tps: 1474.0779
-  dtps: 1307.22087
+  dps: 803.54166
+  tps: 1471.64751
+  dtps: 1302.79261
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 806.94733
-  tps: 1478.1224
-  dtps: 1281.17473
+  dps: 803.27637
+  tps: 1471.32104
+  dtps: 1280.31258
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningRage"
  value: {
-  dps: 835.39805
-  tps: 1496.81652
-  dtps: 1512.7658
+  dps: 838.30491
+  tps: 1501.60352
+  dtps: 1516.27641
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 778.31708
-  tps: 1429.50247
-  dtps: 1309.48434
+  dps: 776.11843
+  tps: 1426.19698
+  dtps: 1311.31098
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 768.23023
-  tps: 1414.29808
-  dtps: 1365.72855
+  dps: 769.7674
+  tps: 1416.4787
+  dtps: 1371.14364
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CloudkeeperLegplates-14554"
  value: {
-  dps: 782.13191
-  tps: 1435.75238
-  dtps: 1324.77342
+  dps: 787.64498
+  tps: 1444.11696
+  dtps: 1332.73538
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 748.63988
-  tps: 1377.84566
-  dtps: 1293.34961
+  dps: 747.89258
+  tps: 1377.05734
+  dtps: 1294.31984
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 762.44884
-  tps: 1398.52883
-  dtps: 1278.43639
+  dps: 763.61168
+  tps: 1401.33751
+  dtps: 1280.90298
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 754.09061
-  tps: 1386.15793
-  dtps: 1294.45672
+  dps: 752.50045
+  tps: 1384.18096
+  dtps: 1295.38017
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 767.4263
-  tps: 1413.39915
-  dtps: 1366.02065
+  dps: 772.01517
+  tps: 1420.28903
+  dtps: 1373.17412
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 754.36092
-  tps: 1386.57121
-  dtps: 1294.45672
+  dps: 752.78017
+  tps: 1384.48393
+  dtps: 1295.38017
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 748.84056
-  tps: 1379.54226
-  dtps: 1265.84821
+  dps: 750.06125
+  tps: 1379.95831
+  dtps: 1246.71832
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 762.19533
-  tps: 1398.48772
-  dtps: 1295.61785
+  dps: 759.24904
+  tps: 1394.08338
+  dtps: 1297.60682
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 747.79103
-  tps: 1376.72181
-  dtps: 1295.81518
+  dps: 745.86203
+  tps: 1374.00042
+  dtps: 1296.85161
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 756.44027
-  tps: 1390.66127
-  dtps: 1299.13744
+  dps: 756.56194
+  tps: 1390.55292
+  dtps: 1296.69896
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerArmor"
  value: {
-  dps: 821.40449
-  tps: 1468.9594
-  dtps: 1096.2165
+  dps: 820.66857
+  tps: 1467.21016
+  dtps: 1097.44965
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerBattlegear"
  value: {
-  dps: 893.28638
-  tps: 1589.78106
-  dtps: 1451.59885
+  dps: 887.24845
+  tps: 1579.99316
+  dtps: 1454.81003
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DirebrewHops-38288"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DonSantos'FamousHuntingRifle-31323"
  value: {
-  dps: 769.47633
-  tps: 1414.62419
-  dtps: 1292.61195
+  dps: 772.00329
+  tps: 1418.33744
+  dtps: 1296.87533
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DoomplateBattlegear"
  value: {
-  dps: 845.80752
-  tps: 1518.13954
-  dtps: 1557.58438
+  dps: 847.0899
+  tps: 1520.75524
+  dtps: 1565.64721
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 777.12583
-  tps: 1426.12461
-  dtps: 1304.56409
+  dps: 775.59127
+  tps: 1424.2875
+  dtps: 1303.19776
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonstrike-28439"
  value: {
-  dps: 774.94669
-  tps: 1424.8959
-  dtps: 1349.72252
+  dps: 773.49501
+  tps: 1421.87183
+  dtps: 1349.3963
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 751.05086
-  tps: 1387.60072
-  dtps: 1336.02502
+  dps: 753.46593
+  tps: 1391.66234
+  dtps: 1331.03958
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Earthstrike-21180"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 748.63988
-  tps: 1377.84566
-  dtps: 1293.34961
+  dps: 747.89258
+  tps: 1377.05734
+  dtps: 1294.31984
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 765.06457
-  tps: 1402.3135
-  dtps: 1299.14808
+  dps: 764.04603
+  tps: 1401.32987
+  dtps: 1302.84167
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 776.30293
-  tps: 1425.25455
-  dtps: 1278.51687
+  dps: 775.85682
+  tps: 1424.24488
+  dtps: 1284.51849
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 775.48506
-  tps: 1396.502
-  dtps: 1296.95746
+  dps: 776.27925
+  tps: 1397.65056
+  dtps: 1302.90071
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 772.5209
-  tps: 1421.82855
-  dtps: 1330.65265
+  dps: 773.70138
+  tps: 1422.95452
+  dtps: 1340.10635
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 766.0738
-  tps: 1408.24365
-  dtps: 1285.7042
+  dps: 765.10695
+  tps: 1406.28572
+  dtps: 1281.68238
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 782.10419
-  tps: 1436.42291
-  dtps: 1329.24683
+  dps: 783.54872
+  tps: 1438.60058
+  dtps: 1339.60693
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofMoam-21473"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 776.36877
-  tps: 1426.75331
-  dtps: 1322.68384
+  dps: 775.16913
+  tps: 1424.99576
+  dtps: 1322.95558
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FelSkin"
  value: {
-  dps: 825.67556
-  tps: 1486.47111
-  dtps: 1549.03449
+  dps: 823.70634
+  tps: 1482.9588
+  dtps: 1544.14551
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FelscaleArmor"
  value: {
-  dps: 786.08523
-  tps: 1414.82816
-  dtps: 1513.90883
+  dps: 785.48432
+  tps: 1414.15319
+  dtps: 1519.44202
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 753.26983
-  tps: 1386.30661
-  dtps: 1266.38726
+  dps: 751.2937
+  tps: 1381.93215
+  dtps: 1244.91688
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 751.73546
-  tps: 1383.38306
-  dtps: 1249.42944
+  dps: 748.86093
+  tps: 1377.96058
+  dtps: 1233.82383
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 756.98424
-  tps: 1389.51542
-  dtps: 1290.16634
+  dps: 756.29774
+  tps: 1389.29567
+  dtps: 1293.81279
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 749.63499
-  tps: 1379.51847
-  dtps: 1293.95394
+  dps: 749.25155
+  tps: 1378.81254
+  dtps: 1293.34897
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForceReactiveDisk-18168"
  value: {
-  dps: 766.51206
-  tps: 1411.42473
-  dtps: 1421.77487
+  dps: 765.52711
+  tps: 1409.63101
+  dtps: 1420.59072
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 929.5992
-  tps: 1644.0459
-  dtps: 1370.54017
+  dps: 925.07168
+  tps: 1636.00779
+  dtps: 1377.26884
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 762.17968
-  tps: 1397.51012
-  dtps: 1277.833
+  dps: 761.55689
+  tps: 1397.73122
+  dtps: 1277.69391
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 762.10509
-  tps: 1398.3856
-  dtps: 1279.65319
+  dps: 761.26892
+  tps: 1397.50141
+  dtps: 1278.93434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HandofJustice-11815"
  value: {
-  dps: 750.11088
-  tps: 1380.09122
-  dtps: 1294.45672
+  dps: 748.52554
+  tps: 1377.99685
+  dtps: 1295.38017
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 760.99848
-  tps: 1396.65961
-  dtps: 1300.10168
+  dps: 761.46645
+  tps: 1397.24845
+  dtps: 1299.68194
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IceGuard-2682"
  value: {
-  dps: 776.0067
-  tps: 1425.15008
-  dtps: 1297.45696
+  dps: 777.17988
+  tps: 1426.95233
+  dtps: 1299.54573
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImbuedNetherweave"
  value: {
-  dps: 750.35798
-  tps: 1389.94003
-  dtps: 1594.43162
+  dps: 750.41157
+  tps: 1389.62519
+  dtps: 1590.79571
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JomGabbar-23570"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KhoriumScope-2723"
  value: {
-  dps: 775.44334
-  tps: 1424.81153
-  dtps: 1290.81941
+  dps: 775.0039
+  tps: 1423.57408
+  dtps: 1294.99259
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KhoriumWard"
  value: {
-  dps: 749.26732
-  tps: 1386.05038
-  dtps: 1385.4572
+  dps: 744.12856
+  tps: 1377.81711
+  dtps: 1381.6884
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 775.92383
-  tps: 1424.43897
-  dtps: 1288.13815
+  dps: 768.08269
+  tps: 1411.36624
+  dtps: 1299.57064
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 746.77191
-  tps: 1374.57808
-  dtps: 1296.63139
+  dps: 746.33983
+  tps: 1374.29488
+  dtps: 1297.59873
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 776.20881
-  tps: 1425.59757
-  dtps: 1287.87846
+  dps: 776.92151
+  tps: 1426.06317
+  dtps: 1294.01337
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 739.77135
-  tps: 1350.13305
-  dtps: 1891.09807
+  dps: 738.36893
+  tps: 1347.75343
+  dtps: 1890.52659
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 761.66867
-  tps: 1403.46377
-  dtps: 1390.77007
+  dps: 761.44557
+  tps: 1403.34702
+  dtps: 1390.69227
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 742.55147
-  tps: 1364.52689
-  dtps: 1168.94991
+  dps: 742.64162
+  tps: 1365.06627
+  dtps: 1175.96072
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherscaleArmor"
  value: {
-  dps: 794.66426
-  tps: 1458.66397
-  dtps: 1392.37399
+  dps: 795.1329
+  tps: 1458.9392
+  dtps: 1390.6346
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherstrikeArmor"
  value: {
-  dps: 740.59226
-  tps: 1371.97162
-  dtps: 1393.92236
+  dps: 739.31093
+  tps: 1369.9248
+  dtps: 1394.97928
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherweaveVestments"
  value: {
-  dps: 712.49421
-  tps: 1306.8534
-  dtps: 1825.04332
+  dps: 713.37217
+  tps: 1309.02321
+  dtps: 1817.27682
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Oathbound'sSavagePlateBattlegear"
  value: {
-  dps: 796.49232
-  tps: 1435.81179
-  dtps: 1563.48442
+  dps: 796.45837
+  tps: 1434.77293
+  dtps: 1564.20322
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 753.59314
-  tps: 1385.39956
-  dtps: 1294.45672
+  dps: 752.00492
+  tps: 1383.42552
+  dtps: 1295.38017
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 788.21926
-  tps: 1410.5255
-  dtps: 798.0837
+  dps: 790.23049
+  tps: 1413.26235
+  dtps: 801.455
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 1000.72845
-  tps: 1755.83461
-  dtps: 1213.14978
+  dps: 997.73389
+  tps: 1750.81334
+  dtps: 1211.92624
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 775.58786
-  tps: 1425.5374
-  dtps: 1322.69087
+  dps: 773.55122
+  tps: 1422.38429
+  dtps: 1320.39922
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 777.80995
-  tps: 1428.93031
-  dtps: 1321.86067
+  dps: 775.6051
+  tps: 1425.52071
+  dtps: 1319.56902
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantofThawing-24093"
  value: {
-  dps: 777.80995
-  tps: 1428.93031
-  dtps: 1321.86067
+  dps: 775.6051
+  tps: 1425.52071
+  dtps: 1319.56902
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantofWithering-24095"
  value: {
-  dps: 777.80995
-  tps: 1428.93031
-  dtps: 1321.86067
+  dps: 775.6051
+  tps: 1425.52071
+  dtps: 1319.56902
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 777.80995
-  tps: 1428.93031
-  dtps: 1321.86067
+  dps: 775.6051
+  tps: 1425.52071
+  dtps: 1319.56902
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PrimalIntent"
  value: {
-  dps: 791.91694
-  tps: 1450.73521
-  dtps: 1331.68823
+  dps: 789.79029
+  tps: 1447.46231
+  dtps: 1334.81233
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PrimalMooncloth"
  value: {
-  dps: 735.14467
-  tps: 1366.64856
-  dtps: 1563.38731
+  dps: 734.78118
+  tps: 1365.98169
+  dtps: 1567.41919
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Prismcharm-15867"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 751.83495
-  tps: 1383.96701
-  dtps: 1280.52081
+  dps: 750.96006
+  tps: 1381.34764
+  dtps: 1259.04619
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 763.30544
-  tps: 1406.63997
-  dtps: 1393.57426
+  dps: 763.08233
+  tps: 1406.52322
+  dtps: 1393.49647
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 775.44334
-  tps: 1424.81153
-  dtps: 1290.81941
+  dps: 775.0039
+  tps: 1423.57408
+  dtps: 1294.99259
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 774.12165
-  tps: 1422.82433
-  dtps: 1284.19854
+  dps: 774.04837
+  tps: 1422.55274
+  dtps: 1292.68035
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofForce-25994"
  value: {
-  dps: 748.63988
-  tps: 1377.84566
-  dtps: 1293.34961
+  dps: 747.89258
+  tps: 1377.05734
+  dtps: 1294.31984
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SavageGuard-2681"
  value: {
-  dps: 776.0067
-  tps: 1425.15008
-  dtps: 1297.45696
+  dps: 777.17988
+  tps: 1426.95233
+  dtps: 1299.54573
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 747.08148
-  tps: 1375.97249
-  dtps: 1237.61271
+  dps: 743.05475
+  tps: 1369.23862
+  dtps: 1235.55968
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 748.39151
-  tps: 1377.40618
-  dtps: 1297.61802
+  dps: 745.63605
+  tps: 1373.9226
+  dtps: 1295.93175
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 741.22863
-  tps: 1376.93909
-  dtps: 1624.72735
+  dps: 740.11138
+  tps: 1375.07045
+  dtps: 1623.68869
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 744.88492
-  tps: 1369.59564
-  dtps: 1222.28409
+  dps: 746.62697
+  tps: 1373.74526
+  dtps: 1211.26928
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShardofContempt-34472"
  value: {
-  dps: 815.60772
-  tps: 1493.25719
-  dtps: 1257.62467
+  dps: 815.10549
+  tps: 1491.89578
+  dtps: 1257.87601
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 751.81779
-  tps: 1382.85628
-  dtps: 1291.89372
+  dps: 749.17568
+  tps: 1378.6727
+  dtps: 1295.73145
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SkullflameShield-1168"
  value: {
-  dps: 768.43069
-  tps: 1415.43503
-  dtps: 1437.5692
+  dps: 767.64519
+  tps: 1413.7339
+  dtps: 1445.49972
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 764.16039
-  tps: 1400.63477
-  dtps: 1294.48885
+  dps: 763.15967
+  tps: 1399.67825
+  dtps: 1298.18244
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Solarian'sSapphire-30446"
  value: {
-  dps: 748.63988
-  tps: 1377.84566
-  dtps: 1293.34961
+  dps: 747.89258
+  tps: 1377.05734
+  dtps: 1294.31984
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulclothEmbrace"
  value: {
-  dps: 741.87127
-  tps: 1350.48605
-  dtps: 1622.00189
+  dps: 741.78712
+  tps: 1350.55736
+  dtps: 1624.88836
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 769.95222
-  tps: 1418.23856
-  dtps: 1477.75128
+  dps: 770.12698
+  tps: 1418.36319
+  dtps: 1480.84187
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 749.42152
-  tps: 1378.65997
-  dtps: 1290.74653
+  dps: 747.37827
+  tps: 1376.19225
+  dtps: 1294.82938
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 775.44334
-  tps: 1424.81153
-  dtps: 1290.81941
+  dps: 775.0039
+  tps: 1423.57408
+  dtps: 1294.99259
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 748.35153
-  tps: 1377.34523
-  dtps: 1297.61802
+  dps: 745.59608
+  tps: 1373.86165
+  dtps: 1295.93175
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 748.63988
-  tps: 1377.84566
-  dtps: 1293.34961
+  dps: 747.89258
+  tps: 1377.05734
+  dtps: 1294.31984
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 809.61115
-  tps: 1484.2123
-  dtps: 1268.14613
+  dps: 809.63254
+  tps: 1483.72246
+  dtps: 1268.19864
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 747.70496
-  tps: 1383.82578
-  dtps: 1457.78406
+  dps: 745.02255
+  tps: 1379.26497
+  dtps: 1459.1102
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 777.95631
-  tps: 1428.73996
-  dtps: 1290.94026
+  dps: 777.52478
+  tps: 1427.5147
+  dtps: 1295.11345
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 775.44334
-  tps: 1424.81153
-  dtps: 1290.81941
+  dps: 775.0039
+  tps: 1423.57408
+  dtps: 1294.99259
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 765.79716
-  tps: 1408.75347
-  dtps: 1288.41087
+  dps: 766.18867
+  tps: 1408.83069
+  dtps: 1287.69727
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 748.32551
-  tps: 1377.30555
-  dtps: 1297.61802
+  dps: 745.57006
+  tps: 1373.82197
+  dtps: 1295.93175
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheBladefist-29348"
  value: {
-  dps: 744.47189
-  tps: 1378.99594
-  dtps: 1326.14977
+  dps: 741.97261
+  tps: 1375.02231
+  dtps: 1328.37212
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 748.35153
-  tps: 1377.34523
-  dtps: 1297.61802
+  dps: 745.59608
+  tps: 1373.86165
+  dtps: 1295.93175
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 976.28654
-  tps: 1712.23474
-  dtps: 2055.298
+  dps: 975.96914
+  tps: 1711.25729
+  dtps: 2051.28718
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThickDraenicArmor"
  value: {
-  dps: 785.34279
-  tps: 1418.77636
-  dtps: 1587.48812
+  dps: 784.16861
+  tps: 1416.18522
+  dtps: 1595.6988
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 775.44334
-  tps: 1424.81153
-  dtps: 1290.81941
+  dps: 775.0039
+  tps: 1423.57408
+  dtps: 1294.99259
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 772.9814
-  tps: 1417.61883
-  dtps: 1285.52283
+  dps: 775.78754
+  tps: 1421.57036
+  dtps: 1300.64002
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnitingCharm-25633"
  value: {
-  dps: 753.59314
-  tps: 1385.39956
-  dtps: 1294.45672
+  dps: 752.00492
+  tps: 1383.42552
+  dtps: 1295.38017
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerArmor"
  value: {
-  dps: 777.54322
-  tps: 1394.66125
-  dtps: 1130.7229
+  dps: 776.20016
+  tps: 1392.41442
+  dtps: 1131.34258
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerBattlegear"
  value: {
-  dps: 866.30964
-  tps: 1547.99419
-  dtps: 1421.55218
+  dps: 864.25924
+  tps: 1544.05903
+  dtps: 1422.36069
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WastewalkerArmor"
  value: {
-  dps: 831.15662
-  tps: 1496.14478
-  dtps: 1653.93888
+  dps: 826.53527
+  tps: 1487.64204
+  dtps: 1647.42361
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WhitemendWisdom"
  value: {
-  dps: 767.27289
-  tps: 1414.35378
-  dtps: 1468.67446
+  dps: 766.89425
+  tps: 1414.0594
+  dtps: 1466.78907
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WindhawkArmor"
  value: {
-  dps: 741.62062
-  tps: 1374.80779
-  dtps: 1448.40066
+  dps: 741.52872
+  tps: 1374.44158
+  dtps: 1447.28016
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 776.76898
-  tps: 1426.78271
-  dtps: 1313.42764
+  dps: 778.25083
+  tps: 1429.03228
+  dtps: 1317.69937
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofSpellfire"
  value: {
-  dps: 734.30497
-  tps: 1337.14164
-  dtps: 1537.36125
+  dps: 734.23128
+  tps: 1337.54886
+  dtps: 1535.40411
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 747.82586
-  tps: 1376.62613
-  dtps: 1294.48932
+  dps: 747.07856
+  tps: 1375.83781
+  dtps: 1295.45955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 782.26678
-  tps: 1432.04148
-  dtps: 1263.90586
+  dps: 781.74863
+  tps: 1431.04865
+  dtps: 1263.78627
  }
 }
 dps_results: {
@@ -1592,9 +1592,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Protection-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 950.03912
-  tps: 1713.49194
-  dtps: 1123.94811
+  dps: 953.75988
+  tps: 1719.56607
+  dtps: 1124.06253
  }
 }
 dps_results: {
@@ -1640,9 +1640,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Protection-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 876.42945
-  tps: 1593.95957
-  dtps: 1186.31617
+  dps: 874.39242
+  tps: 1590.6534
+  dtps: 1187.92456
  }
 }
 dps_results: {
@@ -1688,9 +1688,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Protection-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 942.25205
-  tps: 1699.93489
-  dtps: 1124.69407
+  dps: 941.53589
+  tps: 1698.93239
+  dtps: 1126.99489
  }
 }
 dps_results: {
@@ -1736,9 +1736,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Protection-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 860.83812
-  tps: 1566.85066
-  dtps: 1193.95673
+  dps: 859.27077
+  tps: 1564.71987
+  dtps: 1196.33305
  }
 }
 dps_results: {
@@ -1776,8 +1776,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 860.83812
-  tps: 1566.85066
-  dtps: 1193.95673
+  dps: 859.27077
+  tps: 1564.71987
+  dtps: 1196.33305
  }
 }

--- a/ui/core/components/inputs/buffs_debuffs.ts
+++ b/ui/core/components/inputs/buffs_debuffs.ts
@@ -160,6 +160,12 @@ export const RetributionAura = makeTristatePartyBuffInput({
 	fieldName: 'retributionAura',
 	label: 'Retribution Aura',
 });
+export const ConcentrationAura = makeTristatePartyBuffInput({
+	actionId: () => ActionId.fromSpellId(19746),
+	impId: ActionId.fromSpellId(20256),
+	fieldName: 'concentrationAura',
+	label: 'Concentration Aura',
+});
 export const SanctityAura = makeTristatePartyBuffInput({
 	actionId: () => ActionId.fromSpellId(20218),
 	impId: ActionId.fromSpellId(31870),
@@ -327,6 +333,11 @@ export const PARTY_BUFFS_CONFIG = [
 		config: RetributionAura,
 		picker: IconPicker,
 		stats: [Stat.StatResilienceRating, Stat.StatArmor, Stat.StatDefenseRating],
+	},
+	{
+		config: ConcentrationAura,
+		picker: IconPicker,
+		stats: [Stat.StatDefenseRating],
 	},
 	{
 		config: SanctityAura,

--- a/ui/core/components/raid_sim_action.tsx
+++ b/ui/core/components/raid_sim_action.tsx
@@ -466,7 +466,8 @@ export class RaidSimResultsManager {
 
 		if (players.length === 1) {
 			const playerMetrics = players[0];
-			const isTank = [Spec.SpecFeralBearDruid, Spec.SpecProtectionPaladin].includes(players[0].spec?.specID);
+			const spec = players[0].spec?.specID
+			const isTank = [Spec.SpecFeralBearDruid, Spec.SpecProtectionPaladin].includes(spec);
 			if (playerMetrics.getTargetIndex(filter) === null) {
 				const { chanceOfDeath, dps: dpsMetrics, tps: tpsMetrics, dtps: dtpsMetrics, tmi: tmiMetrics } = playerMetrics;
 
@@ -497,13 +498,15 @@ export class RaidSimResultsManager {
 					unit: 'percentage',
 				});
 
-				resultColumns.push({
-					name: i18n.t('sidebar.results.metrics.cod.label'),
-					average: chanceOfDeath.avg,
-					stdev: chanceOfDeath.stdev,
-					classes: this.getResultsLineClasses('cod'),
-					unit: 'percentage',
-				});
+				if (spec !== Spec.SpecProtectionPaladin) {
+					resultColumns.push({
+						name: i18n.t('sidebar.results.metrics.cod.label'),
+						average: chanceOfDeath.avg,
+						stdev: chanceOfDeath.stdev,
+						classes: this.getResultsLineClasses('cod'),
+						unit: 'percentage',
+					});
+				}
 			} else {
 				const actions = simResult.getRaidIndexedActionMetrics(filter);
 				if (!!actions.length) {

--- a/ui/core/proto_utils/logs_parser.tsx
+++ b/ui/core/proto_utils/logs_parser.tsx
@@ -257,6 +257,7 @@ export class SimLog {
 					StatChangeLog.parse(params) ||
 					SpellQueuedLog.parse(params) ||
 					CastFailedLog.parse(params) ||
+					CastPushbackLog.parse(params) ||
 					Promise.resolve(new SimLog(params))
 				);
 			}),
@@ -1443,6 +1444,55 @@ export class CastFailedLog extends SimLog {
 					return new CastFailedLog(params, reason.replace(/[.!?]$/, ''));
 				},
 			);
+		} else {
+			return null;
+		}
+	}
+}
+
+// Records pushback events emitted when the player takes damage while
+// hardcasting or channeling, delaying the cast or shortening the channel.
+export class CastPushbackLog extends SimLog {
+	readonly pushback: number; // seconds
+	readonly pushbackText: string; // pre-formatted for display
+	readonly isChanneling: boolean;
+
+	constructor(params: SimLogParams, pushback: number, pushbackText: string, isChanneling: boolean) {
+		super(params);
+		this.pushback = pushback;
+		this.pushbackText = pushbackText;
+		this.isChanneling = isChanneling;
+	}
+
+	toHTML(includeTimestamp = true) {
+		return this.cacheOutput(includeTimestamp, () =>
+			this.isChanneling ? (
+				<>
+					{this.toPrefix(includeTimestamp)} {this.newActionIdLink()} lost {this.pushbackText} while channeling due to pushback.
+				</>
+			) : (
+				<>
+					{this.toPrefix(includeTimestamp)} {this.newActionIdLink()} pushed back {this.pushbackText} while casting.
+				</>
+			),
+		);
+	}
+
+	static parse(params: SimLogParams): Promise<CastPushbackLog> | null {
+		const match = params.raw.match(/] (.*?) pushed back (\d+\.?\d*)(m?s) while ((casting)|(channeling))/);
+		if (match) {
+			let pushback = parseFloat(match[2]);
+			if (match[3] == 'ms') {
+				pushback /= 1000;
+			}
+			const pushbackText = pushback >= 1 ? `${pushback.toFixed(2)}s` : `${Math.round(pushback * 1000)}ms`;
+
+			return ActionId.fromLogString(match[1])
+				.fill(params.source?.index)
+				.then(actionId => {
+					params.actionId = actionId;
+					return new CastPushbackLog(params, pushback, pushbackText, match[4] == 'channeling');
+				});
 		} else {
 			return null;
 		}

--- a/ui/core/proto_utils/logs_parser.tsx
+++ b/ui/core/proto_utils/logs_parser.tsx
@@ -255,6 +255,8 @@ export class SimLog {
 					CastCompletedLog.parse(params) ||
 					AutoDelayLog.parse(params) ||
 					StatChangeLog.parse(params) ||
+					SpellQueuedLog.parse(params) ||
+					CastFailedLog.parse(params) ||
 					Promise.resolve(new SimLog(params))
 				);
 			}),
@@ -1344,6 +1346,103 @@ export class StatChangeLog extends SimLog {
 					const sign = match[1] == 'Lost' ? -1 : 1;
 					return new StatChangeLog(params, sign == 1, match[4]);
 				});
+		} else {
+			return null;
+		}
+	}
+}
+
+// Records when a spell is queued to fire at a future time, typically right
+// before a hardcast or auto-attack completes.
+export class SpellQueuedLog extends SimLog {
+	readonly fireAt: number; // seconds
+	readonly fireAtText: string; // pre-formatted for display
+
+	constructor(params: SimLogParams, fireAt: number, fireAtText: string) {
+		super(params);
+		this.fireAt = fireAt;
+		this.fireAtText = fireAtText;
+	}
+
+	toHTML(includeTimestamp = true) {
+		return this.cacheOutput(includeTimestamp, () => (
+			<>
+				{this.toPrefix(includeTimestamp)} Queueing {this.newActionIdLink()} to cast at {this.fireAtText}.
+			</>
+		));
+	}
+
+	static parse(params: SimLogParams): Promise<SpellQueuedLog> | null {
+		const match = params.raw.match(/Queueing up (.*?) to cast at (\d*?m?)(\d+\.?\d*)(m?s)\./);
+		if (match) {
+			const minutePart = match[2];
+			const seconds = parseFloat(match[3]);
+			let fireAt = seconds;
+			if (minutePart && minutePart.endsWith('m')) {
+				fireAt = parseFloat(minutePart.slice(0, -1)) * 60 + seconds;
+			} else if (match[4] == 'ms') {
+				fireAt = seconds / 1000;
+			}
+			const fireAtText = fireAt >= 1 ? `${minutePart}${seconds.toFixed(2)}s` : `${Math.round(fireAt * 1000)}ms`;
+
+			return ActionId.fromLogString(match[1])
+				.fill(params.source?.index)
+				.then(actionId => {
+					params.actionId = actionId;
+					return new SpellQueuedLog(params, fireAt, fireAtText);
+				});
+		} else {
+			return null;
+		}
+	}
+}
+
+// Go's time.Duration.String() can emit nanosecond-precision strings like
+// "29.999999999s" or "33.217000001s". Round these to something readable
+// without disturbing already-clean values like "30s" or "1.5s".
+const reformatGoDurations = (text: string): string =>
+	text.replace(/(\d+m)?(\d+\.\d{3,})(m?s)/g, (_match, minute: string | undefined, value: string, unit: string) => {
+		const seconds = parseFloat(value);
+		if (unit === 'ms') {
+			return `${minute ?? ''}${Math.round(seconds)}ms`;
+		}
+		return `${minute ?? ''}${seconds.toFixed(2)}s`;
+	});
+
+// The sim's cast-failure reasons all append ", curTime = <duration>", which
+// is redundant with the log line's own timestamp prefix.
+const stripCurTime = (text: string): string => text.replace(/, curTime = [\dms.h]+$/, '');
+
+// Records when a cast attempt was rejected (cooldown, GCD, already casting,
+// resource cost, etc.). The reason text comes from the sim log, with the
+// redundant ", curTime = ..." stripped, durations rounded, and embedded
+// action IDs resolved to names.
+export class CastFailedLog extends SimLog {
+	readonly reason: string;
+
+	constructor(params: SimLogParams, reason: string) {
+		super(params);
+		this.reason = reason;
+	}
+
+	toHTML(includeTimestamp = true) {
+		return this.cacheOutput(includeTimestamp, () => (
+			<>
+				{this.toPrefix(includeTimestamp)} Failed to cast {this.newActionIdLink()}: {this.reason}.
+			</>
+		));
+	}
+
+	static parse(params: SimLogParams): Promise<CastFailedLog> | null {
+		const match = params.raw.match(/] (.*?) failed to cast: (.*)/);
+		if (match) {
+			const cleaned = reformatGoDurations(stripCurTime(match[2]));
+			return Promise.all([ActionId.fromLogString(match[1]).fill(params.source?.index), ActionId.replaceAllInString(cleaned)]).then(
+				([actionId, reason]) => {
+					params.actionId = actionId;
+					return new CastFailedLog(params, reason.replace(/[.!?]$/, ''));
+				},
+			);
 		} else {
 			return null;
 		}

--- a/ui/paladin/retribution/presets.ts
+++ b/ui/paladin/retribution/presets.ts
@@ -111,7 +111,7 @@ export const DefaultPartyBuffs = PartyBuffs.create({
 	windfuryTotem: TristateEffect.TristateEffectImproved,
 	graceOfAirTotem: TristateEffect.TristateEffectImproved,
 	drums: Drums.LesserDrumsOfBattle,
-	sanctityAura: TristateEffect.TristateEffectImproved,
+	sanctityAura: TristateEffect.TristateEffectMissing,
 });
 
 export const DefaultIndividualBuffs = IndividualBuffs.create({


### PR DESCRIPTION
Pushes back casted spells by 0.5s per incoming direct hit (that actually does damage, fully absorbed hits don't cause pushback) as well as reducing channeled casts by 25% of their total cast time.
Added pushback prevention (Concentration Aura) as well.
Also fixed some log parsing etc.