### PR TITLE
[Pala] Fix some issues with Consecration

### DIFF
--- a/sim/core/spell_outcome.go
+++ b/sim/core/spell_outcome.go
@@ -39,6 +39,21 @@ func (dot *Dot) OutcomeTick(sim *Simulation, result *SpellResult, _ *AttackTable
 	}
 }
 
+func (dot *Dot) OutcomeTickMagicHit(sim *Simulation, result *SpellResult, attackTable *AttackTable) {
+	if dot.Spell.MagicHitCheck(sim, attackTable) {
+		isPartialResist := result.DidResist()
+		result.Outcome = OutcomeHit
+		dot.Spell.SpellMetrics[result.Target.UnitIndex].Ticks++
+		if isPartialResist {
+			dot.Spell.SpellMetrics[result.Target.UnitIndex].ResistedTicks++
+		}
+	} else {
+		result.Outcome = OutcomeMiss
+		result.Damage = 0
+		dot.Spell.SpellMetrics[result.Target.UnitIndex].Misses++
+	}
+}
+
 func (spell *Spell) OutcomeMagicHitAndCrit(sim *Simulation, result *SpellResult, attackTable *AttackTable) {
 	spell.outcomeMagicHitAndCrit(sim, result, attackTable, true)
 }
@@ -146,7 +161,7 @@ func (spell *Spell) outcomeHealingCrit(sim *Simulation, result *SpellResult, att
 	}
 }
 
-func (spell *Spell) OutcomeTickMagicHit(sim *Simulation, result *SpellResult, attackTable *AttackTable) {
+func (spell *Spell) OutcomeTickMagicHitNoHitCounter(sim *Simulation, result *SpellResult, attackTable *AttackTable) {
 	if spell.MagicHitCheck(sim, attackTable) {
 		result.Outcome = OutcomeHit
 	} else {

--- a/sim/paladin/consecration.go
+++ b/sim/paladin/consecration.go
@@ -69,14 +69,14 @@ func (paladin *Paladin) registerConsecration(rankConfig shared.SpellRankConfig) 
 			TickLength:       time.Second * 1,
 			BonusCoefficient: coefficient,
 			OnTick: func(sim *core.Simulation, _ *core.Unit, dot *core.Dot) {
-				dot.Spell.CalcAndDealPeriodicAoeDamage(sim, minDamage, dot.Spell.OutcomeAlwaysHit)
+				dot.Spell.CalcAndDealPeriodicAoeDamage(sim, minDamage, dot.OutcomeTickMagicHit)
 			},
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			dot := spell.AOEDot()
 			dot.Apply(sim)
-			dot.Spell.CalcAndDealPeriodicAoeDamage(sim, minDamage, dot.Spell.OutcomeAlwaysHit)
+			dot.Spell.CalcAndDealPeriodicAoeDamage(sim, minDamage, dot.OutcomeTickMagicHit)
 		},
 	})
 }

--- a/sim/paladin/consecration.go
+++ b/sim/paladin/consecration.go
@@ -65,7 +65,7 @@ func (paladin *Paladin) registerConsecration(rankConfig shared.SpellRankConfig) 
 				ActionID: core.ActionID{SpellID: spellID},
 				Label:    "Consecration" + paladin.Label + " " + rankConfig.GetRankLabel(),
 			},
-			NumberOfTicks:    8,
+			NumberOfTicks:    7,
 			TickLength:       time.Second * 1,
 			BonusCoefficient: coefficient,
 			OnTick: func(sim *core.Simulation, _ *core.Unit, dot *core.Dot) {
@@ -74,7 +74,9 @@ func (paladin *Paladin) registerConsecration(rankConfig shared.SpellRankConfig) 
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			spell.AOEDot().Apply(sim)
+			dot := spell.AOEDot()
+			dot.Apply(sim)
+			dot.Spell.CalcAndDealPeriodicAoeDamage(sim, minDamage, dot.Spell.OutcomeAlwaysHit)
 		},
 	})
 }

--- a/sim/paladin/consecration.go
+++ b/sim/paladin/consecration.go
@@ -74,6 +74,10 @@ func (paladin *Paladin) registerConsecration(rankConfig shared.SpellRankConfig) 
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			// Consecration does one hit check on cast but the ground effect will still be applied
+			// meaning it's only needed to proc things like Eye of Magtheridon (procs on resist)
+			spell.CalcAndDealOutcome(sim, target, spell.OutcomeMagicHit)
+
 			dot := spell.AOEDot()
 			dot.Apply(sim)
 			dot.Spell.CalcAndDealPeriodicAoeDamage(sim, minDamage, dot.OutcomeTickMagicHit)

