### PR TITLE
add bonereaver's edge proc

### DIFF
--- a/sim/common/tbc/items_weapons.go
+++ b/sim/common/tbc/items_weapons.go
@@ -84,11 +84,10 @@ func init() {
 		dpm := getDpm()
 
 		procTrigger := character.MakeProcTriggerAura(core.ProcTrigger{
-			Name:               "Bonereaver's Edge Trigger",
-			DPM:                dpm,
-			Outcome:            core.OutcomeLanded,
-			Callback:           core.CallbackOnSpellHitDealt,
-			TriggerImmediately: true,
+			Name:     "Bonereaver's Edge Trigger",
+			DPM:      dpm,
+			Outcome:  core.OutcomeLanded,
+			Callback: core.CallbackOnSpellHitDealt,
 			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				arpAura.Activate(sim)
 				arpAura.AddStack(sim)

--- a/sim/common/tbc/items_weapons.go
+++ b/sim/common/tbc/items_weapons.go
@@ -55,6 +55,56 @@ func init() {
 		character.ItemSwap.RegisterProc(28573, procTrigger)
 	})
 
+	// Bonereaver's Edge
+	core.NewItemEffect(17076, func(agent core.Agent) {
+		character := agent.GetCharacter()
+
+		arpAura := core.MakeStackingAura(
+			character,
+			core.StackingStatAura{
+				Aura: core.Aura{
+					Label:     "Bonereaver's Edge",
+					ActionID:  core.ActionID{SpellID: 21153},
+					Duration:  time.Second * 10,
+					MaxStacks: 3,
+				},
+				BonusPerStack: stats.Stats{
+					stats.ArmorPenetration: 700,
+				},
+			},
+		)
+
+		getDpm := func() *core.DynamicProcManager {
+			return character.NewStaticLegacyPPMManager(
+				2,
+				*character.GetDynamicProcMaskForWeaponEffect(17076),
+			)
+		}
+
+		dpm := getDpm()
+
+		procTrigger := character.MakeProcTriggerAura(core.ProcTrigger{
+			Name:               "Bonereaver's Edge Trigger",
+			DPM:                dpm,
+			Outcome:            core.OutcomeLanded,
+			Callback:           core.CallbackOnSpellHitDealt,
+			TriggerImmediately: true,
+			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				arpAura.Activate(sim)
+				arpAura.AddStack(sim)
+			},
+		})
+
+		character.RegisterItemSwapCallback(
+			[]proto.ItemSlot{proto.ItemSlot_ItemSlotMainHand},
+			func(sim *core.Simulation, slot proto.ItemSlot) {
+				dpm = getDpm()
+			},
+		)
+
+		character.ItemSwap.RegisterProc(17076, procTrigger)
+	})
+
 	// Rod of the Sun King
 	core.NewItemEffect(29996, func(agent core.Agent) {
 		character := agent.GetCharacter()


### PR DESCRIPTION
adds bonereaver's edge as a 2 ppm weapon proc.

effect:
- 10s duration
- stacks up to 3
- refreshes on additional applications
- 700 armor penetration per stack
- uses dynamic weapon proc mask for item 17076