--- a/sim/paladin/item_librams.go
+++ b/sim/paladin/item_librams.go
@@ -100,13 +100,17 @@ func init() {
 	core.NewItemEffect(27917, func(agent core.Agent) {
 		paladin := agent.(PaladinAgent).GetPaladin()
 
+		// For some ungodly reason, Libram of the Eternal Rest has its own spell coeff...
+		// This means the coef has to be divided by the default Consecration spell coefficient
+		// to get the correct damage increase when it's then being multiplied in the dmg calc...
+		coef := 0.09525 / ConsecrationRankMap[len(ConsecrationRankMap)-1].Coefficient
 		aura := core.MakePermanent(paladin.RegisterAura(core.Aura{
 			Label:    "Libram of the Eternal Rest",
 			ActionID: core.ActionID{SpellID: 34252},
 		}).AttachSpellMod(core.SpellModConfig{
 			ClassMask:  SpellMaskConsecration,
 			Kind:       core.SpellMod_BaseDamage_Flat,
-			FloatValue: 47.0,
+			FloatValue: 47.0 * coef,
 		}))
 
 		paladin.ItemSwap.RegisterProc(27917, aura)

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -55,280 +55,280 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 908.67173
-  tps: 1620.79988
+  dps: 907.54346
+  tps: 1618.65616
   dtps: 1295.48097
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 895.0941
-  tps: 1602.20105
+  dps: 893.96607
+  tps: 1600.05778
   dtps: 1246.84747
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 939.76509
-  tps: 1687.68369
+  dps: 938.63662
+  tps: 1685.5396
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 900.3825
-  tps: 1611.99922
+  dps: 899.25403
+  tps: 1609.85512
   dtps: 1291.57463
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 897.921
-  tps: 1604.8389
+  dps: 896.79218
+  tps: 1602.69413
   dtps: 1202.47962
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 919.73327
-  tps: 1649.1811
+  dps: 918.6048
+  tps: 1647.037
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 909.21447
-  tps: 1628.94995
+  dps: 908.086
+  tps: 1626.80585
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 908.1354
-  tps: 1621.15282
+  dps: 907.00693
+  tps: 1619.00873
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Annihilator-12798"
  value: {
-  dps: 832.09002
-  tps: 1483.16625
+  dps: 830.96104
+  tps: 1481.02118
   dtps: 1306.2087
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 921.66481
-  tps: 1653.63211
+  dps: 920.53634
+  tps: 1651.48801
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 915.15195
-  tps: 1646.74089
+  dps: 914.02486
+  tps: 1644.59943
   dtps: 1518.66163
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 900.3825
-  tps: 1611.99938
+  dps: 899.25403
+  tps: 1609.85529
   dtps: 1291.43233
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 897.54221
-  tps: 1602.62963
+  dps: 896.41196
+  tps: 1600.48215
   dtps: 1224.69668
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 903.62581
-  tps: 1615.26148
+  dps: 902.49734
+  tps: 1613.11738
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 948.29024
-  tps: 1694.40339
+  dps: 947.16147
+  tps: 1692.25873
   dtps: 1303.57219
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 946.71555
-  tps: 1701.43376
+  dps: 945.58606
+  tps: 1699.28773
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 953.7935
-  tps: 1715.61865
+  dps: 952.66401
+  tps: 1713.47263
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 901.77283
-  tps: 1614.46967
+  dps: 900.64436
+  tps: 1612.32557
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BattlecastGarb"
  value: {
-  dps: 948.198
-  tps: 1710.85364
+  dps: 947.07062
+  tps: 1708.71161
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 897.53902
-  tps: 1607.48565
+  dps: 896.41007
+  tps: 1605.34063
   dtps: 1296.09458
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 897.53902
-  tps: 1607.48565
+  dps: 896.41007
+  tps: 1605.34063
   dtps: 1296.09458
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 918.55824
-  tps: 1646.95018
+  dps: 917.42977
+  tps: 1644.80608
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 906.4206
-  tps: 1619.2028
+  dps: 905.29213
+  tps: 1617.05871
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 900.56081
-  tps: 1612.35696
+  dps: 899.43234
+  tps: 1610.21287
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 907.10805
-  tps: 1618.74372
+  dps: 905.97958
+  tps: 1616.59963
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 911.98404
-  tps: 1634.3152
+  dps: 910.85557
+  tps: 1632.1711
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 914.46706
-  tps: 1626.10273
+  dps: 913.33859
+  tps: 1623.95864
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 940.60102
-  tps: 1689.26717
+  dps: 939.47255
+  tps: 1687.12307
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 912.01227
-  tps: 1621.30021
+  dps: 910.88467
+  tps: 1619.15776
   dtps: 1288.02322
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 908.78249
-  tps: 1622.03616
+  dps: 907.65401
+  tps: 1619.89207
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 894.19284
-  tps: 1601.89431
+  dps: 893.06443
+  tps: 1599.75033
   dtps: 1308.24136
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Blinkstrike-31332"
  value: {
-  dps: 939.76509
-  tps: 1687.68369
+  dps: 938.63662
+  tps: 1685.5396
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 911.46908
-  tps: 1623.10475
+  dps: 910.34061
+  tps: 1620.96066
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 952.08692
-  tps: 1707.34693
+  dps: 950.95748
+  tps: 1705.20098
   dtps: 1335.7269
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 895.0941
-  tps: 1602.28651
+  dps: 893.96607
+  tps: 1600.14324
   dtps: 1259.82996
  }
 }
@@ -351,112 +351,112 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 933.24049
-  tps: 1676.85594
+  dps: 932.11218
+  tps: 1674.71214
   dtps: 1222.58641
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 933.04772
-  tps: 1658.02886
+  dps: 931.92226
+  tps: 1655.89049
   dtps: 1294.27042
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 934.22434
-  tps: 1659.56601
+  dps: 933.09711
+  tps: 1657.42426
   dtps: 1284.01685
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BurningRage"
  value: {
-  dps: 926.27597
-  tps: 1628.60449
+  dps: 925.1466
+  tps: 1626.45869
   dtps: 1546.20737
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 949.65622
-  tps: 1707.66266
+  dps: 948.52673
+  tps: 1705.51663
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 898.42837
-  tps: 1608.51671
+  dps: 897.30144
+  tps: 1606.37554
   dtps: 1245.67488
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 931.5778
-  tps: 1673.00133
+  dps: 930.4485
+  tps: 1670.85566
   dtps: 1401.27151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CloudkeeperLegplates-14554"
  value: {
-  dps: 930.74621
-  tps: 1664.03241
+  dps: 929.61862
+  tps: 1661.89001
   dtps: 1349.43444
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 900.3825
-  tps: 1611.87549
+  dps: 899.25403
+  tps: 1609.73139
   dtps: 1275.54983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 908.37539
-  tps: 1620.01107
+  dps: 907.24692
+  tps: 1617.86697
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 928.99077
-  tps: 1667.2757
+  dps: 927.86147
+  tps: 1665.13003
   dtps: 1401.27151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeArmor"
  value: {
-  dps: 914.07098
-  tps: 1641.29338
+  dps: 912.94208
+  tps: 1639.14848
   dtps: 1290.08496
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeBattlegear"
  value: {
-  dps: 936.76198
-  tps: 1622.50967
+  dps: 935.63459
+  tps: 1620.36762
   dtps: 1405.86367
   hps: 1.16609
  }
@@ -464,272 +464,272 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 907.79333
-  tps: 1619.429
+  dps: 906.66486
+  tps: 1617.28491
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 895.49515
-  tps: 1603.21435
+  dps: 894.36642
+  tps: 1601.06976
   dtps: 1260.07345
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 930.86615
-  tps: 1670.56397
+  dps: 929.73768
+  tps: 1668.41988
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 912.82572
-  tps: 1627.16034
+  dps: 911.69724
+  tps: 1625.01625
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 897.53907
-  tps: 1607.38095
+  dps: 896.41143
+  tps: 1605.23845
   dtps: 1276.55653
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 915.20206
-  tps: 1631.13157
+  dps: 914.07359
+  tps: 1628.98748
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DirebrewHops-38288"
  value: {
-  dps: 920.83599
-  tps: 1651.33059
+  dps: 919.70752
+  tps: 1649.1865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DoomplateBattlegear"
  value: {
-  dps: 920.56937
-  tps: 1614.13188
+  dps: 919.44163
+  tps: 1611.98919
   dtps: 1619.08265
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 908.48291
-  tps: 1627.56004
+  dps: 907.35444
+  tps: 1625.41595
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonmaw-28438"
  value: {
-  dps: 905.69493
-  tps: 1562.48214
+  dps: 904.56666
+  tps: 1560.33842
   dtps: 1262.90409
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 910.83688
-  tps: 1622.27298
+  dps: 909.71012
+  tps: 1620.13215
   dtps: 1286.8966
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonstrike-28439"
  value: {
-  dps: 920.76938
-  tps: 1581.15575
+  dps: 919.64307
+  tps: 1579.01576
   dtps: 1264.15865
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 901.58446
-  tps: 1562.47669
+  dps: 900.45925
+  tps: 1560.33879
   dtps: 1282.27771
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 912.09876
-  tps: 1634.09561
+  dps: 910.97029
+  tps: 1631.95152
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Earthstrike-21180"
  value: {
-  dps: 905.4523
-  tps: 1617.08797
+  dps: 904.32383
+  tps: 1614.94388
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 901.18192
-  tps: 1612.15752
+  dps: 900.05266
+  tps: 1610.01192
   dtps: 1281.89069
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 911.46908
-  tps: 1623.10475
+  dps: 910.34061
+  tps: 1620.96066
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 938.42805
-  tps: 1684.50366
+  dps: 937.29955
+  tps: 1682.35951
   dtps: 1278.88702
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 940.51226
-  tps: 1657.6743
+  dps: 939.38389
+  tps: 1655.57327
   dtps: 1310.99362
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 932.03073
-  tps: 1704.83397
+  dps: 930.90226
+  tps: 1702.64699
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 928.43459
-  tps: 1662.31333
+  dps: 927.30612
+  tps: 1660.16923
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 918.01048
-  tps: 1640.12382
+  dps: 916.88372
+  tps: 1637.98299
   dtps: 1236.86721
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 928.7962
-  tps: 1662.4606
+  dps: 927.66773
+  tps: 1660.3165
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 924.03984
-  tps: 1650.80333
+  dps: 922.91266
+  tps: 1648.66168
   dtps: 1232.40893
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 920.83599
-  tps: 1651.33059
+  dps: 919.70752
+  tps: 1649.1865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeofMoam-21473"
  value: {
-  dps: 903.46948
-  tps: 1617.95192
+  dps: 902.34101
+  tps: 1615.80783
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 931.0633
-  tps: 1670.9509
+  dps: 929.93483
+  tps: 1668.8068
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 945.47833
-  tps: 1699.55256
+  dps: 944.34962
+  tps: 1697.40801
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelSkin"
  value: {
-  dps: 940.5623
-  tps: 1673.04104
+  dps: 939.43397
+  tps: 1670.89723
   dtps: 1591.51554
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelscaleArmor"
  value: {
-  dps: 906.45886
-  tps: 1597.38751
+  dps: 905.33101
+  tps: 1595.2446
   dtps: 1473.24399
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 891.02227
-  tps: 1594.98472
+  dps: 889.89221
+  tps: 1592.8376
   dtps: 1226.52683
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 889.03752
-  tps: 1591.31279
+  dps: 887.90864
+  tps: 1589.16793
   dtps: 1199.11718
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 907.23821
-  tps: 1618.87388
+  dps: 906.10974
+  tps: 1616.72979
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
   hps: 4.7
  }
@@ -737,8 +737,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ForceReactiveDisk-18168"
  value: {
-  dps: 938.95445
-  tps: 1686.73331
+  dps: 937.82637
+  tps: 1684.58996
   dtps: 1453.53081
  }
 }
@@ -761,176 +761,176 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 919.73327
-  tps: 1649.1811
+  dps: 918.6048
+  tps: 1647.037
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 900.3825
-  tps: 1611.92024
+  dps: 899.25403
+  tps: 1609.77614
   dtps: 1280.69983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 900.3825
-  tps: 1611.87549
+  dps: 899.25403
+  tps: 1609.73139
   dtps: 1275.54983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HandofJustice-11815"
  value: {
-  dps: 912.97163
-  tps: 1631.61794
+  dps: 911.84322
+  tps: 1629.47398
   dtps: 1293.43818
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 897.92938
-  tps: 1606.83676
+  dps: 896.80098
+  tps: 1604.69281
   dtps: 1305.00032
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 906.76962
-  tps: 1623.67808
+  dps: 905.64114
+  tps: 1621.53399
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 939.73892
-  tps: 1687.60184
+  dps: 938.61045
+  tps: 1685.45775
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 909.8419
-  tps: 1630.16716
+  dps: 908.71343
+  tps: 1628.02306
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 907.43875
-  tps: 1620.22095
+  dps: 906.31028
+  tps: 1618.07686
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IceGuard-2682"
  value: {
-  dps: 940.7619
-  tps: 1690.43873
+  dps: 939.63191
+  tps: 1688.29176
   dtps: 1312.25995
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 907.76988
-  tps: 1619.14447
+  dps: 906.64314
+  tps: 1617.00366
   dtps: 1283.53082
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImbuedNetherweave"
  value: {
-  dps: 936.69675
-  tps: 1688.05513
+  dps: 935.56966
+  tps: 1685.91366
   dtps: 1573.5504
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JomGabbar-23570"
  value: {
-  dps: 906.5661
-  tps: 1618.20177
+  dps: 905.43763
+  tps: 1616.05767
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarArmor"
  value: {
-  dps: 926.2824
-  tps: 1662.93763
+  dps: 925.15314
+  tps: 1660.79203
   dtps: 1329.87036
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarBattlegear"
  value: {
-  dps: 926.08444
-  tps: 1613.70465
+  dps: 924.958
+  tps: 1611.5644
   dtps: 1461.81743
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumScope-2723"
  value: {
-  dps: 939.76509
-  tps: 1687.68369
+  dps: 938.63662
+  tps: 1685.5396
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumWard"
  value: {
-  dps: 962.62011
-  tps: 1737.98136
+  dps: 961.49204
+  tps: 1735.83802
   dtps: 1484.42037
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 909.46475
-  tps: 1625.8989
+  dps: 908.33867
+  tps: 1623.75934
   dtps: 1293.10578
  }
 }
@@ -1017,72 +1017,72 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-LightbringerArmor"
  value: {
-  dps: 957.47556
-  tps: 1721.27257
+  dps: 956.23623
+  tps: 1718.91785
   dtps: 1061.24395
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1052.61497
-  tps: 1765.86105
+  dps: 1051.49107
+  tps: 1763.72564
   dtps: 1700.06334
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 913.81174
-  tps: 1626.6224
+  dps: 912.68641
+  tps: 1624.48427
   dtps: 1281.99271
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 917.97192
-  tps: 1659.13629
+  dps: 916.84414
+  tps: 1656.99351
   dtps: 1955.39544
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 923.81548
-  tps: 1658.70489
+  dps: 922.68731
+  tps: 1656.56136
   dtps: 1379.27527
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 914.69106
-  tps: 1638.75237
+  dps: 913.56259
+  tps: 1636.60828
   dtps: 1294.28455
  }
 }
@@ -1105,336 +1105,336 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 898.39691
-  tps: 1607.7646
+  dps: 897.26932
+  tps: 1605.62219
   dtps: 1295.58137
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 887.05963
-  tps: 1588.72705
+  dps: 885.93396
+  tps: 1586.58829
   dtps: 1194.67222
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 905.45917
-  tps: 1622.36793
+  dps: 904.33069
+  tps: 1620.22383
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 911.407
-  tps: 1633.16948
+  dps: 910.27853
+  tps: 1631.02538
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherscaleArmor"
  value: {
-  dps: 950.7565
-  tps: 1691.14919
+  dps: 949.62824
+  tps: 1689.0055
   dtps: 1509.65126
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherstrikeArmor"
  value: {
-  dps: 962.8946
-  tps: 1738.46319
+  dps: 961.76642
+  tps: 1736.31965
   dtps: 1511.76151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherweaveVestments"
  value: {
-  dps: 964.48501
-  tps: 1748.36039
+  dps: 963.35654
+  tps: 1746.21629
   dtps: 2069.19023
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 906.97889
-  tps: 1618.61456
+  dps: 905.85042
+  tps: 1616.47046
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 914.24648
-  tps: 1638.6654
+  dps: 913.11801
+  tps: 1636.5213
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 943.07051
-  tps: 1694.65712
+  dps: 941.94181
+  tps: 1692.51257
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 943.07051
-  tps: 1694.65712
+  dps: 941.94181
+  tps: 1692.51257
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofThawing-24093"
  value: {
-  dps: 943.07051
-  tps: 1694.65712
+  dps: 941.94181
+  tps: 1692.51257
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofWithering-24095"
  value: {
-  dps: 943.07051
-  tps: 1694.65712
+  dps: 941.94181
+  tps: 1692.51257
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 943.07051
-  tps: 1694.65712
+  dps: 941.94181
+  tps: 1692.51257
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 900.56081
-  tps: 1611.57318
+  dps: 899.43234
+  tps: 1609.42908
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalIntent"
  value: {
-  dps: 952.97975
-  tps: 1681.61962
+  dps: 951.85079
+  tps: 1679.47461
   dtps: 1458.1094
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalMooncloth"
  value: {
-  dps: 948.14279
-  tps: 1708.76213
+  dps: 947.01531
+  tps: 1706.61991
   dtps: 1606.88095
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Prismcharm-15867"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 908.45351
-  tps: 1628.36919
+  dps: 907.32493
+  tps: 1626.22489
   dtps: 1285.83994
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 897.68979
-  tps: 1608.68357
+  dps: 896.56132
+  tps: 1606.53947
   dtps: 1301.79137
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 896.47705
-  tps: 1605.23382
+  dps: 895.34931
+  tps: 1603.09112
   dtps: 1260.67102
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 932.71947
-  tps: 1675.79323
+  dps: 931.5913
+  tps: 1673.6497
   dtps: 1379.27527
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 939.76509
-  tps: 1687.68369
+  dps: 938.63662
+  tps: 1685.5396
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 921.75536
-  tps: 1638.61916
+  dps: 920.62931
+  tps: 1636.47967
   dtps: 1290.34989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RuneofForce-25994"
  value: {
-  dps: 902.04373
-  tps: 1613.6794
+  dps: 900.91525
+  tps: 1611.5353
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SavageGuard-2681"
  value: {
-  dps: 940.7619
-  tps: 1690.43873
+  dps: 939.63191
+  tps: 1688.29176
   dtps: 1312.25995
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 894.51767
-  tps: 1603.33083
+  dps: 893.39002
+  tps: 1601.18829
   dtps: 1241.83006
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 909.66373
-  tps: 1629.85579
+  dps: 908.53526
+  tps: 1627.7117
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 902.21216
-  tps: 1614.20529
+  dps: 901.08379
+  tps: 1612.06139
   dtps: 1282.29274
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 917.76876
-  tps: 1646.29198
+  dps: 916.64029
+  tps: 1644.14788
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 915.73574
-  tps: 1641.50351
+  dps: 914.60727
+  tps: 1639.35942
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 903.83205
-  tps: 1625.32286
+  dps: 902.70427
+  tps: 1623.18008
   dtps: 1552.52139
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 892.32402
-  tps: 1596.82737
+  dps: 891.19835
+  tps: 1594.68859
   dtps: 1220.28564
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShardofContempt-34472"
  value: {
-  dps: 932.00193
-  tps: 1651.86464
+  dps: 930.87419
+  tps: 1649.72193
   dtps: 1286.42927
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 903.04084
-  tps: 1617.12304
+  dps: 901.91237
+  tps: 1614.97895
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 917.51469
-  tps: 1645.04395
+  dps: 916.38564
+  tps: 1642.89875
   dtps: 1294.99466
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SkullflameShield-1168"
  value: {
-  dps: 950.13383
-  tps: 1701.03057
+  dps: 949.00557
+  tps: 1698.88687
   dtps: 1473.80805
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 910.47061
-  tps: 1622.10628
+  dps: 909.34214
+  tps: 1619.96219
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SoulclothEmbrace"
  value: {
-  dps: 887.65916
-  tps: 1594.61537
+  dps: 886.53138
+  tps: 1592.47259
   dtps: 1556.20338
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 954.06998
-  tps: 1723.49329
+  dps: 952.9426
+  tps: 1721.35126
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 900.3825
-  tps: 1612.01817
+  dps: 899.25403
+  tps: 1609.87408
   dtps: 1294.28455
   hps: 15.16667
  }
@@ -1442,168 +1442,168 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 941.09722
-  tps: 1690.21474
+  dps: 939.96875
+  tps: 1688.07065
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 915.64103
-  tps: 1642.0546
+  dps: 914.51256
+  tps: 1639.91051
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 905.6311
-  tps: 1622.07553
+  dps: 904.50263
+  tps: 1619.93143
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 932.71218
-  tps: 1656.3908
+  dps: 931.58357
+  tps: 1654.24644
   dtps: 1261.67544
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 894.12517
-  tps: 1603.10711
+  dps: 892.99709
+  tps: 1600.96376
   dtps: 1460.21448
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 941.44647
-  tps: 1689.36508
+  dps: 940.318
+  tps: 1687.22098
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 939.76509
-  tps: 1687.68369
+  dps: 938.63662
+  tps: 1685.5396
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 905.51175
-  tps: 1621.86203
+  dps: 904.38328
+  tps: 1619.71794
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 912.76976
-  tps: 1635.77723
+  dps: 911.64129
+  tps: 1633.63313
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 904.54592
-  tps: 1615.82947
+  dps: 903.4199
+  tps: 1613.69003
   dtps: 1288.19539
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 912.57432
-  tps: 1636.10889
+  dps: 911.44585
+  tps: 1633.9648
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 902.89543
-  tps: 1607.34505
+  dps: 901.76746
+  tps: 1605.20189
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 927.47135
-  tps: 1664.04609
+  dps: 926.34288
+  tps: 1661.90199
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 928.41162
-  tps: 1667.14809
+  dps: 927.28404
+  tps: 1665.00568
   dtps: 1306.38861
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 863.74194
-  tps: 1426.81529
+  dps: 862.61522
+  tps: 1424.67454
   dtps: 1853.62548
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThickDraenicArmor"
  value: {
-  dps: 905.3915
-  tps: 1599.45033
+  dps: 904.2638
+  tps: 1597.3077
   dtps: 1541.01632
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 939.76509
-  tps: 1687.68369
+  dps: 938.63662
+  tps: 1685.5396
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 913.21636
-  tps: 1635.60845
+  dps: 912.08788
+  tps: 1633.46436
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 912.77049
-  tps: 1626.89597
+  dps: 911.64402
+  tps: 1624.75566
   dtps: 1287.8636
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-UnitingCharm-25633"
  value: {
-  dps: 906.97889
-  tps: 1618.61456
+  dps: 905.85042
+  tps: 1616.47046
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 909.21447
-  tps: 1628.94995
+  dps: 908.086
+  tps: 1626.80585
   dtps: 1294.28455
  }
 }
@@ -1626,176 +1626,176 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 909.52176
-  tps: 1628.80874
+  dps: 908.39329
+  tps: 1626.66465
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WastewalkerArmor"
  value: {
-  dps: 907.45704
-  tps: 1589.7666
+  dps: 906.32874
+  tps: 1587.62284
   dtps: 1680.99401
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WhitemendWisdom"
  value: {
-  dps: 931.95206
-  tps: 1678.36798
+  dps: 930.82467
+  tps: 1676.22595
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WindhawkArmor"
  value: {
-  dps: 965.22081
-  tps: 1743.926
+  dps: 964.09263
+  tps: 1741.78246
   dtps: 1568.72218
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 941.226
-  tps: 1691.49153
+  dps: 940.09651
+  tps: 1689.3455
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofSpellfire"
  value: {
-  dps: 912.16525
-  tps: 1640.53808
+  dps: 911.03767
+  tps: 1638.39568
   dtps: 1578.32174
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 897.92938
-  tps: 1606.83676
+  dps: 896.80098
+  tps: 1604.69281
   dtps: 1305.00032
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 911.25098
-  tps: 1632.85871
+  dps: 910.12251
+  tps: 1630.71462
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 935.93137
-  tps: 1679.63843
+  dps: 934.80315
+  tps: 1677.49482
   dtps: 1257.99916
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2554.84492
-  tps: 4504.49145
+  dps: 2549.89582
+  tps: 4495.08814
   dtps: 44358.6852
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 1004.21677
-  tps: 1775.24805
+  dps: 1003.09262
+  tps: 1773.11215
   dtps: 1253.73335
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1126.72443
-  tps: 1973.53922
+  dps: 1125.52354
+  tps: 1971.25751
   dtps: 1325.75557
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2364.3729
-  tps: 5418.73985
+  dps: 2351.76967
+  tps: 5394.79371
   dtps: 46514.55637
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 434.3113
-  tps: 909.56477
+  dps: 433.3805
+  tps: 907.79626
   dtps: 2281.36763
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 453.95986
-  tps: 945.69303
+  dps: 452.96879
+  tps: 943.80998
   dtps: 2347.11751
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2581.5004
-  tps: 4537.23235
+  dps: 2576.55475
+  tps: 4527.83561
   dtps: 44367.41399
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 1022.11977
-  tps: 1801.87864
+  dps: 1020.99353
+  tps: 1799.73879
   dtps: 1253.94098
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1151.53457
-  tps: 2010.45216
+  dps: 1150.33483
+  tps: 2008.17265
   dtps: 1325.97528
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2371.59395
-  tps: 5430.80029
+  dps: 2358.98936
+  tps: 5406.85156
   dtps: 46580.56953
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 436.40865
-  tps: 912.76743
+  dps: 435.47783
+  tps: 910.99887
   dtps: 2281.72218
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 455.65422
-  tps: 948.2148
+  dps: 454.66332
+  tps: 946.33208
   dtps: 2347.48218
  }
 }
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1004.21677
-  tps: 1775.24805
+  dps: 1003.09262
+  tps: 1773.11215
   dtps: 1253.73335
  }
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -55,408 +55,408 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 910.43369
-  tps: 1624.1476
+  dps: 890.90021
+  tps: 1588.10676
   dtps: 1295.48097
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 895.25729
-  tps: 1602.51109
+  dps: 875.58312
+  tps: 1566.25672
   dtps: 1246.84747
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 939.62438
-  tps: 1687.41636
+  dps: 915.41209
+  tps: 1642.00253
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 900.28275
-  tps: 1611.8097
+  dps: 879.19553
+  tps: 1572.34295
   dtps: 1291.57463
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 898.44684
-  tps: 1605.838
+  dps: 875.77266
+  tps: 1564.0402
   dtps: 1202.47962
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 919.62649
-  tps: 1648.97822
+  dps: 898.02242
+  tps: 1608.53334
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 909.02615
-  tps: 1628.59214
+  dps: 887.92165
+  tps: 1589.09695
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 908.16042
-  tps: 1621.20035
+  dps: 887.30394
+  tps: 1582.1764
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Annihilator-12798"
  value: {
-  dps: 832.76069
-  tps: 1484.44052
+  dps: 811.1422
+  tps: 1443.79747
   dtps: 1306.2087
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 921.52261
-  tps: 1653.36191
+  dps: 903.62632
+  tps: 1619.62655
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 914.45607
-  tps: 1645.41871
+  dps: 896.86924
+  tps: 1611.97682
   dtps: 1518.66163
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 900.28275
-  tps: 1611.80987
+  dps: 879.19553
+  tps: 1572.34312
   dtps: 1291.43233
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 898.03864
-  tps: 1603.57285
+  dps: 874.58975
+  tps: 1559.28551
   dtps: 1224.69668
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 903.52606
-  tps: 1615.07196
+  dps: 882.43884
+  tps: 1575.60521
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 949.00311
-  tps: 1695.75784
+  dps: 925.71016
+  tps: 1652.32648
   dtps: 1303.57219
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 947.45695
-  tps: 1702.84242
+  dps: 926.36208
+  tps: 1663.90015
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 954.55186
-  tps: 1717.05954
+  dps: 932.98257
+  tps: 1677.20897
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 901.69966
-  tps: 1614.33063
+  dps: 880.52553
+  tps: 1574.70119
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BattlecastGarb"
  value: {
-  dps: 948.40748
-  tps: 1711.25164
+  dps: 928.12945
+  tps: 1673.08645
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 898.4962
-  tps: 1609.30428
+  dps: 876.14274
+  tps: 1567.43315
   dtps: 1296.09458
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 898.4962
-  tps: 1609.30428
+  dps: 876.14274
+  tps: 1567.43315
   dtps: 1296.09458
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 918.49359
-  tps: 1646.82733
+  dps: 896.81322
+  tps: 1606.24064
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 906.52756
-  tps: 1619.40603
+  dps: 885.44034
+  tps: 1579.93928
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 900.46106
-  tps: 1612.16745
+  dps: 879.37384
+  tps: 1572.7007
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 907.0083
-  tps: 1618.5542
+  dps: 885.92108
+  tps: 1579.08745
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 911.90669
-  tps: 1634.16823
+  dps: 890.44086
+  tps: 1593.98663
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 914.36731
-  tps: 1625.91321
+  dps: 893.28009
+  tps: 1586.44646
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 940.45817
-  tps: 1688.99575
+  dps: 916.24587
+  tps: 1643.58192
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 912.87147
-  tps: 1622.93269
+  dps: 898.69901
+  tps: 1596.8699
   dtps: 1288.02322
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 908.8075
-  tps: 1622.0837
+  dps: 887.95102
+  tps: 1583.05974
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 894.86264
-  tps: 1603.16692
+  dps: 872.26726
+  tps: 1561.05833
   dtps: 1308.24136
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Blinkstrike-31332"
  value: {
-  dps: 939.62438
-  tps: 1687.41636
+  dps: 915.41209
+  tps: 1642.00253
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 911.36934
-  tps: 1622.91524
+  dps: 890.28211
+  tps: 1583.44849
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 952.77822
-  tps: 1708.66039
+  dps: 930.36028
+  tps: 1667.20101
   dtps: 1335.7269
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 895.25729
-  tps: 1602.59655
+  dps: 875.58312
+  tps: 1566.35028
   dtps: 1259.82996
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofFortitude-35039"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofVengeance-35041"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 933.82083
-  tps: 1677.95858
+  dps: 910.65862
+  tps: 1635.01039
   dtps: 1222.58641
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 934.23301
-  tps: 1660.28091
+  dps: 916.26395
+  tps: 1626.97029
   dtps: 1294.27042
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 935.19293
-  tps: 1661.40633
+  dps: 915.49919
+  tps: 1624.44332
   dtps: 1284.01685
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BurningRage"
  value: {
-  dps: 926.47306
-  tps: 1628.97897
+  dps: 904.97883
+  tps: 1588.04853
   dtps: 1546.20737
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 950.39502
-  tps: 1709.06638
+  dps: 928.82101
+  tps: 1669.20291
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 898.28241
-  tps: 1608.23938
+  dps: 870.59924
+  tps: 1555.86087
   dtps: 1245.67488
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 931.94035
-  tps: 1673.69018
+  dps: 911.28861
+  tps: 1635.56772
   dtps: 1401.27151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CloudkeeperLegplates-14554"
  value: {
-  dps: 930.8711
-  tps: 1664.26971
+  dps: 909.13531
+  tps: 1623.61503
   dtps: 1349.43444
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 900.28275
-  tps: 1611.68597
+  dps: 879.19553
+  tps: 1572.23449
   dtps: 1275.54983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 908.27565
-  tps: 1619.82155
+  dps: 887.18842
+  tps: 1580.3548
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 929.36894
-  tps: 1667.99422
+  dps: 908.53576
+  tps: 1629.51127
   dtps: 1401.27151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeArmor"
  value: {
-  dps: 914.21017
-  tps: 1641.55785
+  dps: 894.42338
+  tps: 1604.52511
   dtps: 1290.08496
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeBattlegear"
  value: {
-  dps: 936.8555
-  tps: 1622.68736
+  dps: 917.60323
+  tps: 1586.56173
   dtps: 1405.86367
   hps: 1.16609
  }
@@ -464,272 +464,272 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 907.69358
-  tps: 1619.23948
+  dps: 886.60636
+  tps: 1579.77273
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 895.83945
-  tps: 1603.86852
+  dps: 877.01131
+  tps: 1569.49992
   dtps: 1260.07345
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 930.75909
-  tps: 1670.36057
+  dps: 908.84792
+  tps: 1629.33476
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 912.72986
-  tps: 1626.97821
+  dps: 891.50251
+  tps: 1587.24541
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 897.64381
-  tps: 1607.57997
+  dps: 875.09629
+  tps: 1565.79818
   dtps: 1276.55653
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 915.30902
-  tps: 1631.3348
+  dps: 894.59055
+  tps: 1592.55737
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DirebrewHops-38288"
  value: {
-  dps: 920.94109
-  tps: 1651.53027
+  dps: 898.89889
+  tps: 1610.2611
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DoomplateBattlegear"
  value: {
-  dps: 921.91242
-  tps: 1616.68368
+  dps: 898.90184
+  tps: 1574.76306
   dtps: 1619.08265
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 908.3704
-  tps: 1627.34628
+  dps: 887.28448
+  tps: 1587.89613
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonmaw-28438"
  value: {
-  dps: 907.01183
-  tps: 1564.98424
+  dps: 888.9699
+  tps: 1530.41816
   dtps: 1262.90409
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 911.08327
-  tps: 1622.73108
+  dps: 888.93214
+  tps: 1580.93095
   dtps: 1286.8966
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonstrike-28439"
  value: {
-  dps: 921.24201
-  tps: 1582.05376
+  dps: 898.60185
+  tps: 1539.91834
   dtps: 1264.15865
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 901.66061
-  tps: 1562.62091
+  dps: 883.78334
+  tps: 1528.90971
   dtps: 1282.27771
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 912.07675
-  tps: 1634.05379
+  dps: 890.51135
+  tps: 1593.69209
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Earthstrike-21180"
  value: {
-  dps: 905.35255
-  tps: 1616.89845
+  dps: 884.26533
+  tps: 1577.4317
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 901.34597
-  tps: 1612.46921
+  dps: 880.66581
+  tps: 1573.29406
   dtps: 1281.89069
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 911.36934
-  tps: 1622.91524
+  dps: 890.28211
+  tps: 1583.44849
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 939.15551
-  tps: 1685.88584
+  dps: 915.00982
+  tps: 1640.84916
   dtps: 1278.88702
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 941.03253
-  tps: 1658.64304
+  dps: 917.42871
+  tps: 1615.39189
   dtps: 1310.99362
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 931.87509
-  tps: 1704.53235
+  dps: 907.9152
+  tps: 1658.6961
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 928.23278
-  tps: 1661.9299
+  dps: 904.50779
+  tps: 1617.43597
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 917.4804
-  tps: 1639.11055
+  dps: 893.56054
+  tps: 1593.33087
   dtps: 1236.86721
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 928.61847
-  tps: 1662.12292
+  dps: 904.91098
+  tps: 1617.66222
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 924.34752
-  tps: 1651.38792
+  dps: 905.16014
+  tps: 1615.48319
   dtps: 1232.40893
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 920.94109
-  tps: 1651.53027
+  dps: 898.89889
+  tps: 1610.2611
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeofMoam-21473"
  value: {
-  dps: 903.36945
-  tps: 1617.76187
+  dps: 882.26861
+  tps: 1578.27206
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 931.27223
-  tps: 1671.34788
+  dps: 908.81546
+  tps: 1629.30292
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 946.11797
-  tps: 1700.76788
+  dps: 925.89975
+  tps: 1664.10189
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelSkin"
  value: {
-  dps: 942.13154
-  tps: 1676.0226
+  dps: 922.1434
+  tps: 1638.39591
   dtps: 1591.51554
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelscaleArmor"
  value: {
-  dps: 906.9179
-  tps: 1598.25968
+  dps: 885.17947
+  tps: 1557.94471
   dtps: 1473.24399
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 891.67329
-  tps: 1596.22165
+  dps: 871.72001
+  tps: 1558.40599
   dtps: 1226.52683
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 890.11615
-  tps: 1593.3622
+  dps: 868.19749
+  tps: 1551.46692
   dtps: 1199.11718
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 907.13846
-  tps: 1618.68436
+  dps: 886.05124
+  tps: 1579.21761
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
   hps: 4.7
  }
@@ -737,704 +737,704 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ForceReactiveDisk-18168"
  value: {
-  dps: 939.9988
-  tps: 1688.64211
+  dps: 915.48803
+  tps: 1642.47232
   dtps: 1453.53081
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofFortitude-33936"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofVengeance-33948"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 919.62649
-  tps: 1648.97822
+  dps: 898.02242
+  tps: 1608.53334
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 900.28275
-  tps: 1611.73072
+  dps: 879.19553
+  tps: 1572.27461
   dtps: 1280.69983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 900.28275
-  tps: 1611.68597
+  dps: 879.19553
+  tps: 1572.23449
   dtps: 1275.54983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HandofJustice-11815"
  value: {
-  dps: 914.20864
-  tps: 1633.96827
+  dps: 893.08523
+  tps: 1593.95039
   dtps: 1293.43818
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 898.85602
-  tps: 1608.59739
+  dps: 875.61862
+  tps: 1565.5167
   dtps: 1305.00032
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 906.8675
-  tps: 1623.86406
+  dps: 885.58562
+  tps: 1584.03764
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 939.6251
-  tps: 1687.38557
+  dps: 917.4861
+  tps: 1645.92839
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 910.03484
-  tps: 1630.53375
+  dps: 888.65933
+  tps: 1590.52752
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 907.54571
-  tps: 1620.42418
+  dps: 886.45848
+  tps: 1580.95743
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IceGuard-2682"
  value: {
-  dps: 941.93254
-  tps: 1692.66294
+  dps: 921.22483
+  tps: 1654.23485
   dtps: 1312.25995
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 907.32221
-  tps: 1618.29389
+  dps: 890.55024
+  tps: 1586.54603
   dtps: 1283.53082
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImbuedNetherweave"
  value: {
-  dps: 936.02821
-  tps: 1686.7849
+  dps: 915.14506
+  tps: 1647.11333
   dtps: 1573.5504
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JomGabbar-23570"
  value: {
-  dps: 906.46635
-  tps: 1618.01225
+  dps: 885.37913
+  tps: 1578.5455
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarArmor"
  value: {
-  dps: 927.36711
-  tps: 1664.99858
+  dps: 905.33084
+  tps: 1623.98798
   dtps: 1329.87036
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarBattlegear"
  value: {
-  dps: 926.5438
-  tps: 1614.57742
+  dps: 908.64982
+  tps: 1580.9022
   dtps: 1461.81743
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumScope-2723"
  value: {
-  dps: 939.62438
-  tps: 1687.41636
+  dps: 915.41209
+  tps: 1642.00253
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumWard"
  value: {
-  dps: 962.57045
-  tps: 1737.88701
+  dps: 940.10342
+  tps: 1694.46385
   dtps: 1484.42037
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 909.7834
-  tps: 1626.50433
+  dps: 888.16315
+  tps: 1586.31036
   dtps: 1293.10578
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofAvengement-27484"
  value: {
-  dps: 940.47189
-  tps: 1685.93947
+  dps: 916.81045
+  tps: 1641.57228
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivinePurpose-33504"
  value: {
-  dps: 956.82786
-  tps: 1720.10296
+  dps: 933.19544
+  tps: 1675.7909
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofFervor-23203"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofHope-22401"
  value: {
-  dps: 935.07248
-  tps: 1678.03892
+  dps: 911.37103
+  tps: 1633.59672
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRepentance-29388"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRighteousPower-31033"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofWracking-28065"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27949"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27983"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerArmor"
  value: {
-  dps: 957.51163
-  tps: 1721.3411
+  dps: 924.02949
+  tps: 1658.5225
   dtps: 1061.24395
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1052.81049
-  tps: 1766.23253
+  dps: 1034.07761
+  tps: 1730.70766
   dtps: 1700.06334
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 913.25885
-  tps: 1625.57191
+  dps: 898.69486
+  tps: 1597.97459
   dtps: 1281.99271
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 917.1786
-  tps: 1657.62898
+  dps: 899.02097
+  tps: 1623.18659
   dtps: 1955.39544
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 924.3012
-  tps: 1659.62776
+  dps: 900.74343
+  tps: 1615.60674
   dtps: 1379.27527
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 914.61894
-  tps: 1638.61534
+  dps: 893.06477
+  tps: 1598.26109
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofFortitude-33937"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofVengeance-33949"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 898.89081
-  tps: 1608.70302
+  dps: 876.64635
+  tps: 1567.28033
   dtps: 1295.58137
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 887.26319
-  tps: 1589.11382
+  dps: 862.05812
+  tps: 1541.69414
   dtps: 1194.67222
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 905.35942
-  tps: 1622.17841
+  dps: 888.57159
+  tps: 1590.6922
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 911.28463
-  tps: 1632.93699
+  dps: 890.2169
+  tps: 1593.51785
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherscaleArmor"
  value: {
-  dps: 950.42225
-  tps: 1690.51412
+  dps: 933.19665
+  tps: 1657.70408
   dtps: 1509.65126
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherstrikeArmor"
  value: {
-  dps: 962.98873
-  tps: 1738.64204
+  dps: 937.93203
+  tps: 1690.40568
   dtps: 1511.76151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherweaveVestments"
  value: {
-  dps: 965.30148
-  tps: 1749.91167
+  dps: 939.27109
+  tps: 1700.85085
   dtps: 2069.19023
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 906.87914
-  tps: 1618.42504
+  dps: 885.79191
+  tps: 1578.95829
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 914.29209
-  tps: 1638.75205
+  dps: 892.54625
+  tps: 1598.04224
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 943.70559
-  tps: 1695.86376
+  dps: 921.04686
+  tps: 1654.54698
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 943.70559
-  tps: 1695.86376
+  dps: 921.04686
+  tps: 1654.54698
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofThawing-24093"
  value: {
-  dps: 943.70559
-  tps: 1695.86376
+  dps: 921.04686
+  tps: 1654.54698
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofWithering-24095"
  value: {
-  dps: 943.70559
-  tps: 1695.86376
+  dps: 921.04686
+  tps: 1654.54698
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 943.70559
-  tps: 1695.86376
+  dps: 921.04686
+  tps: 1654.54698
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 900.46106
-  tps: 1611.38366
+  dps: 879.37384
+  tps: 1571.91195
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalIntent"
  value: {
-  dps: 954.25939
-  tps: 1684.05094
+  dps: 935.75339
+  tps: 1649.74553
   dtps: 1458.1094
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalMooncloth"
  value: {
-  dps: 948.296
-  tps: 1709.05323
+  dps: 926.93477
+  tps: 1668.05645
   dtps: 1606.88095
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Prismcharm-15867"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 909.43683
-  tps: 1630.23749
+  dps: 890.22397
+  tps: 1594.77505
   dtps: 1285.83994
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 897.6699
-  tps: 1608.64579
+  dps: 878.60205
+  tps: 1572.94683
   dtps: 1301.79137
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 896.69304
-  tps: 1605.6442
+  dps: 875.34085
+  tps: 1566.29715
   dtps: 1260.67102
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 933.2029
-  tps: 1676.71173
+  dps: 909.68973
+  tps: 1632.76696
   dtps: 1379.27527
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 939.62438
-  tps: 1687.41636
+  dps: 915.41209
+  tps: 1642.00253
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 922.57874
-  tps: 1640.07643
+  dps: 900.30886
+  tps: 1597.42188
   dtps: 1290.34989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RuneofForce-25994"
  value: {
-  dps: 901.94398
-  tps: 1613.48988
+  dps: 880.85675
+  tps: 1574.02313
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SavageGuard-2681"
  value: {
-  dps: 941.93254
-  tps: 1692.66294
+  dps: 921.22483
+  tps: 1654.23485
   dtps: 1312.25995
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 894.96179
-  tps: 1604.17465
+  dps: 868.06952
+  tps: 1553.66972
   dtps: 1241.83006
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 909.5819
-  tps: 1629.70032
+  dps: 888.1918
+  tps: 1589.66169
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 903.4094
-  tps: 1616.48004
+  dps: 882.31443
+  tps: 1576.33083
   dtps: 1282.29274
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 917.57878
-  tps: 1645.93102
+  dps: 901.51885
+  tps: 1615.59346
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 915.53931
-  tps: 1641.1303
+  dps: 893.84979
+  tps: 1600.51919
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 903.07627
-  tps: 1623.88689
+  dps: 883.41362
+  tps: 1586.64555
   dtps: 1552.52139
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 891.95954
-  tps: 1596.13485
+  dps: 866.55205
+  tps: 1548.75423
   dtps: 1220.28564
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShardofContempt-34472"
  value: {
-  dps: 932.08539
-  tps: 1652.0232
+  dps: 910.86674
+  tps: 1611.99646
   dtps: 1286.42927
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 902.9516
-  tps: 1616.95348
+  dps: 881.7499
+  tps: 1577.25969
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 918.64701
-  tps: 1647.19535
+  dps: 897.25078
+  tps: 1607.05198
   dtps: 1294.99466
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SkullflameShield-1168"
  value: {
-  dps: 949.58682
-  tps: 1700.04521
+  dps: 926.40314
+  tps: 1657.60288
   dtps: 1473.80805
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 910.37087
-  tps: 1621.91677
+  dps: 889.28364
+  tps: 1582.45002
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SoulclothEmbrace"
  value: {
-  dps: 886.88109
-  tps: 1593.13703
+  dps: 870.36135
+  tps: 1561.84292
   dtps: 1556.20338
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 954.27096
-  tps: 1723.87514
+  dps: 938.54564
+  tps: 1694.24965
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 900.28275
-  tps: 1611.82865
+  dps: 879.19553
+  tps: 1572.3619
   dtps: 1294.28455
   hps: 15.16667
  }
@@ -1442,360 +1442,360 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 941.16732
-  tps: 1690.34794
+  dps: 916.96922
+  tps: 1644.96109
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 915.45244
-  tps: 1641.69627
+  dps: 897.91603
+  tps: 1608.63564
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 905.51533
-  tps: 1621.85557
+  dps: 884.30648
+  tps: 1582.1597
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 933.1897
-  tps: 1657.29809
+  dps: 911.35644
+  tps: 1616.10529
   dtps: 1261.67544
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 894.08731
-  tps: 1603.03517
+  dps: 871.63347
+  tps: 1560.95018
   dtps: 1460.21448
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 941.30577
-  tps: 1689.09775
+  dps: 917.09347
+  tps: 1643.68391
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 939.62438
-  tps: 1687.41636
+  dps: 915.41209
+  tps: 1642.00253
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 905.40091
-  tps: 1621.65144
+  dps: 884.23382
+  tps: 1582.03578
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 912.5784
-  tps: 1635.41365
+  dps: 891.36023
+  tps: 1595.70248
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 904.32611
-  tps: 1615.41183
+  dps: 889.80347
+  tps: 1588.09159
   dtps: 1288.19539
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 912.38799
-  tps: 1635.75486
+  dps: 894.1065
+  tps: 1601.15528
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 904.50723
-  tps: 1610.7371
+  dps: 884.52529
+  tps: 1573.95265
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 927.36841
-  tps: 1663.85051
+  dps: 905.54047
+  tps: 1622.98238
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 927.78674
-  tps: 1665.96082
+  dps: 907.20713
+  tps: 1627.01614
   dtps: 1306.38861
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 864.31341
-  tps: 1427.90108
+  dps: 846.20948
+  tps: 1393.44899
   dtps: 1853.62548
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThickDraenicArmor"
  value: {
-  dps: 906.55376
-  tps: 1601.65861
+  dps: 890.57102
+  tps: 1571.30712
   dtps: 1541.01632
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 939.62438
-  tps: 1687.41636
+  dps: 915.41209
+  tps: 1642.00253
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 913.36186
-  tps: 1635.88491
+  dps: 891.47249
+  tps: 1594.92483
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 912.4004
-  tps: 1626.19278
+  dps: 895.68072
+  tps: 1595.83305
   dtps: 1287.8636
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-UnitingCharm-25633"
  value: {
-  dps: 906.87914
-  tps: 1618.42504
+  dps: 885.79191
+  tps: 1578.95829
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 909.02615
-  tps: 1628.59214
+  dps: 887.92165
+  tps: 1589.09695
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofFortitude-33938"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofVengeance-33950"
  value: {
-  dps: 935.07248
-  tps: 1678.76774
+  dps: 911.37103
+  tps: 1634.32453
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 909.59666
-  tps: 1628.95106
+  dps: 887.93821
+  tps: 1588.41884
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WastewalkerArmor"
  value: {
-  dps: 907.74685
-  tps: 1590.31725
+  dps: 886.92408
+  tps: 1550.62933
   dtps: 1680.99401
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WhitemendWisdom"
  value: {
-  dps: 932.13431
-  tps: 1678.71426
+  dps: 912.28705
+  tps: 1641.36841
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WindhawkArmor"
  value: {
-  dps: 965.31927
-  tps: 1744.11308
+  dps: 940.17922
+  tps: 1695.71679
   dtps: 1568.72218
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 941.92767
-  tps: 1692.82471
+  dps: 920.6405
+  tps: 1653.49672
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofSpellfire"
  value: {
-  dps: 911.74207
-  tps: 1639.73404
+  dps: 889.7583
+  tps: 1597.99297
   dtps: 1578.32174
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 898.85602
-  tps: 1608.59739
+  dps: 875.61862
+  tps: 1565.5167
   dtps: 1305.00032
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 911.061
-  tps: 1632.49776
+  dps: 889.8945
+  tps: 1592.88476
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 936.79872
-  tps: 1681.28641
+  dps: 912.84118
+  tps: 1635.72558
   dtps: 1257.99916
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2549.8788
-  tps: 4495.05581
+  dps: 2435.09478
+  tps: 4277.32541
   dtps: 44358.6852
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 1004.26587
-  tps: 1775.34134
+  dps: 977.08934
+  tps: 1724.07814
   dtps: 1253.73335
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1133.50123
-  tps: 1986.41514
+  dps: 1104.92185
+  tps: 1933.96276
   dtps: 1325.75557
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2360.30508
-  tps: 5411.01099
+  dps: 2114.59694
+  tps: 4943.67728
   dtps: 46514.55637
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 433.25248
-  tps: 907.55302
+  dps: 416.2841
+  tps: 875.29591
   dtps: 2281.36763
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 454.97674
-  tps: 947.62509
+  dps: 439.64922
+  tps: 916.57819
   dtps: 2347.11751
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2576.7527
-  tps: 4528.2117
+  dps: 2472.61373
+  tps: 4330.92283
   dtps: 44367.41399
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 1022.46844
-  tps: 1802.5411
+  dps: 997.40012
+  tps: 1755.45164
   dtps: 1253.94098
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1156.66295
-  tps: 2020.19608
+  dps: 1129.44026
+  tps: 1970.0012
   dtps: 1325.97528
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2367.53475
-  tps: 5423.08781
+  dps: 2120.97623
+  tps: 4954.23471
   dtps: 46580.56953
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 435.53284
-  tps: 911.10339
+  dps: 418.66147
+  tps: 879.03059
   dtps: 2281.72218
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 456.63946
-  tps: 950.08675
+  dps: 441.22721
+  tps: 918.87886
   dtps: 2347.48218
  }
 }
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1004.26587
-  tps: 1775.34134
+  dps: 977.08934
+  tps: 1724.07814
   dtps: 1253.73335
  }
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -55,408 +55,408 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 907.54346
-  tps: 1618.65616
+  dps: 910.43369
+  tps: 1624.1476
   dtps: 1295.48097
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 893.96607
-  tps: 1600.05778
+  dps: 895.25729
+  tps: 1602.51109
   dtps: 1246.84747
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 938.63662
-  tps: 1685.5396
+  dps: 939.62438
+  tps: 1687.41636
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 899.25403
-  tps: 1609.85512
+  dps: 900.28275
+  tps: 1611.8097
   dtps: 1291.57463
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 896.79218
-  tps: 1602.69413
+  dps: 898.44684
+  tps: 1605.838
   dtps: 1202.47962
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 918.6048
-  tps: 1647.037
+  dps: 919.62649
+  tps: 1648.97822
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 908.086
-  tps: 1626.80585
+  dps: 909.02615
+  tps: 1628.59214
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 907.00693
-  tps: 1619.00873
+  dps: 908.16042
+  tps: 1621.20035
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Annihilator-12798"
  value: {
-  dps: 830.96104
-  tps: 1481.02118
+  dps: 832.76069
+  tps: 1484.44052
   dtps: 1306.2087
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 920.53634
-  tps: 1651.48801
+  dps: 921.52261
+  tps: 1653.36191
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 914.02486
-  tps: 1644.59943
+  dps: 914.45607
+  tps: 1645.41871
   dtps: 1518.66163
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 899.25403
-  tps: 1609.85529
+  dps: 900.28275
+  tps: 1611.80987
   dtps: 1291.43233
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 896.41196
-  tps: 1600.48215
+  dps: 898.03864
+  tps: 1603.57285
   dtps: 1224.69668
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 902.49734
-  tps: 1613.11738
+  dps: 903.52606
+  tps: 1615.07196
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 947.16147
-  tps: 1692.25873
+  dps: 949.00311
+  tps: 1695.75784
   dtps: 1303.57219
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 945.58606
-  tps: 1699.28773
+  dps: 947.45695
+  tps: 1702.84242
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 952.66401
-  tps: 1713.47263
+  dps: 954.55186
+  tps: 1717.05954
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 900.64436
-  tps: 1612.32557
+  dps: 901.69966
+  tps: 1614.33063
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BattlecastGarb"
  value: {
-  dps: 947.07062
-  tps: 1708.71161
+  dps: 948.40748
+  tps: 1711.25164
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 896.41007
-  tps: 1605.34063
+  dps: 898.4962
+  tps: 1609.30428
   dtps: 1296.09458
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 896.41007
-  tps: 1605.34063
+  dps: 898.4962
+  tps: 1609.30428
   dtps: 1296.09458
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 917.42977
-  tps: 1644.80608
+  dps: 918.49359
+  tps: 1646.82733
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 905.29213
-  tps: 1617.05871
+  dps: 906.52756
+  tps: 1619.40603
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 899.43234
-  tps: 1610.21287
+  dps: 900.46106
+  tps: 1612.16745
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 905.97958
-  tps: 1616.59963
+  dps: 907.0083
+  tps: 1618.5542
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 910.85557
-  tps: 1632.1711
+  dps: 911.90669
+  tps: 1634.16823
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 913.33859
-  tps: 1623.95864
+  dps: 914.36731
+  tps: 1625.91321
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 939.47255
-  tps: 1687.12307
+  dps: 940.45817
+  tps: 1688.99575
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 910.88467
-  tps: 1619.15776
+  dps: 912.87147
+  tps: 1622.93269
   dtps: 1288.02322
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 907.65401
-  tps: 1619.89207
+  dps: 908.8075
+  tps: 1622.0837
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 893.06443
-  tps: 1599.75033
+  dps: 894.86264
+  tps: 1603.16692
   dtps: 1308.24136
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Blinkstrike-31332"
  value: {
-  dps: 938.63662
-  tps: 1685.5396
+  dps: 939.62438
+  tps: 1687.41636
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 910.34061
-  tps: 1620.96066
+  dps: 911.36934
+  tps: 1622.91524
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 950.95748
-  tps: 1705.20098
+  dps: 952.77822
+  tps: 1708.66039
   dtps: 1335.7269
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 893.96607
-  tps: 1600.14324
+  dps: 895.25729
+  tps: 1602.59655
   dtps: 1259.82996
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofFortitude-35039"
  value: {
-  dps: 934.11085
-  tps: 1676.94065
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofVengeance-35041"
  value: {
-  dps: 934.11801
-  tps: 1676.95425
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 932.11218
-  tps: 1674.71214
+  dps: 933.82083
+  tps: 1677.95858
   dtps: 1222.58641
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 931.92226
-  tps: 1655.89049
+  dps: 934.23301
+  tps: 1660.28091
   dtps: 1294.27042
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 933.09711
-  tps: 1657.42426
+  dps: 935.19293
+  tps: 1661.40633
   dtps: 1284.01685
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BurningRage"
  value: {
-  dps: 925.1466
-  tps: 1626.45869
+  dps: 926.47306
+  tps: 1628.97897
   dtps: 1546.20737
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 948.52673
-  tps: 1705.51663
+  dps: 950.39502
+  tps: 1709.06638
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 897.30144
-  tps: 1606.37554
+  dps: 898.28241
+  tps: 1608.23938
   dtps: 1245.67488
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 930.4485
-  tps: 1670.85566
+  dps: 931.94035
+  tps: 1673.69018
   dtps: 1401.27151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CloudkeeperLegplates-14554"
  value: {
-  dps: 929.61862
-  tps: 1661.89001
+  dps: 930.8711
+  tps: 1664.26971
   dtps: 1349.43444
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 899.25403
-  tps: 1609.73139
+  dps: 900.28275
+  tps: 1611.68597
   dtps: 1275.54983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 907.24692
-  tps: 1617.86697
+  dps: 908.27565
+  tps: 1619.82155
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 927.86147
-  tps: 1665.13003
+  dps: 929.36894
+  tps: 1667.99422
   dtps: 1401.27151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeArmor"
  value: {
-  dps: 912.94208
-  tps: 1639.14848
+  dps: 914.21017
+  tps: 1641.55785
   dtps: 1290.08496
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeBattlegear"
  value: {
-  dps: 935.63459
-  tps: 1620.36762
+  dps: 936.8555
+  tps: 1622.68736
   dtps: 1405.86367
   hps: 1.16609
  }
@@ -464,272 +464,272 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 906.66486
-  tps: 1617.28491
+  dps: 907.69358
+  tps: 1619.23948
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 894.36642
-  tps: 1601.06976
+  dps: 895.83945
+  tps: 1603.86852
   dtps: 1260.07345
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 929.73768
-  tps: 1668.41988
+  dps: 930.75909
+  tps: 1670.36057
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 911.69724
-  tps: 1625.01625
+  dps: 912.72986
+  tps: 1626.97821
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 896.41143
-  tps: 1605.23845
+  dps: 897.64381
+  tps: 1607.57997
   dtps: 1276.55653
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 914.07359
-  tps: 1628.98748
+  dps: 915.30902
+  tps: 1631.3348
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DirebrewHops-38288"
  value: {
-  dps: 919.70752
-  tps: 1649.1865
+  dps: 920.94109
+  tps: 1651.53027
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DoomplateBattlegear"
  value: {
-  dps: 919.44163
-  tps: 1611.98919
+  dps: 921.91242
+  tps: 1616.68368
   dtps: 1619.08265
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 907.35444
-  tps: 1625.41595
+  dps: 908.3704
+  tps: 1627.34628
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonmaw-28438"
  value: {
-  dps: 904.56666
-  tps: 1560.33842
+  dps: 907.01183
+  tps: 1564.98424
   dtps: 1262.90409
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 909.71012
-  tps: 1620.13215
+  dps: 911.08327
+  tps: 1622.73108
   dtps: 1286.8966
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonstrike-28439"
  value: {
-  dps: 919.64307
-  tps: 1579.01576
+  dps: 921.24201
+  tps: 1582.05376
   dtps: 1264.15865
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 900.45925
-  tps: 1560.33879
+  dps: 901.66061
+  tps: 1562.62091
   dtps: 1282.27771
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 910.97029
-  tps: 1631.95152
+  dps: 912.07675
+  tps: 1634.05379
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Earthstrike-21180"
  value: {
-  dps: 904.32383
-  tps: 1614.94388
+  dps: 905.35255
+  tps: 1616.89845
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 900.05266
-  tps: 1610.01192
+  dps: 901.34597
+  tps: 1612.46921
   dtps: 1281.89069
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 910.34061
-  tps: 1620.96066
+  dps: 911.36934
+  tps: 1622.91524
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 937.29955
-  tps: 1682.35951
+  dps: 939.15551
+  tps: 1685.88584
   dtps: 1278.88702
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 939.38389
-  tps: 1655.57327
+  dps: 941.03253
+  tps: 1658.64304
   dtps: 1310.99362
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 930.90226
-  tps: 1702.64699
+  dps: 931.87509
+  tps: 1704.53235
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 927.30612
-  tps: 1660.16923
+  dps: 928.23278
+  tps: 1661.9299
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 916.88372
-  tps: 1637.98299
+  dps: 917.4804
+  tps: 1639.11055
   dtps: 1236.86721
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 927.66773
-  tps: 1660.3165
+  dps: 928.61847
+  tps: 1662.12292
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 922.91266
-  tps: 1648.66168
+  dps: 924.34752
+  tps: 1651.38792
   dtps: 1232.40893
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 919.70752
-  tps: 1649.1865
+  dps: 920.94109
+  tps: 1651.53027
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeofMoam-21473"
  value: {
-  dps: 902.34101
-  tps: 1615.80783
+  dps: 903.36945
+  tps: 1617.76187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 929.93483
-  tps: 1668.8068
+  dps: 931.27223
+  tps: 1671.34788
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 944.34962
-  tps: 1697.40801
+  dps: 946.11797
+  tps: 1700.76788
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelSkin"
  value: {
-  dps: 939.43397
-  tps: 1670.89723
+  dps: 942.13154
+  tps: 1676.0226
   dtps: 1591.51554
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelscaleArmor"
  value: {
-  dps: 905.33101
-  tps: 1595.2446
+  dps: 906.9179
+  tps: 1598.25968
   dtps: 1473.24399
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 889.89221
-  tps: 1592.8376
+  dps: 891.67329
+  tps: 1596.22165
   dtps: 1226.52683
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 887.90864
-  tps: 1589.16793
+  dps: 890.11615
+  tps: 1593.3622
   dtps: 1199.11718
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 906.10974
-  tps: 1616.72979
+  dps: 907.13846
+  tps: 1618.68436
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
   hps: 4.7
  }
@@ -737,704 +737,704 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ForceReactiveDisk-18168"
  value: {
-  dps: 937.82637
-  tps: 1684.58996
+  dps: 939.9988
+  tps: 1688.64211
   dtps: 1453.53081
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofFortitude-33936"
  value: {
-  dps: 934.11085
-  tps: 1676.94065
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofVengeance-33948"
  value: {
-  dps: 934.11801
-  tps: 1676.95425
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 918.6048
-  tps: 1647.037
+  dps: 919.62649
+  tps: 1648.97822
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 899.25403
-  tps: 1609.77614
+  dps: 900.28275
+  tps: 1611.73072
   dtps: 1280.69983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 899.25403
-  tps: 1609.73139
+  dps: 900.28275
+  tps: 1611.68597
   dtps: 1275.54983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HandofJustice-11815"
  value: {
-  dps: 911.84322
-  tps: 1629.47398
+  dps: 914.20864
+  tps: 1633.96827
   dtps: 1293.43818
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 896.80098
-  tps: 1604.69281
+  dps: 898.85602
+  tps: 1608.59739
   dtps: 1305.00032
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 905.64114
-  tps: 1621.53399
+  dps: 906.8675
+  tps: 1623.86406
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 938.61045
-  tps: 1685.45775
+  dps: 939.6251
+  tps: 1687.38557
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 908.71343
-  tps: 1628.02306
+  dps: 910.03484
+  tps: 1630.53375
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 906.31028
-  tps: 1618.07686
+  dps: 907.54571
+  tps: 1620.42418
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IceGuard-2682"
  value: {
-  dps: 939.63191
-  tps: 1688.29176
+  dps: 941.93254
+  tps: 1692.66294
   dtps: 1312.25995
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 906.64314
-  tps: 1617.00366
+  dps: 907.32221
+  tps: 1618.29389
   dtps: 1283.53082
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImbuedNetherweave"
  value: {
-  dps: 935.56966
-  tps: 1685.91366
+  dps: 936.02821
+  tps: 1686.7849
   dtps: 1573.5504
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JomGabbar-23570"
  value: {
-  dps: 905.43763
-  tps: 1616.05767
+  dps: 906.46635
+  tps: 1618.01225
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarArmor"
  value: {
-  dps: 925.15314
-  tps: 1660.79203
+  dps: 927.36711
+  tps: 1664.99858
   dtps: 1329.87036
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarBattlegear"
  value: {
-  dps: 924.958
-  tps: 1611.5644
+  dps: 926.5438
+  tps: 1614.57742
   dtps: 1461.81743
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumScope-2723"
  value: {
-  dps: 938.63662
-  tps: 1685.5396
+  dps: 939.62438
+  tps: 1687.41636
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumWard"
  value: {
-  dps: 961.49204
-  tps: 1735.83802
+  dps: 962.57045
+  tps: 1737.88701
   dtps: 1484.42037
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 908.33867
-  tps: 1623.75934
+  dps: 909.7834
+  tps: 1626.50433
   dtps: 1293.10578
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofAvengement-27484"
  value: {
-  dps: 939.29945
-  tps: 1683.71185
+  dps: 940.47189
+  tps: 1685.93947
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 934.11085
-  tps: 1676.94065
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivinePurpose-33504"
  value: {
-  dps: 955.82927
-  tps: 1718.20564
+  dps: 956.82786
+  tps: 1720.10296
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofFervor-23203"
  value: {
-  dps: 934.11085
-  tps: 1676.94065
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofHope-22401"
  value: {
-  dps: 934.11085
-  tps: 1676.21183
+  dps: 935.07248
+  tps: 1678.03892
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRepentance-29388"
  value: {
-  dps: 934.11085
-  tps: 1676.94065
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRighteousPower-31033"
  value: {
-  dps: 934.11085
-  tps: 1676.94065
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofWracking-28065"
  value: {
-  dps: 934.11085
-  tps: 1676.94065
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27949"
  value: {
-  dps: 934.11085
-  tps: 1676.94065
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27983"
  value: {
-  dps: 934.11085
-  tps: 1676.94065
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerArmor"
  value: {
-  dps: 956.23623
-  tps: 1718.91785
+  dps: 957.51163
+  tps: 1721.3411
   dtps: 1061.24395
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1051.49107
-  tps: 1763.72564
+  dps: 1052.81049
+  tps: 1766.23253
   dtps: 1700.06334
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 912.68641
-  tps: 1624.48427
+  dps: 913.25885
+  tps: 1625.57191
   dtps: 1281.99271
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 916.84414
-  tps: 1656.99351
+  dps: 917.1786
+  tps: 1657.62898
   dtps: 1955.39544
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 922.68731
-  tps: 1656.56136
+  dps: 924.3012
+  tps: 1659.62776
   dtps: 1379.27527
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 913.56259
-  tps: 1636.60828
+  dps: 914.61894
+  tps: 1638.61534
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofFortitude-33937"
  value: {
-  dps: 934.11085
-  tps: 1676.94065
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofVengeance-33949"
  value: {
-  dps: 934.11801
-  tps: 1676.95425
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 897.26932
-  tps: 1605.62219
+  dps: 898.89081
+  tps: 1608.70302
   dtps: 1295.58137
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 885.93396
-  tps: 1586.58829
+  dps: 887.26319
+  tps: 1589.11382
   dtps: 1194.67222
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 904.33069
-  tps: 1620.22383
+  dps: 905.35942
+  tps: 1622.17841
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 910.27853
-  tps: 1631.02538
+  dps: 911.28463
+  tps: 1632.93699
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherscaleArmor"
  value: {
-  dps: 949.62824
-  tps: 1689.0055
+  dps: 950.42225
+  tps: 1690.51412
   dtps: 1509.65126
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherstrikeArmor"
  value: {
-  dps: 961.76642
-  tps: 1736.31965
+  dps: 962.98873
+  tps: 1738.64204
   dtps: 1511.76151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherweaveVestments"
  value: {
-  dps: 963.35654
-  tps: 1746.21629
+  dps: 965.30148
+  tps: 1749.91167
   dtps: 2069.19023
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 905.85042
-  tps: 1616.47046
+  dps: 906.87914
+  tps: 1618.42504
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 913.11801
-  tps: 1636.5213
+  dps: 914.29209
+  tps: 1638.75205
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 941.94181
-  tps: 1692.51257
+  dps: 943.70559
+  tps: 1695.86376
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 941.94181
-  tps: 1692.51257
+  dps: 943.70559
+  tps: 1695.86376
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofThawing-24093"
  value: {
-  dps: 941.94181
-  tps: 1692.51257
+  dps: 943.70559
+  tps: 1695.86376
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofWithering-24095"
  value: {
-  dps: 941.94181
-  tps: 1692.51257
+  dps: 943.70559
+  tps: 1695.86376
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 941.94181
-  tps: 1692.51257
+  dps: 943.70559
+  tps: 1695.86376
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 899.43234
-  tps: 1609.42908
+  dps: 900.46106
+  tps: 1611.38366
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalIntent"
  value: {
-  dps: 951.85079
-  tps: 1679.47461
+  dps: 954.25939
+  tps: 1684.05094
   dtps: 1458.1094
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalMooncloth"
  value: {
-  dps: 947.01531
-  tps: 1706.61991
+  dps: 948.296
+  tps: 1709.05323
   dtps: 1606.88095
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Prismcharm-15867"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 907.32493
-  tps: 1626.22489
+  dps: 909.43683
+  tps: 1630.23749
   dtps: 1285.83994
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 896.56132
-  tps: 1606.53947
+  dps: 897.6699
+  tps: 1608.64579
   dtps: 1301.79137
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 895.34931
-  tps: 1603.09112
+  dps: 896.69304
+  tps: 1605.6442
   dtps: 1260.67102
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 931.5913
-  tps: 1673.6497
+  dps: 933.2029
+  tps: 1676.71173
   dtps: 1379.27527
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 938.63662
-  tps: 1685.5396
+  dps: 939.62438
+  tps: 1687.41636
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 920.62931
-  tps: 1636.47967
+  dps: 922.57874
+  tps: 1640.07643
   dtps: 1290.34989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RuneofForce-25994"
  value: {
-  dps: 900.91525
-  tps: 1611.5353
+  dps: 901.94398
+  tps: 1613.48988
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SavageGuard-2681"
  value: {
-  dps: 939.63191
-  tps: 1688.29176
+  dps: 941.93254
+  tps: 1692.66294
   dtps: 1312.25995
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 893.39002
-  tps: 1601.18829
+  dps: 894.96179
+  tps: 1604.17465
   dtps: 1241.83006
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 908.53526
-  tps: 1627.7117
+  dps: 909.5819
+  tps: 1629.70032
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 901.08379
-  tps: 1612.06139
+  dps: 903.4094
+  tps: 1616.48004
   dtps: 1282.29274
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 916.64029
-  tps: 1644.14788
+  dps: 917.57878
+  tps: 1645.93102
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 914.60727
-  tps: 1639.35942
+  dps: 915.53931
+  tps: 1641.1303
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 902.70427
-  tps: 1623.18008
+  dps: 903.07627
+  tps: 1623.88689
   dtps: 1552.52139
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 891.19835
-  tps: 1594.68859
+  dps: 891.95954
+  tps: 1596.13485
   dtps: 1220.28564
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShardofContempt-34472"
  value: {
-  dps: 930.87419
-  tps: 1649.72193
+  dps: 932.08539
+  tps: 1652.0232
   dtps: 1286.42927
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 901.91237
-  tps: 1614.97895
+  dps: 902.9516
+  tps: 1616.95348
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 916.38564
-  tps: 1642.89875
+  dps: 918.64701
+  tps: 1647.19535
   dtps: 1294.99466
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SkullflameShield-1168"
  value: {
-  dps: 949.00557
-  tps: 1698.88687
+  dps: 949.58682
+  tps: 1700.04521
   dtps: 1473.80805
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 909.34214
-  tps: 1619.96219
+  dps: 910.37087
+  tps: 1621.91677
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SoulclothEmbrace"
  value: {
-  dps: 886.53138
-  tps: 1592.47259
+  dps: 886.88109
+  tps: 1593.13703
   dtps: 1556.20338
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 952.9426
-  tps: 1721.35126
+  dps: 954.27096
+  tps: 1723.87514
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 899.25403
-  tps: 1609.87408
+  dps: 900.28275
+  tps: 1611.82865
   dtps: 1294.28455
   hps: 15.16667
  }
@@ -1442,360 +1442,360 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 939.96875
-  tps: 1688.07065
+  dps: 941.16732
+  tps: 1690.34794
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 914.51256
-  tps: 1639.91051
+  dps: 915.45244
+  tps: 1641.69627
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 904.50263
-  tps: 1619.93143
+  dps: 905.51533
+  tps: 1621.85557
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 931.58357
-  tps: 1654.24644
+  dps: 933.1897
+  tps: 1657.29809
   dtps: 1261.67544
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 892.99709
-  tps: 1600.96376
+  dps: 894.08731
+  tps: 1603.03517
   dtps: 1460.21448
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 940.318
-  tps: 1687.22098
+  dps: 941.30577
+  tps: 1689.09775
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 938.63662
-  tps: 1685.5396
+  dps: 939.62438
+  tps: 1687.41636
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 904.38328
-  tps: 1619.71794
+  dps: 905.40091
+  tps: 1621.65144
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 911.64129
-  tps: 1633.63313
+  dps: 912.5784
+  tps: 1635.41365
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 903.4199
-  tps: 1613.69003
+  dps: 904.32611
+  tps: 1615.41183
   dtps: 1288.19539
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 911.44585
-  tps: 1633.9648
+  dps: 912.38799
+  tps: 1635.75486
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 901.76746
-  tps: 1605.20189
+  dps: 904.50723
+  tps: 1610.7371
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 926.34288
-  tps: 1661.90199
+  dps: 927.36841
+  tps: 1663.85051
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 927.28404
-  tps: 1665.00568
+  dps: 927.78674
+  tps: 1665.96082
   dtps: 1306.38861
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 862.61522
-  tps: 1424.67454
+  dps: 864.31341
+  tps: 1427.90108
   dtps: 1853.62548
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThickDraenicArmor"
  value: {
-  dps: 904.2638
-  tps: 1597.3077
+  dps: 906.55376
+  tps: 1601.65861
   dtps: 1541.01632
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 938.63662
-  tps: 1685.5396
+  dps: 939.62438
+  tps: 1687.41636
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 912.08788
-  tps: 1633.46436
+  dps: 913.36186
+  tps: 1635.88491
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 911.64402
-  tps: 1624.75566
+  dps: 912.4004
+  tps: 1626.19278
   dtps: 1287.8636
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-UnitingCharm-25633"
  value: {
-  dps: 905.85042
-  tps: 1616.47046
+  dps: 906.87914
+  tps: 1618.42504
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 908.086
-  tps: 1626.80585
+  dps: 909.02615
+  tps: 1628.59214
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofFortitude-33938"
  value: {
-  dps: 934.11085
-  tps: 1676.94065
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofVengeance-33950"
  value: {
-  dps: 934.11801
-  tps: 1676.95425
+  dps: 935.07248
+  tps: 1678.76774
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 908.39329
-  tps: 1626.66465
+  dps: 909.59666
+  tps: 1628.95106
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WastewalkerArmor"
  value: {
-  dps: 906.32874
-  tps: 1587.62284
+  dps: 907.74685
+  tps: 1590.31725
   dtps: 1680.99401
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WhitemendWisdom"
  value: {
-  dps: 930.82467
-  tps: 1676.22595
+  dps: 932.13431
+  tps: 1678.71426
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WindhawkArmor"
  value: {
-  dps: 964.09263
-  tps: 1741.78246
+  dps: 965.31927
+  tps: 1744.11308
   dtps: 1568.72218
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 940.09651
-  tps: 1689.3455
+  dps: 941.92767
+  tps: 1692.82471
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofSpellfire"
  value: {
-  dps: 911.03767
-  tps: 1638.39568
+  dps: 911.74207
+  tps: 1639.73404
   dtps: 1578.32174
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 896.80098
-  tps: 1604.69281
+  dps: 898.85602
+  tps: 1608.59739
   dtps: 1305.00032
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 910.12251
-  tps: 1630.71462
+  dps: 911.061
+  tps: 1632.49776
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 934.80315
-  tps: 1677.49482
+  dps: 936.79872
+  tps: 1681.28641
   dtps: 1257.99916
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2549.89582
-  tps: 4495.08814
+  dps: 2549.8788
+  tps: 4495.05581
   dtps: 44358.6852
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 1003.09262
-  tps: 1773.11215
+  dps: 1004.26587
+  tps: 1775.34134
   dtps: 1253.73335
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1125.52354
-  tps: 1971.25751
+  dps: 1133.50123
+  tps: 1986.41514
   dtps: 1325.75557
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2351.76967
-  tps: 5394.79371
+  dps: 2360.30508
+  tps: 5411.01099
   dtps: 46514.55637
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 433.3805
-  tps: 907.79626
+  dps: 433.25248
+  tps: 907.55302
   dtps: 2281.36763
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 452.96879
-  tps: 943.80998
+  dps: 454.97674
+  tps: 947.62509
   dtps: 2347.11751
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2576.55475
-  tps: 4527.83561
+  dps: 2576.7527
+  tps: 4528.2117
   dtps: 44367.41399
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 1020.99353
-  tps: 1799.73879
+  dps: 1022.46844
+  tps: 1802.5411
   dtps: 1253.94098
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1150.33483
-  tps: 2008.17265
+  dps: 1156.66295
+  tps: 2020.19608
   dtps: 1325.97528
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2358.98936
-  tps: 5406.85156
+  dps: 2367.53475
+  tps: 5423.08781
   dtps: 46580.56953
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 435.47783
-  tps: 910.99887
+  dps: 435.53284
+  tps: 911.10339
   dtps: 2281.72218
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 454.66332
-  tps: 946.33208
+  dps: 456.63946
+  tps: 950.08675
   dtps: 2347.48218
  }
 }
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1003.09262
-  tps: 1773.11215
+  dps: 1004.26587
+  tps: 1775.34134
   dtps: 1253.73335
  }
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -55,408 +55,408 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 890.90021
-  tps: 1588.10676
+  dps: 890.75914
+  tps: 1587.55867
   dtps: 1295.48097
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 875.58312
-  tps: 1566.25672
+  dps: 876.31076
+  tps: 1566.98187
   dtps: 1246.84747
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 915.41209
-  tps: 1642.00253
+  dps: 921.56171
+  tps: 1653.87612
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 879.19553
-  tps: 1572.34295
+  dps: 880.16453
+  tps: 1574.26244
   dtps: 1291.57463
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 875.77266
-  tps: 1564.0402
+  dps: 875.59119
+  tps: 1564.08145
   dtps: 1202.47962
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 898.02242
-  tps: 1608.53334
+  dps: 898.96614
+  tps: 1610.39875
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 887.92165
-  tps: 1589.09695
+  dps: 888.62883
+  tps: 1590.49922
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 887.30394
-  tps: 1582.1764
+  dps: 888.06834
+  tps: 1583.69246
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Annihilator-12798"
  value: {
-  dps: 811.1422
-  tps: 1443.79747
+  dps: 815.28597
+  tps: 1451.5861
   dtps: 1306.2087
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 903.62632
-  tps: 1619.62655
+  dps: 905.04696
+  tps: 1622.34944
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 896.86924
-  tps: 1611.97682
+  dps: 897.94173
+  tps: 1614.79491
   dtps: 1518.66163
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 879.19553
-  tps: 1572.34312
+  dps: 880.16453
+  tps: 1574.25291
   dtps: 1291.43233
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 874.58975
-  tps: 1559.28551
+  dps: 875.70047
+  tps: 1562.13434
   dtps: 1224.69668
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 882.43884
-  tps: 1575.60521
+  dps: 883.40784
+  tps: 1577.51221
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 925.71016
-  tps: 1652.32648
+  dps: 929.0604
+  tps: 1659.01369
   dtps: 1303.57219
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 926.36208
-  tps: 1663.90015
+  dps: 928.207
+  tps: 1667.24365
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 932.98257
-  tps: 1677.20897
+  dps: 934.15736
+  tps: 1679.27359
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 880.52553
-  tps: 1574.70119
+  dps: 881.5145
+  tps: 1576.68041
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BattlecastGarb"
  value: {
-  dps: 928.12945
-  tps: 1673.08645
+  dps: 927.65471
+  tps: 1672.80689
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 876.14274
-  tps: 1567.43315
+  dps: 878.71609
+  tps: 1572.08213
   dtps: 1296.09458
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 876.14274
-  tps: 1567.43315
+  dps: 878.71609
+  tps: 1572.08213
   dtps: 1296.09458
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 896.81322
-  tps: 1606.24064
+  dps: 897.811
+  tps: 1608.20067
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 885.44034
-  tps: 1579.93928
+  dps: 886.40934
+  tps: 1581.84628
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 879.37384
-  tps: 1572.7007
+  dps: 880.34284
+  tps: 1574.6077
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 885.92108
-  tps: 1579.08745
+  dps: 886.89008
+  tps: 1580.99446
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 890.44086
-  tps: 1593.98663
+  dps: 891.42823
+  tps: 1595.92748
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 893.28009
-  tps: 1586.44646
+  dps: 894.24909
+  tps: 1588.35347
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 916.24587
-  tps: 1643.58192
+  dps: 922.39319
+  tps: 1655.45114
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 898.69901
-  tps: 1596.8699
+  dps: 898.30877
+  tps: 1595.8247
   dtps: 1288.02322
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 887.95102
-  tps: 1583.05974
+  dps: 888.71542
+  tps: 1584.5758
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 872.26726
-  tps: 1561.05833
+  dps: 877.3219
+  tps: 1571.42482
   dtps: 1308.24136
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Blinkstrike-31332"
  value: {
-  dps: 915.41209
-  tps: 1642.00253
+  dps: 921.56171
+  tps: 1653.87612
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 890.28211
-  tps: 1583.44849
+  dps: 891.25111
+  tps: 1585.35549
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 930.36028
-  tps: 1667.20101
+  dps: 934.22168
+  tps: 1674.64838
   dtps: 1335.7269
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 875.58312
-  tps: 1566.35028
+  dps: 876.31076
+  tps: 1567.06957
   dtps: 1259.82996
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofFortitude-35039"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.5121
+  tps: 1646.18187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofVengeance-35041"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.50494
+  tps: 1646.16826
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 910.65862
-  tps: 1635.01039
+  dps: 915.47028
+  tps: 1644.20008
   dtps: 1222.58641
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 916.26395
-  tps: 1626.97029
+  dps: 919.61384
+  tps: 1633.55175
   dtps: 1294.27042
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 915.49919
-  tps: 1624.44332
+  dps: 920.77202
+  tps: 1635.08405
   dtps: 1284.01685
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BurningRage"
  value: {
-  dps: 904.97883
-  tps: 1588.04853
+  dps: 909.6118
+  tps: 1597.78461
   dtps: 1546.20737
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 928.82101
-  tps: 1669.20291
+  dps: 930.19886
+  tps: 1671.65167
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 870.59924
-  tps: 1555.86087
+  dps: 876.00373
+  tps: 1566.26049
   dtps: 1245.67488
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 911.28861
-  tps: 1635.56772
+  dps: 914.90753
+  tps: 1642.86831
   dtps: 1401.27151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CloudkeeperLegplates-14554"
  value: {
-  dps: 909.13531
-  tps: 1623.61503
+  dps: 912.26521
+  tps: 1629.8492
   dtps: 1349.43444
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 879.19553
-  tps: 1572.23449
+  dps: 880.16453
+  tps: 1574.13975
   dtps: 1275.54983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 887.18842
-  tps: 1580.3548
+  dps: 888.15742
+  tps: 1582.2618
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 908.53576
-  tps: 1629.51127
+  dps: 910.66146
+  tps: 1633.79376
   dtps: 1401.27151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeArmor"
  value: {
-  dps: 894.42338
-  tps: 1604.52511
+  dps: 894.38057
+  tps: 1605.11418
   dtps: 1290.08496
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeBattlegear"
  value: {
-  dps: 917.60323
-  tps: 1586.56173
+  dps: 915.73935
+  tps: 1583.49678
   dtps: 1405.86367
   hps: 1.16609
  }
@@ -464,272 +464,272 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 886.60636
-  tps: 1579.77273
+  dps: 887.57536
+  tps: 1581.67973
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 877.01131
-  tps: 1569.49992
+  dps: 876.1932
+  tps: 1567.19063
   dtps: 1260.07345
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 908.84792
-  tps: 1629.33476
+  dps: 909.78186
+  tps: 1631.18456
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 891.50251
-  tps: 1587.24541
+  dps: 906.43096
+  tps: 1616.00408
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 875.09629
-  tps: 1565.79818
+  dps: 876.66757
+  tps: 1568.33791
   dtps: 1276.55653
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 894.59055
-  tps: 1592.55737
+  dps: 896.89001
+  tps: 1596.74295
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DirebrewHops-38288"
  value: {
-  dps: 898.89889
-  tps: 1610.2611
+  dps: 900.02326
+  tps: 1612.46441
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DoomplateBattlegear"
  value: {
-  dps: 898.90184
-  tps: 1574.76306
+  dps: 904.94632
+  tps: 1585.59442
   dtps: 1619.08265
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 887.28448
-  tps: 1587.89613
+  dps: 888.2164
+  tps: 1589.73127
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonmaw-28438"
  value: {
-  dps: 888.9699
-  tps: 1530.41816
+  dps: 893.1961
+  tps: 1539.75777
   dtps: 1262.90409
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 888.93214
-  tps: 1580.93095
+  dps: 892.58855
+  tps: 1589.31151
   dtps: 1286.8966
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonstrike-28439"
  value: {
-  dps: 898.60185
-  tps: 1539.91834
+  dps: 903.84303
+  tps: 1550.8006
   dtps: 1264.15865
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 883.78334
-  tps: 1528.90971
+  dps: 887.29746
+  tps: 1536.49783
   dtps: 1282.27771
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 890.51135
-  tps: 1593.69209
+  dps: 891.53989
+  tps: 1595.76174
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Earthstrike-21180"
  value: {
-  dps: 884.26533
-  tps: 1577.4317
+  dps: 885.23433
+  tps: 1579.33871
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 880.66581
-  tps: 1573.29406
+  dps: 881.90925
+  tps: 1576.37281
   dtps: 1281.89069
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 890.28211
-  tps: 1583.44849
+  dps: 891.25111
+  tps: 1585.35549
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 915.00982
-  tps: 1640.84916
+  dps: 921.02341
+  tps: 1651.62698
   dtps: 1278.88702
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 917.42871
-  tps: 1615.39189
+  dps: 921.26171
+  tps: 1622.99859
   dtps: 1310.99362
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 907.9152
-  tps: 1658.6961
+  dps: 914.05257
+  tps: 1670.78022
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 904.50779
-  tps: 1617.43597
+  dps: 910.70416
+  tps: 1629.39979
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 893.56054
-  tps: 1593.33087
-  dtps: 1236.86721
+  dps: 897.41551
+  tps: 1601.42716
+  dtps: 1227.25598
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 904.91098
-  tps: 1617.66222
+  dps: 911.02895
+  tps: 1629.47709
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 905.16014
-  tps: 1615.48319
+  dps: 910.24358
+  tps: 1626.42778
   dtps: 1232.40893
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 898.89889
-  tps: 1610.2611
+  dps: 900.02326
+  tps: 1612.46441
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeofMoam-21473"
  value: {
-  dps: 882.26861
-  tps: 1578.27206
+  dps: 883.20069
+  tps: 1580.11104
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 908.81546
-  tps: 1629.30292
+  dps: 909.79795
+  tps: 1631.23575
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 925.89975
-  tps: 1664.10189
+  dps: 927.57107
+  tps: 1666.87925
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelSkin"
  value: {
-  dps: 922.1434
-  tps: 1638.39591
+  dps: 920.28305
+  tps: 1635.46286
   dtps: 1591.51554
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelscaleArmor"
  value: {
-  dps: 885.17947
-  tps: 1557.94471
+  dps: 891.39229
+  tps: 1569.10901
   dtps: 1473.24399
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 871.72001
-  tps: 1558.40599
+  dps: 868.32755
+  tps: 1552.27841
   dtps: 1226.52683
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 868.19749
-  tps: 1551.46692
+  dps: 864.08711
+  tps: 1544.5025
   dtps: 1199.11718
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 886.05124
-  tps: 1579.21761
+  dps: 887.02024
+  tps: 1581.12462
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
   hps: 4.7
  }
@@ -737,704 +737,704 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ForceReactiveDisk-18168"
  value: {
-  dps: 915.48803
-  tps: 1642.47232
+  dps: 922.42419
+  tps: 1655.8315
   dtps: 1453.53081
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofFortitude-33936"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.5121
+  tps: 1646.18187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofVengeance-33948"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.50494
+  tps: 1646.16826
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 898.02242
-  tps: 1608.53334
+  dps: 898.96614
+  tps: 1610.39875
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 879.19553
-  tps: 1572.27461
+  dps: 880.16453
+  tps: 1574.17372
   dtps: 1280.69983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 879.19553
-  tps: 1572.23449
+  dps: 880.16453
+  tps: 1574.13975
   dtps: 1275.54983
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HandofJustice-11815"
  value: {
-  dps: 893.08523
-  tps: 1593.95039
+  dps: 890.34269
+  tps: 1589.81094
   dtps: 1293.43818
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 875.61862
-  tps: 1565.5167
+  dps: 879.07754
+  tps: 1572.27514
   dtps: 1305.00032
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 885.58562
-  tps: 1584.03764
+  dps: 886.48273
+  tps: 1585.77301
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 917.4861
-  tps: 1645.92839
+  dps: 918.40397
+  tps: 1647.75128
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 888.65933
-  tps: 1590.52752
+  dps: 889.52186
+  tps: 1592.23156
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 886.45848
-  tps: 1580.95743
+  dps: 887.42748
+  tps: 1582.86443
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IceGuard-2682"
  value: {
-  dps: 921.22483
-  tps: 1654.23485
+  dps: 921.99593
+  tps: 1655.8546
   dtps: 1312.25995
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 890.55024
-  tps: 1586.54603
+  dps: 890.03718
+  tps: 1585.68156
   dtps: 1283.53082
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImbuedNetherweave"
  value: {
-  dps: 915.14506
-  tps: 1647.11333
+  dps: 913.49434
+  tps: 1644.78864
   dtps: 1573.5504
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JomGabbar-23570"
  value: {
-  dps: 885.37913
-  tps: 1578.5455
+  dps: 886.34813
+  tps: 1580.4525
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarArmor"
  value: {
-  dps: 905.33084
-  tps: 1623.98798
+  dps: 909.54423
+  tps: 1632.3982
   dtps: 1329.87036
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarBattlegear"
  value: {
-  dps: 908.64982
-  tps: 1580.9022
+  dps: 908.26573
+  tps: 1581.26604
   dtps: 1461.81743
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumScope-2723"
  value: {
-  dps: 915.41209
-  tps: 1642.00253
+  dps: 921.56171
+  tps: 1653.87612
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumWard"
  value: {
-  dps: 940.10342
-  tps: 1694.46385
+  dps: 944.62569
+  tps: 1705.76752
   dtps: 1484.42037
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 888.16315
-  tps: 1586.31036
+  dps: 888.51613
+  tps: 1587.08838
   dtps: 1293.10578
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofAvengement-27484"
  value: {
-  dps: 916.81045
-  tps: 1641.57228
+  dps: 922.95152
+  tps: 1653.42962
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.5121
+  tps: 1646.18187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivinePurpose-33504"
  value: {
-  dps: 933.19544
-  tps: 1675.7909
+  dps: 939.37768
+  tps: 1687.72647
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofFervor-23203"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.5121
+  tps: 1646.18187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofHope-22401"
  value: {
-  dps: 911.37103
-  tps: 1633.59672
+  dps: 917.5121
+  tps: 1645.42218
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRepentance-29388"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.5121
+  tps: 1646.18187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRighteousPower-31033"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.5121
+  tps: 1646.18187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofWracking-28065"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.5121
+  tps: 1646.18187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27949"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.5121
+  tps: 1646.18187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27983"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.5121
+  tps: 1646.18187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerArmor"
  value: {
-  dps: 924.02949
-  tps: 1658.5225
+  dps: 929.5124
+  tps: 1669.12532
   dtps: 1061.24395
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1034.07761
-  tps: 1730.70766
+  dps: 1039.5731
+  tps: 1741.27521
   dtps: 1700.06334
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 898.69486
-  tps: 1597.97459
+  dps: 898.78825
+  tps: 1599.20135
   dtps: 1281.99271
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 899.02097
-  tps: 1623.18659
+  dps: 904.58329
+  tps: 1635.6361
   dtps: 1955.39544
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 900.74343
-  tps: 1615.60674
+  dps: 904.72669
+  tps: 1623.58694
   dtps: 1379.27527
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 893.06477
-  tps: 1598.26109
+  dps: 894.05643
+  tps: 1600.19505
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofFortitude-33937"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.5121
+  tps: 1646.18187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofVengeance-33949"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.50494
+  tps: 1646.16826
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 876.64635
-  tps: 1567.28033
+  dps: 877.85714
+  tps: 1569.809
   dtps: 1295.58137
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 862.05812
-  tps: 1541.69414
+  dps: 865.60727
+  tps: 1548.79729
   dtps: 1194.67222
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 888.57159
-  tps: 1590.6922
+  dps: 889.55881
+  tps: 1592.64915
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 890.2169
-  tps: 1593.51785
+  dps: 890.95647
+  tps: 1594.99247
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherscaleArmor"
  value: {
-  dps: 933.19665
-  tps: 1657.70408
+  dps: 931.90544
+  tps: 1656.94519
   dtps: 1509.65126
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherstrikeArmor"
  value: {
-  dps: 937.93203
-  tps: 1690.40568
+  dps: 941.19839
+  tps: 1699.52105
   dtps: 1511.76151
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherweaveVestments"
  value: {
-  dps: 939.27109
-  tps: 1700.85085
+  dps: 943.0307
+  tps: 1708.52784
   dtps: 2069.19023
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 885.79191
-  tps: 1578.95829
+  dps: 886.76092
+  tps: 1580.86529
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 892.54625
-  tps: 1598.04224
+  dps: 893.6254
+  tps: 1600.1594
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 921.04686
-  tps: 1654.54698
+  dps: 923.51502
+  tps: 1658.65152
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 921.04686
-  tps: 1654.54698
+  dps: 923.51502
+  tps: 1658.65152
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofThawing-24093"
  value: {
-  dps: 921.04686
-  tps: 1654.54698
+  dps: 923.51502
+  tps: 1658.65152
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofWithering-24095"
  value: {
-  dps: 921.04686
-  tps: 1654.54698
+  dps: 923.51502
+  tps: 1658.65152
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 921.04686
-  tps: 1654.54698
+  dps: 923.51502
+  tps: 1658.65152
   dtps: 1323.58974
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 879.37384
-  tps: 1571.91195
+  dps: 880.34284
+  tps: 1573.84678
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalIntent"
  value: {
-  dps: 935.75339
-  tps: 1649.74553
+  dps: 935.21538
+  tps: 1648.32809
   dtps: 1458.1094
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalMooncloth"
  value: {
-  dps: 926.93477
-  tps: 1668.05645
+  dps: 929.23109
+  tps: 1674.68452
   dtps: 1606.88095
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Prismcharm-15867"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 890.22397
-  tps: 1594.77505
+  dps: 893.29774
+  tps: 1600.90439
   dtps: 1285.83994
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 878.60205
-  tps: 1572.94683
+  dps: 878.38657
+  tps: 1572.87637
   dtps: 1301.79137
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 875.34085
-  tps: 1566.29715
+  dps: 876.42152
+  tps: 1567.27392
   dtps: 1260.67102
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 909.68973
-  tps: 1632.76696
+  dps: 913.08971
+  tps: 1639.64196
   dtps: 1379.27527
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 915.41209
-  tps: 1642.00253
+  dps: 921.56171
+  tps: 1653.87612
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 900.30886
-  tps: 1597.42188
+  dps: 897.8816
+  tps: 1592.04162
   dtps: 1290.34989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RuneofForce-25994"
  value: {
-  dps: 880.85675
-  tps: 1574.02313
+  dps: 881.82575
+  tps: 1575.93013
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SavageGuard-2681"
  value: {
-  dps: 921.22483
-  tps: 1654.23485
+  dps: 921.99593
+  tps: 1655.8546
   dtps: 1312.25995
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 868.06952
-  tps: 1553.66972
+  dps: 872.8652
+  tps: 1562.89316
   dtps: 1241.83006
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 888.1918
-  tps: 1589.66169
+  dps: 889.17549
+  tps: 1591.59576
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 882.31443
-  tps: 1576.33083
+  dps: 885.45184
+  tps: 1583.98318
   dtps: 1282.29274
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 901.51885
-  tps: 1615.59346
+  dps: 903.28438
+  tps: 1619.03328
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 893.84979
-  tps: 1600.51919
+  dps: 894.83856
+  tps: 1602.47609
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 883.41362
-  tps: 1586.64555
+  dps: 882.03865
+  tps: 1584.77388
   dtps: 1552.52139
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 866.55205
-  tps: 1548.75423
+  dps: 870.04216
+  tps: 1556.06555
   dtps: 1220.28564
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShardofContempt-34472"
  value: {
-  dps: 910.86674
-  tps: 1611.99646
+  dps: 910.72043
+  tps: 1611.95152
   dtps: 1286.42927
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 881.7499
-  tps: 1577.25969
+  dps: 882.91612
+  tps: 1579.56366
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 897.25078
-  tps: 1607.05198
+  dps: 899.18727
+  tps: 1611.08929
   dtps: 1294.99466
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SkullflameShield-1168"
  value: {
-  dps: 926.40314
-  tps: 1657.60288
+  dps: 925.07693
+  tps: 1654.98052
   dtps: 1473.80805
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 889.28364
-  tps: 1582.45002
+  dps: 890.25264
+  tps: 1584.35702
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SoulclothEmbrace"
  value: {
-  dps: 870.36135
-  tps: 1561.84292
+  dps: 871.28408
+  tps: 1564.27663
   dtps: 1556.20338
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 938.54564
-  tps: 1694.24965
+  dps: 940.86898
+  tps: 1698.74337
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 879.19553
-  tps: 1572.3619
+  dps: 880.16453
+  tps: 1574.26891
   dtps: 1294.28455
   hps: 15.16667
  }
@@ -1442,360 +1442,360 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 916.96922
-  tps: 1644.96109
+  dps: 923.11885
+  tps: 1656.83468
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 897.91603
-  tps: 1608.63564
+  dps: 899.6768
+  tps: 1612.04855
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 884.30648
-  tps: 1582.1597
+  dps: 885.22689
+  tps: 1583.97537
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 911.35644
-  tps: 1616.10529
+  dps: 912.58766
+  tps: 1618.15918
   dtps: 1261.67544
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 871.63347
-  tps: 1560.95018
+  dps: 874.99909
+  tps: 1567.54055
   dtps: 1460.21448
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 917.09347
-  tps: 1643.68391
+  dps: 923.2431
+  tps: 1655.55751
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 915.41209
-  tps: 1642.00253
+  dps: 921.56171
+  tps: 1653.87612
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 884.23382
-  tps: 1582.03578
+  dps: 885.16498
+  tps: 1583.87201
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 891.36023
-  tps: 1595.70248
+  dps: 892.04118
+  tps: 1597.05259
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 889.80347
-  tps: 1588.09159
+  dps: 889.28996
+  tps: 1588.11133
   dtps: 1288.19539
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 894.1065
-  tps: 1601.15528
+  dps: 894.71482
+  tps: 1602.35061
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 884.52529
-  tps: 1573.95265
+  dps: 884.49297
+  tps: 1573.71264
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 905.54047
-  tps: 1622.98238
+  dps: 906.48247
+  tps: 1624.84585
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 907.20713
-  tps: 1627.01614
+  dps: 909.21064
+  tps: 1631.07509
   dtps: 1306.38861
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 846.20948
-  tps: 1393.44899
+  dps: 853.0013
+  tps: 1406.48853
   dtps: 1853.62548
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThickDraenicArmor"
  value: {
-  dps: 890.57102
-  tps: 1571.30712
+  dps: 893.13582
+  tps: 1576.44083
   dtps: 1541.01632
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 915.41209
-  tps: 1642.00253
+  dps: 921.56171
+  tps: 1653.87612
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 891.47249
-  tps: 1594.92483
+  dps: 892.62578
+  tps: 1597.13312
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 895.68072
-  tps: 1595.83305
+  dps: 894.55749
+  tps: 1593.46782
   dtps: 1287.8636
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-UnitingCharm-25633"
  value: {
-  dps: 885.79191
-  tps: 1578.95829
+  dps: 886.76092
+  tps: 1580.86529
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 887.92165
-  tps: 1589.09695
+  dps: 888.62883
+  tps: 1590.49922
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofFortitude-33938"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.5121
+  tps: 1646.18187
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofVengeance-33950"
  value: {
-  dps: 911.37103
-  tps: 1634.32453
+  dps: 917.50494
+  tps: 1646.16826
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 887.93821
-  tps: 1588.41884
+  dps: 889.03845
+  tps: 1590.53275
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WastewalkerArmor"
  value: {
-  dps: 886.92408
-  tps: 1550.62933
+  dps: 892.61182
+  tps: 1561.88184
   dtps: 1680.99401
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WhitemendWisdom"
  value: {
-  dps: 912.28705
-  tps: 1641.36841
+  dps: 911.94856
+  tps: 1641.29145
   dtps: 1528.30421
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WindhawkArmor"
  value: {
-  dps: 940.17922
-  tps: 1695.71679
+  dps: 943.44582
+  tps: 1704.84229
   dtps: 1568.72218
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 920.6405
-  tps: 1653.49672
+  dps: 922.16075
+  tps: 1656.21894
   dtps: 1314.90897
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofSpellfire"
  value: {
-  dps: 889.7583
-  tps: 1597.99297
+  dps: 891.67295
+  tps: 1603.88719
   dtps: 1578.32174
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 875.61862
-  tps: 1565.5167
+  dps: 879.07754
+  tps: 1572.27514
   dtps: 1305.00032
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 889.8945
-  tps: 1592.88476
+  dps: 890.58738
+  tps: 1594.25858
   dtps: 1294.28455
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 912.84118
-  tps: 1635.72558
+  dps: 918.17948
+  tps: 1646.45072
   dtps: 1257.99916
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2435.09478
-  tps: 4277.32541
+  dps: 2442.00892
+  tps: 4291.41637
   dtps: 44358.6852
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 977.08934
-  tps: 1724.07814
+  dps: 978.80174
+  tps: 1729.23128
   dtps: 1253.73335
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1104.92185
-  tps: 1933.96276
+  dps: 1106.42632
+  tps: 1937.18106
   dtps: 1325.75557
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2114.59694
-  tps: 4943.67728
+  dps: 2114.45057
+  tps: 4941.90059
   dtps: 46514.55637
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 416.2841
-  tps: 875.29591
+  dps: 419.32687
+  tps: 880.89485
   dtps: 2281.36763
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 439.64922
-  tps: 916.57819
+  dps: 442.21601
+  tps: 922.10635
   dtps: 2347.11751
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2472.61373
-  tps: 4330.92283
+  dps: 2479.04709
+  tps: 4343.54169
   dtps: 44367.41399
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 997.40012
-  tps: 1755.45164
+  dps: 1000.31254
+  tps: 1762.46734
   dtps: 1253.94098
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1129.44026
-  tps: 1970.0012
+  dps: 1135.17236
+  tps: 1980.99047
   dtps: 1325.97528
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2120.97623
-  tps: 4954.23471
+  dps: 2121.35405
+  tps: 4953.38566
   dtps: 46580.56953
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 418.66147
-  tps: 879.03059
+  dps: 421.80252
+  tps: 884.81627
   dtps: 2281.72218
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 441.22721
-  tps: 918.87886
+  dps: 443.6182
+  tps: 924.07299
   dtps: 2347.48218
  }
 }
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 977.08934
-  tps: 1724.07814
+  dps: 978.80174
+  tps: 1729.23128
   dtps: 1253.73335
  }
 }

--- a/sim/warlock/hellfire.go
+++ b/sim/warlock/hellfire.go
@@ -41,7 +41,7 @@ func (warlock *Warlock) registerHellfire() *core.Spell {
 			BonusCoefficient:     hellFireCoeff,
 
 			OnTick: func(sim *core.Simulation, _ *core.Unit, dot *core.Dot) {
-				resultSlice := dot.Spell.CalcPeriodicAoeDamage(sim, 308, dot.Spell.OutcomeTickMagicHit)
+				resultSlice := dot.Spell.CalcPeriodicAoeDamage(sim, 308, dot.Spell.OutcomeTickMagicHitNoHitCounter)
 				if resultSlice[0].Damage > warlock.CurrentHealth() {
 					dot.Deactivate(sim)
 				}


### PR DESCRIPTION
* Libram of the Eternal Rest has its own spell coef (0.09525 instead of 0.119)
* The ground effect should start ticking immediately, not offset by 1s
* Ticks should be able to fully resist
    * The reason this was missed is probably because missed ticks aren't even shown in logs, this cast is missing ticks at 3s, 4s, 6s and 10s for example:
      <img width="448" height="574" alt="image" src="https://github.com/user-attachments/assets/ba82e74f-902f-499d-bdb1-50b51fc2c3ff" />
* The initial cast of Consecration should perform a hit check and this hit should be able to proc stuff (on hit or miss, like Eye of Magtheridon).
    * Here we can see the initial hit missing but the tick still happening at the same time at the cast (as well as two missing ticks at 21s and 22s:
      <img width="428" height="271" alt="image" src="https://github.com/user-attachments/assets/25b37517-150d-437a-8f45-638edc8ee8a0" />  