### PR TITLE
Fix attribute rounding and base stats to match the game

### DIFF
--- a/sim/core/base_stats.go
+++ b/sim/core/base_stats.go
@@ -51,7 +51,7 @@ var RaceOffsets = map[proto.Race]stats.Stats{
 		stats.Stamina:   0,
 	},
 	proto.Race_RaceUndead: {
-		stats.Agility:   -2,
+		stats.Agility:   -3,
 		stats.Strength:  -1,
 		stats.Intellect: -2,
 		stats.Spirit:    5,
@@ -261,4 +261,43 @@ func init() {
 	AddBaseStatsCombo(proto.Race_RaceTauren, proto.Class_ClassWarrior)
 	AddBaseStatsCombo(proto.Race_RaceTroll, proto.Class_ClassWarrior)
 	AddBaseStatsCombo(proto.Race_RaceUndead, proto.Class_ClassWarrior)
+
+	// The class tables above hold as-shown naked character sheet values, but
+	// for races with a multiplier racial (The Human Spirit ×1.1, gnome
+	// Expansive Mind ×1.05) the as-shown number already includes the racial:
+	// e.g. human paladin shows Spirit 97 = floor(89 * 1.1). The racial is
+	// applied via MultiplyStat in racials.go, so these combos must store the
+	// true pre-racial base — both to avoid double-dipping and because the
+	// game carries the fractional product (97.9) into further multipliers:
+	// with Blessing of Kings, floor(89 * 1.1 * 1.1) = 107, not floor(97 * 1.1).
+	// Each base below is the unique integer whose floored product matches the
+	// as-shown sheet value.
+	humanBaseSpirit := map[proto.Class]float64{
+		proto.Class_ClassWarrior: 51,  // floor(51 * 1.1) = 56
+		proto.Class_ClassPaladin: 89,  // floor(89 * 1.1) = 97
+		proto.Class_ClassRogue:   53,  // floor(53 * 1.1) = 58
+		proto.Class_ClassPriest:  151, // floor(151 * 1.1) = 166
+		proto.Class_ClassMage:    132, // floor(132 * 1.1) = 145
+		proto.Class_ClassWarlock: 131, // floor(131 * 1.1) = 144
+	}
+	for class, spirit := range humanBaseSpirit {
+		key := BaseStatsKey{Race: proto.Race_RaceHuman, Class: class}
+		baseStats := BaseStats[key]
+		baseStats[stats.Spirit] = spirit
+		BaseStats[key] = baseStats
+	}
+
+	gnomeBaseIntellect := map[proto.Class]float64{
+		proto.Class_ClassWarrior: 35,  // floor(35 * 1.05) = 36
+		proto.Class_ClassRogue:   40,  // floor(40 * 1.05) = 42
+		proto.Class_ClassPriest:  141, // floor(141 * 1.05) = 148
+		proto.Class_ClassMage:    147, // floor(147 * 1.05) = 154
+		proto.Class_ClassWarlock: 130, // floor(130 * 1.05) = 136
+	}
+	for class, intellect := range gnomeBaseIntellect {
+		key := BaseStatsKey{Race: proto.Race_RaceGnome, Class: class}
+		baseStats := BaseStats[key]
+		baseStats[stats.Intellect] = intellect
+		BaseStats[key] = baseStats
+	}
 }

--- a/sim/core/base_stats.go
+++ b/sim/core/base_stats.go
@@ -12,8 +12,17 @@ type BaseStatsKey struct {
 
 var BaseStats = map[BaseStatsKey]stats.Stats{}
 
-// To calculate base stats, get a naked level 70 of the race/class you want, ideally without any talents to mess up base stats.
-//  Basic stats are as-shown (str/agi/stm/int/spirit)
+// ClassBaseStats + RaceOffsets hold TRUE pre-racial base attributes: the
+// multiplier racials (The Human Spirit ×1.1 spirit, gnome Expansive Mind
+// ×1.05 int, applied via MultiplyStat in racials.go) are NOT included here.
+// A naked character sheet shows floor(base × racial), e.g. human paladin
+// spirit 89 shows as 97; multipliers (racial, Kings, %-stat talents) stack
+// multiplicatively on the unfloored value with a single floor at the end.
+//
+// Values verified against WCL TBC-anniversary COMBATANT_INFO audit snapshots
+// (420 players, ≥2 independent players per race/class where available) plus
+// naked-character screenshots for human paladin. Hunter rows could not be
+// pinned precisely (consumable noise) and remain wowhead-era values.
 
 // Base Spell Crit is calculated by
 //   1. Take as-shown value (troll shaman have 3.5%)
@@ -33,8 +42,8 @@ var RaceOffsets = map[proto.Race]stats.Stats{
 		stats.Agility:   -3,
 		stats.Strength:  3,
 		stats.Intellect: -3,
-		stats.Spirit:    2,
-		stats.Stamina:   1,
+		stats.Spirit:    3,
+		stats.Stamina:   2,
 	},
 	proto.Race_RaceDwarf: {
 		stats.Agility:   -4,
@@ -51,7 +60,7 @@ var RaceOffsets = map[proto.Race]stats.Stats{
 		stats.Stamina:   0,
 	},
 	proto.Race_RaceUndead: {
-		stats.Agility:   -3,
+		stats.Agility:   -2,
 		stats.Strength:  -1,
 		stats.Intellect: -2,
 		stats.Spirit:    5,
@@ -65,7 +74,7 @@ var RaceOffsets = map[proto.Race]stats.Stats{
 		stats.Stamina:   1,
 	},
 	proto.Race_RaceGnome: {
-		stats.Agility:   2,
+		stats.Agility:   3,
 		stats.Strength:  -5,
 		stats.Intellect: 3,
 		stats.Spirit:    0,
@@ -76,13 +85,13 @@ var RaceOffsets = map[proto.Race]stats.Stats{
 		stats.Strength:  1,
 		stats.Intellect: -4,
 		stats.Spirit:    1,
-		stats.Stamina:   0,
+		stats.Stamina:   1,
 	},
 	proto.Race_RaceBloodElf: {
 		stats.Agility:   2,
 		stats.Strength:  -3,
-		stats.Intellect: 3,
-		stats.Spirit:    -2,
+		stats.Intellect: 4,
+		stats.Spirit:    -1,
 		stats.Stamina:   0,
 	},
 	proto.Race_RaceDraenei: {
@@ -101,7 +110,7 @@ var ClassBaseStats = map[proto.Class]stats.Stats{
 		stats.Agility:     96,
 		stats.Strength:    145,
 		stats.Intellect:   33,
-		stats.Spirit:      56,
+		stats.Spirit:      51,
 		stats.Stamina:     133,
 		stats.AttackPower: float64(CharacterLevel)*3.0 - 20,
 	},
@@ -110,7 +119,7 @@ var ClassBaseStats = map[proto.Class]stats.Stats{
 		stats.Agility:     77,
 		stats.Strength:    126,
 		stats.Intellect:   83,
-		stats.Spirit:      97,
+		stats.Spirit:      89,
 		stats.Stamina:     120,
 		stats.AttackPower: float64(CharacterLevel)*3.0 - 20,
 	},
@@ -138,7 +147,7 @@ var ClassBaseStats = map[proto.Class]stats.Stats{
 		stats.Agility:   45,
 		stats.Strength:  39,
 		stats.Intellect: 145,
-		stats.Spirit:    166,
+		stats.Spirit:    151,
 		stats.Stamina:   58,
 	},
 	proto.Class_ClassShaman: {
@@ -163,7 +172,7 @@ var ClassBaseStats = map[proto.Class]stats.Stats{
 		stats.Agility:     58,
 		stats.Strength:    51,
 		stats.Intellect:   133,
-		stats.Spirit:      144,
+		stats.Spirit:      143,
 		stats.Stamina:     76,
 		stats.AttackPower: -10,
 	},
@@ -261,43 +270,4 @@ func init() {
 	AddBaseStatsCombo(proto.Race_RaceTauren, proto.Class_ClassWarrior)
 	AddBaseStatsCombo(proto.Race_RaceTroll, proto.Class_ClassWarrior)
 	AddBaseStatsCombo(proto.Race_RaceUndead, proto.Class_ClassWarrior)
-
-	// The class tables above hold as-shown naked character sheet values, but
-	// for races with a multiplier racial (The Human Spirit ×1.1, gnome
-	// Expansive Mind ×1.05) the as-shown number already includes the racial:
-	// e.g. human paladin shows Spirit 97 = floor(89 * 1.1). The racial is
-	// applied via MultiplyStat in racials.go, so these combos must store the
-	// true pre-racial base — both to avoid double-dipping and because the
-	// game carries the fractional product (97.9) into further multipliers:
-	// with Blessing of Kings, floor(89 * 1.1 * 1.1) = 107, not floor(97 * 1.1).
-	// Each base below is the unique integer whose floored product matches the
-	// as-shown sheet value.
-	humanBaseSpirit := map[proto.Class]float64{
-		proto.Class_ClassWarrior: 51,  // floor(51 * 1.1) = 56
-		proto.Class_ClassPaladin: 89,  // floor(89 * 1.1) = 97
-		proto.Class_ClassRogue:   53,  // floor(53 * 1.1) = 58
-		proto.Class_ClassPriest:  151, // floor(151 * 1.1) = 166
-		proto.Class_ClassMage:    132, // floor(132 * 1.1) = 145
-		proto.Class_ClassWarlock: 131, // floor(131 * 1.1) = 144
-	}
-	for class, spirit := range humanBaseSpirit {
-		key := BaseStatsKey{Race: proto.Race_RaceHuman, Class: class}
-		baseStats := BaseStats[key]
-		baseStats[stats.Spirit] = spirit
-		BaseStats[key] = baseStats
-	}
-
-	gnomeBaseIntellect := map[proto.Class]float64{
-		proto.Class_ClassWarrior: 35,  // floor(35 * 1.05) = 36
-		proto.Class_ClassRogue:   40,  // floor(40 * 1.05) = 42
-		proto.Class_ClassPriest:  141, // floor(141 * 1.05) = 148
-		proto.Class_ClassMage:    147, // floor(147 * 1.05) = 154
-		proto.Class_ClassWarlock: 130, // floor(130 * 1.05) = 136
-	}
-	for class, intellect := range gnomeBaseIntellect {
-		key := BaseStatsKey{Race: proto.Race_RaceGnome, Class: class}
-		baseStats := BaseStats[key]
-		baseStats[stats.Intellect] = intellect
-		BaseStats[key] = baseStats
-	}
 }

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"math"
 	"slices"
 	"time"
 
@@ -447,22 +448,25 @@ func GiftOfTheWildAura(char *Character, improved bool) *Aura {
 		mod = 1.35
 	}
 
+	// The game truncates talent-modified aura amounts to integers, so
+	// improved GotW grants 18 stats (14*1.35=18.9), not 18.9.
+	statMod := math.Floor(14 * mod)
 	aura := makeStatBuff(char, BuffConfig{
 		Label:    "Gift of the Wild",
 		ActionID: ActionID{SpellID: 26991},
 		Stats: []StatConfig{
-			{stats.Armor, 340 * mod, false},
-			{stats.Stamina, 14 * mod, false},
-			{stats.Strength, 14 * mod, false},
-			{stats.Agility, 14 * mod, false},
-			{stats.Intellect, 14 * mod, false},
-			{stats.Spirit, 14 * mod, false},
+			{stats.Armor, math.Floor(340 * mod), false},
+			{stats.Stamina, statMod, false},
+			{stats.Strength, statMod, false},
+			{stats.Agility, statMod, false},
+			{stats.Intellect, statMod, false},
+			{stats.Spirit, statMod, false},
 		},
 	})
 	// Resistance stats use exclusive categories so they don't stack with
 	// dedicated resistance buffs (Shadow Protection, Frost/Nature Resistance
 	// Aura/Totem). Only the highest value applies per school.
-	resistMod := 25 * mod
+	resistMod := math.Floor(25 * mod)
 	makeExclusiveFlatStatBuff(aura, stats.ArcaneResistance, resistMod, ResistanceCategoryArcane)
 	makeExclusiveFlatStatBuff(aura, stats.FireResistance, resistMod, ResistanceCategoryFire)
 	makeExclusiveFlatStatBuff(aura, stats.FrostResistance, resistMod, ResistanceCategoryFrost)
@@ -474,7 +478,8 @@ func GiftOfTheWildAura(char *Character, improved bool) *Aura {
 func PowerWordFortitudeAura(char *Character, improved bool) *Aura {
 	stat := 79.0
 	if improved {
-		stat *= 1.3
+		// Truncated like the game: 79*1.3=102.7 -> 102.
+		stat = math.Floor(stat * 1.3)
 	}
 
 	return makeStatBuff(char, BuffConfig{
@@ -622,7 +627,8 @@ func GetBattleShoutValue(boomingVoicePoints int32, commandingPresenceMultiplier 
 			apBuff += 30
 		}
 	}
-	return apBuff * commandingPresenceMultiplier
+	// Truncated like the game: 306*1.25=382.5 -> 382.
+	return math.Floor(apBuff * commandingPresenceMultiplier)
 }
 
 func BattleShoutAura(char *Character, isPlayer bool, boomingVoicePoints int32, commandingPresenceMultiplier float64, hasSolarianSapphire bool, hasT2 bool) *Aura {
@@ -714,7 +720,7 @@ func GetCommandingShoutValue(boomingVoicePoints int32, commandingPresenceMultipl
 			baseHpBuff += 170
 		}
 	}
-	return baseHpBuff * commandingPresenceMultiplier
+	return math.Floor(baseHpBuff * commandingPresenceMultiplier)
 }
 
 func CommandingShoutAura(char *Character, isPlayer bool, boomingVoicePoints int32, commandingPresenceMultiplier float64, hasT6Tank2P bool) *Aura {
@@ -765,7 +771,8 @@ func paladinAuraPriority(isPlayer bool) float64 {
 }
 
 func DevotionAuraBuff(char *Character, isPlayer bool, impDevotionAuraRank int32) *Aura {
-	armorBuff := 861.0 * (1 + 0.08*float64(impDevotionAuraRank))
+	// Truncated like the game: e.g. 861*1.24=1067.64 -> 1067.
+	armorBuff := math.Floor(861.0 * (1 + 0.08*float64(impDevotionAuraRank)))
 
 	// Self-cast: Tag=0 matches the paladin's castable spell and only applies when the APL
 	// triggers it. External: Tag=-1 is auto-applied in the Buffs build phase and the UI
@@ -975,7 +982,8 @@ var GraceOfAirTotemCategory = "GraceOfAirTotem"
 func GraceOfAirTotemAura(char *Character, improved bool, wfActive bool) *Aura {
 	agiBuff := 77.0
 	if improved {
-		agiBuff *= 1.15
+		// Truncated like the game: 77*1.15=88.55 -> 88.
+		agiBuff = math.Floor(agiBuff * 1.15)
 	}
 
 	duration := NeverExpires
@@ -1011,6 +1019,8 @@ var ManaSpringTotemCategory = "ManaSpringTotem"
 func ManaSpringTotemAura(char *Character, improved bool) *Aura {
 	mp5Buff := 50.0
 	if improved {
+		// No truncation here: the aura's native amount is mana per 2-sec tick
+		// (20*1.25=25, an exact integer), so the effective 62.5 MP5 is real.
 		mp5Buff *= 1.25
 	}
 
@@ -1033,7 +1043,8 @@ const (
 var StrengthOfEarthMultipliers = []float64{1, 1.08, 1.15}
 
 func StrengthOfEarthTotemValue(enhancingTotemsPoints int32, hasEnh2pT4 bool) float64 {
-	return (86.0 + TernaryFloat64(hasEnh2pT4, StrengthOfEarthTotemImprovedValue, 0)) * StrengthOfEarthMultipliers[enhancingTotemsPoints]
+	// Truncated like the game: e.g. 86*1.15=98.9 -> 98.
+	return math.Floor((86.0 + TernaryFloat64(hasEnh2pT4, StrengthOfEarthTotemImprovedValue, 0)) * StrengthOfEarthMultipliers[enhancingTotemsPoints])
 }
 
 func StrengthOfEarthTotemAura(char *Character, enhancingTotemsPoints int32, hasEnh2pT4 bool) *Aura {
@@ -1072,7 +1083,8 @@ var WindfuryTotemCategory = "WindfuryTotem"
 func WindfuryTotemAura(char *Character, isImpoved bool) *Aura {
 	apBonus := 445.0
 	if isImpoved {
-		apBonus *= 1.3
+		// Truncated like the game: 445*1.3=578.5 -> 578.
+		apBonus = math.Floor(apBonus * 1.3)
 	}
 	// Chance on MH Auto Attack to instantly attack with another AA with apBonus.
 	// AP bonus lingers until 2 auto attacks are performed.
@@ -1533,7 +1545,9 @@ func BlessingOfSanctuaryAura(char *Character) *Aura {
 func BlessingOfWisdomAura(char *Character, improved bool) *Aura {
 	mp5Buff := 41.0
 	if improved {
-		mp5Buff *= 1.20
+		// Truncated like the game: 41*1.2=49.2 -> 49 (the aura's native
+		// amount is mana per 5 sec).
+		mp5Buff = math.Floor(mp5Buff * 1.20)
 	}
 
 	return makeStatBuff(char, BuffConfig{

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -280,7 +280,7 @@ func (character *Character) applyAllEffects(agent Agent, raidBuffs *proto.RaidBu
 
 	measureStats := func() *proto.UnitStats {
 		baseStats := character.GetStats()
-		character.stats = character.SortAndApplyStatDependencies(character.stats)
+		character.stats = character.SortAndApplyStatDependencies(character.stats).FloorGameStats()
 		measuredStatsProto := &proto.UnitStats{
 			Stats:       character.GetStats().ToProtoArray(),
 			PseudoStats: character.GetPseudoStatsProto(),

--- a/sim/core/stats/deps.go
+++ b/sim/core/stats/deps.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"fmt"
+	"math"
 )
 
 // This stat list is arranged such that evaluating dependencies in this order
@@ -255,6 +256,11 @@ func (sdm *StatDependencyManager) ApplyStatDependencies(s Stats) Stats {
 		if dep.enabled {
 			if dep.src == dep.dst {
 				s[dep.dst] *= dep.amount
+			} else if isFlooredGameStat[dep.src] {
+				// The dep sort guarantees the source stat is final here, and
+				// the game floors attributes before dependents consume them
+				// (e.g. dodge is derived from the floored Agility).
+				s[dep.dst] += math.Floor(s[dep.src]) * dep.amount
 			} else {
 				s[dep.dst] += s[dep.src] * dep.amount
 			}

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -297,6 +297,37 @@ func (stats Stats) Floor() Stats {
 	return stats
 }
 
+// Stats the game stores as rounded-down integers on the unit: the five
+// attributes. The game floors these after resolving percentage multipliers
+// (e.g. Blessing of Kings), and derived values consume the floored integers
+// (health from floored Stamina, dodge from floored Agility). Verified against
+// live character sheets.
+//
+// Unlike attributes, combat ratings must NOT be floored here: the sim uses
+// rating stats as mixed accumulators that include fractional conversions from
+// talents and racials (e.g. dodge% talents stored as DodgeRating), and TBC has
+// no rating multipliers, so real rating totals are already integers.
+var flooredGameStats = []Stat{
+	Strength, Agility, Stamina, Intellect, Spirit,
+}
+
+var isFlooredGameStat = func() [SimStatsLen]bool {
+	var m [SimStatsLen]bool
+	for _, s := range flooredGameStats {
+		m[s] = true
+	}
+	return m
+}()
+
+// Rounds attributes down to integers, matching how the game stores them.
+// Must be applied after stat dependencies are resolved.
+func (stats Stats) FloorGameStats() Stats {
+	for _, k := range flooredGameStats {
+		stats[k] = math.Floor(stats[k])
+	}
+	return stats
+}
+
 func (stats Stats) Multiply(multiplier float64) Stats {
 	for k := range stats {
 		stats[k] *= multiplier

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -351,14 +351,21 @@ func (unit *Unit) AddStatsDynamic(sim *Simulation, bonus stats.Stats) {
 	unit.statsWithoutDeps.AddInplace(&bonus)
 
 	if !unit.Env.MeasuringStats || unit.Env.State == Finalized {
-		bonus = unit.ApplyStatDependencies(bonus)
+		// Recompute the full total rather than applying dependencies to the
+		// delta: floored stats are only path-independent as floor(newTotal) -
+		// floor(oldTotal), while flooring per-delta would drift on every
+		// aura gain/expire cycle.
+		newStats := unit.ApplyStatDependencies(unit.statsWithoutDeps).FloorGameStats()
+		bonus = newStats.Subtract(unit.stats)
+		unit.stats = newStats
+	} else {
+		unit.stats.AddInplace(&bonus)
 	}
 
 	if sim.Log != nil {
 		unit.Log(sim, "Dynamic stat change: %s", bonus.FlatString())
 	}
 
-	unit.stats.AddInplace(&bonus)
 	unit.processDynamicBonus(sim, bonus)
 }
 
@@ -408,7 +415,7 @@ func (unit *Unit) processDynamicBonus(sim *Simulation, bonus stats.Stats) {
 func (unit *Unit) EnableDynamicStatDep(sim *Simulation, dep *stats.StatDependency) {
 	if unit.StatDependencyManager.EnableDynamicStatDep(dep) {
 		oldStats := unit.stats
-		unit.stats = unit.ApplyStatDependencies(unit.statsWithoutDeps)
+		unit.stats = unit.ApplyStatDependencies(unit.statsWithoutDeps).FloorGameStats()
 		unit.processDynamicBonus(sim, unit.stats.Subtract(oldStats))
 
 		if sim.Log != nil {
@@ -419,7 +426,7 @@ func (unit *Unit) EnableDynamicStatDep(sim *Simulation, dep *stats.StatDependenc
 func (unit *Unit) DisableDynamicStatDep(sim *Simulation, dep *stats.StatDependency) {
 	if unit.StatDependencyManager.DisableDynamicStatDep(dep) {
 		oldStats := unit.stats
-		unit.stats = unit.ApplyStatDependencies(unit.statsWithoutDeps)
+		unit.stats = unit.ApplyStatDependencies(unit.statsWithoutDeps).FloorGameStats()
 		unit.processDynamicBonus(sim, unit.stats.Subtract(oldStats))
 
 		if sim.Log != nil {
@@ -433,7 +440,7 @@ func (unit *Unit) UpdateDynamicStatDep(sim *Simulation, dep *stats.StatDependenc
 
 	if unit.Env.IsFinalized() {
 		oldStats := unit.stats
-		unit.stats = unit.ApplyStatDependencies(unit.statsWithoutDeps)
+		unit.stats = unit.ApplyStatDependencies(unit.statsWithoutDeps).FloorGameStats()
 		statsChange := unit.stats.Subtract(oldStats)
 		unit.processDynamicBonus(sim, statsChange)
 
@@ -702,7 +709,7 @@ func (unit *Unit) finalize() {
 	unit.initialRangedSwingSpeed = unit.TotalRangedHasteMultiplier()
 
 	unit.StatDependencyManager.FinalizeStatDeps()
-	unit.initialStats = unit.ApplyStatDependencies(unit.initialStatsWithoutDeps)
+	unit.initialStats = unit.ApplyStatDependencies(unit.initialStatsWithoutDeps).FloorGameStats()
 	unit.statsWithoutDeps = unit.initialStatsWithoutDeps
 	unit.stats = unit.initialStats
 

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestBalance-CharacterStats-Default"
  value: {
-  final_stats: 209.88
-  final_stats: 200.695
-  final_stats: 545.16
-  final_stats: 473.99
-  final_stats: 905.499
-  final_stats: 1044.1758
+  final_stats: 207
+  final_stats: 199
+  final_stats: 543
+  final_stats: 473
+  final_stats: 905.4
+  final_stats: 1043.76
   final_stats: 222
   final_stats: 172
   final_stats: 0
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 262
   final_stats: 0
   final_stats: 0
-  final_stats: 264.99
-  final_stats: 1057.518
+  final_stats: 264
+  final_stats: 1053.8
   final_stats: 389
   final_stats: 0
   final_stats: 0
@@ -29,24 +29,24 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 258.24787
+  final_stats: 256.0668
   final_stats: 0
   final_stats: 0
-  final_stats: 7837.79
+  final_stats: 7834
   final_stats: 0
-  final_stats: 10235.6
-  final_stats: 9199.85
-  final_stats: 175.099
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 43.75
+  final_stats: 10214
+  final_stats: 9185
+  final_stats: 174.8
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 43
   final_stats: 70
   final_stats: 0
   final_stats: 1
   final_stats: 14.97561
-  final_stats: 16.16302
-  final_stats: 29.64397
+  final_stats: 16.09522
+  final_stats: 29.6316
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -55,709 +55,709 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1241.43559
-  tps: 1169.41866
+  dps: 1236.73959
+  tps: 1164.66964
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 1480.86376
-  tps: 1409.47054
+  dps: 1477.27466
+  tps: 1405.86287
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BattlecastGarb"
  value: {
-  dps: 1342.11952
-  tps: 1269.00781
+  dps: 1338.02383
+  tps: 1264.87657
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1393.36531
-  tps: 1321.58254
+  dps: 1387.93314
+  tps: 1316.11125
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1448.55836
-  tps: 1377.19712
+  dps: 1440.61678
+  tps: 1369.19825
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1491.56706
-  tps: 1420.33161
+  dps: 1486.20432
+  tps: 1414.92975
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1449.49377
-  tps: 1378.25832
+  dps: 1444.34326
+  tps: 1373.06869
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnchantBoots-Boar'sSpeed-2940"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 1463.89703
-  tps: 1364.98483
+  dps: 1458.64995
+  tps: 1359.80354
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1463.89703
-  tps: 1420.05181
+  dps: 1458.64995
+  tps: 1414.6607
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EverbloomIdol-29390"
  value: {
-  dps: 1427.84937
-  tps: 1356.47066
+  dps: 1422.75024
+  tps: 1351.33241
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1483.57633
-  tps: 1412.1318
+  dps: 1478.20234
+  tps: 1406.71868
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1422.62914
-  tps: 1350.90805
+  dps: 1417.02564
+  tps: 1345.24487
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FelSkin"
  value: {
-  dps: 1182.73957
-  tps: 1110.64481
+  dps: 1178.6783
+  tps: 1106.57074
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FrostscytheofLordAhune-278953"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sRefuge"
  value: {
-  dps: 1279.70073
-  tps: 1208.48519
+  dps: 1279.3344
+  tps: 1208.10583
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 1117.16581
-  tps: 1045.18182
+  dps: 1114.8024
+  tps: 1042.78482
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 1377.95192
-  tps: 1305.86003
+  dps: 1377.66793
+  tps: 1305.56572
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HandofJustice-11815"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IceGuard-2682"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofBrutality-23198"
  value: {
-  dps: 1427.84937
-  tps: 1356.47066
+  dps: 1422.75024
+  tps: 1351.33241
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofFeralShadows-28372"
  value: {
-  dps: 1427.84937
-  tps: 1356.47066
+  dps: 1422.75024
+  tps: 1351.33241
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofTerror-33509"
  value: {
-  dps: 1427.84937
-  tps: 1356.47066
+  dps: 1422.75024
+  tps: 1351.33241
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofUrsoc-27744"
  value: {
-  dps: 1427.84937
-  tps: 1356.47066
+  dps: 1422.75024
+  tps: 1351.33241
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheAvenger-31025"
  value: {
-  dps: 1427.84937
-  tps: 1356.47066
+  dps: 1422.75024
+  tps: 1351.33241
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheBeast-25667"
  value: {
-  dps: 1427.84937
-  tps: 1356.47066
+  dps: 1422.75024
+  tps: 1351.33241
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheMoon-23197"
  value: {
-  dps: 1430.37048
-  tps: 1358.99177
+  dps: 1425.27135
+  tps: 1353.85352
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 1437.07895
-  tps: 1365.70024
+  dps: 1431.97762
+  tps: 1360.55979
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 1427.84937
-  tps: 1356.47066
+  dps: 1422.75024
+  tps: 1351.33241
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheWild-28064"
  value: {
-  dps: 1427.84937
-  tps: 1356.47066
+  dps: 1422.75024
+  tps: 1351.33241
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1343.18008
-  tps: 1272.26282
+  dps: 1340.76359
+  tps: 1269.73714
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InfinityBlade-30312"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-JomGabbar-23570"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 1458.19316
-  tps: 1386.6191
+  dps: 1454.54189
+  tps: 1382.91842
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MalorneHarness"
  value: {
-  dps: 1045.24918
-  tps: 972.18396
+  dps: 1045.83384
+  tps: 972.72836
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MalorneRegalia"
  value: {
-  dps: 1341.45148
-  tps: 1271.11586
+  dps: 1340.29549
+  tps: 1269.94801
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1249.95375
-  tps: 1177.12183
+  dps: 1248.28213
+  tps: 1175.43899
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1480.38974
-  tps: 1409.37826
+  dps: 1480.20576
+  tps: 1409.16543
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MoongladeRaiment"
  value: {
-  dps: 1177.27152
-  tps: 1104.7761
+  dps: 1173.45495
+  tps: 1100.91315
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NetherweaveVestments"
  value: {
-  dps: 1097.2156
-  tps: 1023.29852
+  dps: 1098.74234
+  tps: 1024.84573
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NordrassilHarness"
  value: {
-  dps: 1046.185
-  tps: 973.16055
+  dps: 1046.25971
+  tps: 973.18383
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NordrassilRegalia"
  value: {
-  dps: 1496.44821
-  tps: 1424.50317
+  dps: 1495.99131
+  tps: 1424.0361
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Oathbound'sDragonhideBattlegear"
  value: {
-  dps: 1083.76044
-  tps: 1010.54966
+  dps: 1080.3383
+  tps: 1007.0649
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Oathbound'sKodohideBattlegear"
  value: {
-  dps: 1159.14004
-  tps: 1086.53998
+  dps: 1155.62371
+  tps: 1082.99188
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Oathbound'sWyrmhideBattlegear"
  value: {
-  dps: 1185.61879
-  tps: 1112.49789
+  dps: 1181.4475
+  tps: 1108.26669
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1393.36531
-  tps: 1321.58254
+  dps: 1387.93314
+  tps: 1316.11125
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1393.36531
-  tps: 1321.58254
+  dps: 1387.93314
+  tps: 1316.11125
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1393.36531
-  tps: 1321.58254
+  dps: 1387.93314
+  tps: 1316.11125
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1393.36531
-  tps: 1321.58254
+  dps: 1387.93314
+  tps: 1316.11125
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1393.36531
-  tps: 1321.58254
+  dps: 1387.93314
+  tps: 1316.11125
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1481.96866
-  tps: 1411.84175
+  dps: 1481.63804
+  tps: 1411.50284
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PrimalIntent"
  value: {
-  dps: 1200.09329
-  tps: 1127.81848
+  dps: 1197.90862
+  tps: 1125.5981
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PrimalMooncloth"
  value: {
-  dps: 1356.49731
-  tps: 1283.63787
+  dps: 1356.00972
+  tps: 1283.07227
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SavageGuard-2681"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1484.61677
-  tps: 1413.38132
+  dps: 1479.46386
+  tps: 1408.18929
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1208.46916
-  tps: 1135.15547
+  dps: 1207.50867
+  tps: 1134.21737
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1494.18912
-  tps: 1423.05256
+  dps: 1490.01588
+  tps: 1418.85686
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1252.82692
-  tps: 1180.00286
+  dps: 1247.20487
+  tps: 1174.34572
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1351.11671
-  tps: 1277.60469
+  dps: 1344.07128
+  tps: 1270.50754
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1436.67683
-  tps: 1365.44138
+  dps: 1431.52928
+  tps: 1360.2547
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StaffofNaturalFury-31334"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1155.01743
-  tps: 1082.76841
+  dps: 1154.82585
+  tps: 1082.56646
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1434.09398
-  tps: 1362.71527
+  dps: 1428.96798
+  tps: 1357.55015
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1472.9808
-  tps: 1370.34805
+  dps: 1469.72567
+  tps: 1367.07435
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThickDraenicArmor"
  value: {
-  dps: 1090.00334
-  tps: 1017.56007
+  dps: 1085.99807
+  tps: 1013.51748
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
-  dps: 939.18015
-  tps: 866.3512
+  dps: 937.37896
+  tps: 864.49856
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartRegalia"
  value: {
-  dps: 1621.48155
-  tps: 1549.94189
+  dps: 1620.89364
+  tps: 1549.34287
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WastewalkerArmor"
  value: {
-  dps: 944.89789
-  tps: 870.29751
+  dps: 942.12593
+  tps: 867.51523
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WhitemendWisdom"
  value: {
-  dps: 1317.74667
-  tps: 1244.7442
+  dps: 1312.3744
+  tps: 1239.33551
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WindhawkArmor"
  value: {
-  dps: 1413.19871
-  tps: 1342.46967
+  dps: 1412.34194
+  tps: 1341.58706
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WrathofSpellfire"
  value: {
-  dps: 1417.32565
-  tps: 1345.84726
+  dps: 1411.1695
+  tps: 1339.61866
  }
 }
 dps_results: {
  key: "TestBalance-Average-Default"
  value: {
-  dps: 1483.65423
-  tps: 1409.12401
+  dps: 1481.65906
+  tps: 1407.12783
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-p1_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2611.25527
-  tps: 2792.38633
+  dps: 2605.69436
+  tps: 2787.04014
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-p1_a-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-p1_a-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1836.50822
-  tps: 1605.21127
+  dps: 1836.16441
+  tps: 1604.84259
  }
 }
 dps_results: {
@@ -784,22 +784,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p2_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2980.17376
-  tps: 3151.23045
+  dps: 2968.96425
+  tps: 3139.02864
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-p2_a-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1604.4379
-  tps: 1531.36744
+  dps: 1602.87843
+  tps: 1529.71949
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-p2_a-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1989.43568
-  tps: 1754.4993
+  dps: 1988.86658
+  tps: 1753.88061
  }
 }
 dps_results: {
@@ -826,22 +826,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p3-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3422.79187
-  tps: 3629.38555
+  dps: 3421.00461
+  tps: 3626.83145
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-p3-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1876.73158
-  tps: 1804.61211
+  dps: 1876.17088
+  tps: 1804.03578
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-p3-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2296.08974
-  tps: 2062.68049
+  dps: 2295.49994
+  tps: 2062.0438
  }
 }
 dps_results: {
@@ -868,22 +868,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p4-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3563.75044
-  tps: 3772.06953
+  dps: 3562.71682
+  tps: 3770.63382
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-p4-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1864.28778
-  tps: 1791.99572
+  dps: 1862.61639
+  tps: 1790.31589
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-p4-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2265.32895
-  tps: 2031.2786
+  dps: 2262.13232
+  tps: 2028.05664
  }
 }
 dps_results: {
@@ -910,22 +910,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p5-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4176.19188
-  tps: 4398.93606
+  dps: 4173.88222
+  tps: 4396.29058
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-p5-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2212.59701
-  tps: 2141.02565
+  dps: 2210.3901
+  tps: 2138.78345
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-p5-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2670.03395
-  tps: 2436.2032
+  dps: 2665.87204
+  tps: 2431.99711
  }
 }
 dps_results: {
@@ -952,22 +952,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p1_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2561.84588
-  tps: 2741.15153
+  dps: 2537.64219
+  tps: 2717.58228
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p1_a-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1442.83331
-  tps: 1371.21353
+  dps: 1437.28301
+  tps: 1365.61643
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p1_a-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1817.93755
-  tps: 1586.39905
+  dps: 1817.42376
+  tps: 1585.84486
  }
 }
 dps_results: {
@@ -994,22 +994,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p2_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2935.41831
-  tps: 3103.13175
+  dps: 2929.5513
+  tps: 3096.55768
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p2_a-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1592.85974
-  tps: 1519.52258
+  dps: 1590.38966
+  tps: 1517.00882
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p2_a-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1969.64253
-  tps: 1734.46104
+  dps: 1969.15289
+  tps: 1733.93287
  }
 }
 dps_results: {
@@ -1036,22 +1036,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p3-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3399.14573
-  tps: 3602.1906
+  dps: 3397.71719
+  tps: 3600.48602
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p3-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1850.49905
-  tps: 1778.27732
+  dps: 1849.94178
+  tps: 1777.70811
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p3-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2282.82661
-  tps: 2049.26476
+  dps: 2282.32073
+  tps: 2048.72306
  }
 }
 dps_results: {
@@ -1078,22 +1078,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p4-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3523.58141
-  tps: 3730.6128
+  dps: 3521.49954
+  tps: 3728.00949
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p4-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1860.95375
-  tps: 1788.6211
+  dps: 1860.49769
+  tps: 1788.15125
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p4-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2261.62519
-  tps: 2027.45307
+  dps: 2261.07476
+  tps: 2026.86128
  }
 }
 dps_results: {
@@ -1120,22 +1120,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p5-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4125.12386
-  tps: 4345.75812
+  dps: 4119.32594
+  tps: 4339.08739
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p5-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2178.7827
-  tps: 2107.03713
+  dps: 2177.28854
+  tps: 2105.53193
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p5-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2650.18463
-  tps: 2416.1396
+  dps: 2646.59094
+  tps: 2412.5128
  }
 }
 dps_results: {
@@ -1162,7 +1162,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1463.89703
-  tps: 1392.51832
+  dps: 1458.64995
+  tps: 1387.23212
  }
 }

--- a/sim/druid/feralbear/TestFeralBear.results
+++ b/sim/druid/feralbear/TestFeralBear.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestFeralBear-CharacterStats-Default"
  value: {
-  final_stats: 543.6134
-  final_stats: 639.52185
-  final_stats: 1556.0622
-  final_stats: 358.79844
-  final_stats: 254.82107
-  final_stats: 233.82107
+  final_stats: 541
+  final_stats: 637
+  final_stats: 1553
+  final_stats: 357
+  final_stats: 254.7
+  final_stats: 233.7
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 258.2107
-  final_stats: 3469.09948
+  final_stats: 257
+  final_stats: 3462.8
   final_stats: 495
   final_stats: 894
   final_stats: 93
@@ -29,24 +29,24 @@ character_stats_results: {
   final_stats: 73
   final_stats: 0
   final_stats: 0
-  final_stats: 913.60846
+  final_stats: 910.36342
   final_stats: 0
   final_stats: 65
-  final_stats: 30163.4437
+  final_stats: 30158
   final_stats: 13073.5
-  final_stats: 20344.622
-  final_stats: 7471.9766
-  final_stats: 122.7
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 43.75
+  final_stats: 20314
+  final_stats: 7445
+  final_stats: 122.5
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 43
   final_stats: 80
   final_stats: 4
   final_stats: 6.89756
   final_stats: 4
-  final_stats: 43.38508
-  final_stats: 18.5107
+  final_stats: 43.28421
+  final_stats: 18.48822
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -55,7 +55,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestFeralBear-StatWeights-Default"
  value: {
-  weights: 1.80264
+  weights: 1.60175
   weights: 1
   weights: 0
   weights: 0
@@ -72,18 +72,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.79552
+  weights: 0.72807
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.67701
-  weights: 0.04888
+  weights: 2.76775
+  weights: 0.04677
   weights: 0
   weights: 0
-  weights: 0.16441
+  weights: 0.12931
   weights: 0
   weights: 0
   weights: 0
@@ -109,4035 +109,4035 @@ stat_weights_results: {
 dps_results: {
  key: "TestFeralBear-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 442.84264
-  tps: 683.1979
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 441.76183
+  tps: 681.58791
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 436.59653
-  tps: 673.63534
-  dtps: 1103.92475
-  hps: 71.35766
+  dps: 435.53766
+  tps: 672.02067
+  dtps: 1106.5454
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 440.3661
-  tps: 679.42167
-  dtps: 1113.60006
-  hps: 72.22788
+  dps: 438.96383
+  tps: 677.32149
+  dtps: 1115.65852
+  hps: 71.66133
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 436.97318
-  tps: 674.24781
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.9009
+  tps: 672.65083
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 404.10956
-  tps: 624.95411
-  dtps: 1435.09703
-  hps: 67.92434
+  dps: 402.92726
+  tps: 623.15125
+  dtps: 1436.65313
+  hps: 67.82207
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 73.58741
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 73.48658
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 436.78239
-  tps: 673.95976
-  dtps: 1070.51853
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.36278
+  dtps: 1072.49242
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 448.49465
-  tps: 691.50684
-  dtps: 1133.4518
-  hps: 76.06879
+  dps: 447.72838
+  tps: 690.33838
+  dtps: 1133.27585
+  hps: 75.94418
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 435.92507
-  tps: 672.79704
-  dtps: 1181.74571
-  hps: 73.77322
+  dps: 434.84101
+  tps: 671.14396
+  dtps: 1181.82096
+  hps: 73.6688
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 435.92507
-  tps: 672.79704
-  dtps: 1181.74571
-  hps: 73.77322
+  dps: 434.84101
+  tps: 671.14396
+  dtps: 1181.82096
+  hps: 73.6688
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-BattlecastGarb"
  value: {
-  dps: 392.16242
-  tps: 606.77083
-  dtps: 1476.17881
-  hps: 67.879
+  dps: 391.20242
+  tps: 605.30695
+  dtps: 1480.72815
+  hps: 67.77369
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 443.24323
-  tps: 683.80901
-  dtps: 1113.60006
-  hps: 73.31565
+  dps: 442.45119
+  tps: 682.63936
+  dtps: 1115.65852
+  hps: 73.18142
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 444.3577
-  tps: 685.50812
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 443.27475
+  tps: 683.89488
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 445.30462
-  tps: 686.95201
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 444.22034
+  tps: 685.33674
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 455.18335
-  tps: 702.0165
-  dtps: 1101.40949
-  hps: 73.96831
+  dps: 454.12091
+  tps: 700.43452
+  dtps: 1103.46429
+  hps: 73.83289
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 440.95127
-  tps: 680.314
-  dtps: 1113.60006
-  hps: 72.44543
+  dps: 440.44334
+  tps: 679.5776
+  dtps: 1115.65852
+  hps: 72.3128
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 443.60017
-  tps: 684.35301
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 442.51829
+  tps: 682.7414
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 432.3571
-  tps: 667.43745
-  dtps: 1135.40738
-  hps: 72.80732
+  dps: 431.54448
+  tps: 666.23642
+  dtps: 1135.34936
+  hps: 72.6812
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 436.59653
-  tps: 673.63534
-  dtps: 1103.92475
-  hps: 71.35766
+  dps: 435.53766
+  tps: 672.02067
+  dtps: 1106.5454
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 428.12841
-  tps: 661.02732
-  dtps: 1133.56265
-  hps: 72.58467
+  dps: 427.01002
+  tps: 659.3219
+  dtps: 1134.06581
+  hps: 72.23667
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 407.11216
-  tps: 629.20787
-  dtps: 1228.72365
-  hps: 71.83786
+  dps: 406.52517
+  tps: 628.31279
+  dtps: 1232.51543
+  hps: 71.50027
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.88809
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.76213
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 441.70634
-  tps: 681.46523
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 440.62713
+  tps: 679.85769
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 407.11216
-  tps: 629.20787
-  dtps: 1228.72365
-  hps: 71.65828
+  dps: 406.52517
+  tps: 628.31279
+  dtps: 1232.51543
+  hps: 71.32471
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 440.15685
-  tps: 679.10248
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 439.07982
+  tps: 677.49825
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 436.62308
-  tps: 673.67583
-  dtps: 1104.50461
-  hps: 71.35766
+  dps: 435.56421
+  tps: 672.06116
+  dtps: 1108.98254
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 445.3168
-  tps: 686.97099
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 444.22892
+  tps: 685.35022
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 436.75807
-  tps: 673.76731
-  dtps: 1116.91196
-  hps: 74.51647
+  dps: 435.68579
+  tps: 672.1322
+  dtps: 1119.00572
+  hps: 74.39769
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 439.1368
-  tps: 677.54711
-  dtps: 1113.60006
-  hps: 73.0981
+  dps: 438.06146
+  tps: 675.94547
+  dtps: 1115.65852
+  hps: 72.96427
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-DirebrewHops-38288"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Dragonmaw-28438"
  value: {
-  dps: 368.23317
-  tps: 569.8162
-  dtps: 1155.50277
-  hps: 69.54242
+  dps: 367.79908
+  tps: 569.15427
+  dtps: 1162.02786
+  hps: 69.44413
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 454.41876
-  tps: 700.85046
-  dtps: 1122.20458
-  hps: 73.75076
+  dps: 453.32333
+  tps: 699.21818
+  dtps: 1124.26438
+  hps: 73.61573
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Dragonstrike-28439"
  value: {
-  dps: 377.06319
-  tps: 583.16645
-  dtps: 1154.02472
-  hps: 70.36349
+  dps: 376.62722
+  tps: 582.50164
+  dtps: 1160.54968
+  hps: 70.26507
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 361.29764
-  tps: 559.08801
-  dtps: 1146.02805
-  hps: 69.43595
+  dps: 360.86171
+  tps: 558.42327
+  dtps: 1152.55218
+  hps: 69.312
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Earthstrike-21180"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 73.21578
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 73.08569
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 443.60017
-  tps: 684.35301
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 442.51829
+  tps: 682.7414
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 437.8064
-  tps: 675.48029
-  dtps: 1104.14798
-  hps: 74.03611
+  dps: 436.75019
+  tps: 673.86969
+  dtps: 1110.45729
+  hps: 73.71062
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 434.68082
-  tps: 657.52576
-  dtps: 1129.90995
-  hps: 74.14484
+  dps: 434.1416
+  tps: 656.71995
+  dtps: 1127.16826
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 432.10772
-  tps: 667.14023
-  dtps: 1146.28897
-  hps: 72.33643
+  dps: 431.62867
+  tps: 666.40975
+  dtps: 1148.15512
+  hps: 72.22756
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 436.91954
-  tps: 674.09655
-  dtps: 1083.48716
-  hps: 72.33643
+  dps: 436.41331
+  tps: 673.32462
+  dtps: 1082.25346
+  hps: 72.22756
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 434.67672
-  tps: 671.05769
-  dtps: 1146.28897
-  hps: 72.33643
+  dps: 434.19051
+  tps: 670.31629
+  dtps: 1148.15512
+  hps: 72.22756
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 437.94505
-  tps: 675.9272
-  dtps: 1125.96378
-  hps: 73.91879
+  dps: 437.42807
+  tps: 675.13889
+  dtps: 1125.58402
+  hps: 73.80753
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EverbloomIdol-29390"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EyeofMoam-21473"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 428.15799
-  tps: 661.07243
-  dtps: 1136.95426
-  hps: 72.58467
+  dps: 427.053
+  tps: 659.42557
+  dtps: 1136.89636
+  hps: 72.23667
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-FelSkin"
  value: {
-  dps: 421.63899
-  tps: 638.90976
-  dtps: 1495.12356
-  hps: 63.92661
+  dps: 421.17298
+  tps: 638.21309
+  dtps: 1490.9785
+  hps: 63.8248
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 436.59653
-  tps: 673.63534
-  dtps: 1103.92475
-  hps: 71.35766
+  dps: 435.53766
+  tps: 672.02067
+  dtps: 1106.5454
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 436.56998
-  tps: 673.59485
-  dtps: 1102.76126
-  hps: 71.35766
+  dps: 435.48455
+  tps: 671.9397
+  dtps: 1103.37008
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 441.89573
-  tps: 681.75401
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 440.81625
+  tps: 680.14606
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-FrostscytheofLordAhune-278953"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 76.80815
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 76.69369
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Gladiator'sRefuge"
  value: {
-  dps: 358.8819
-  tps: 546.05641
-  dtps: 1592.13981
-  hps: 67.08097
+  dps: 358.20898
+  tps: 545.12515
+  dtps: 1598.22091
+  hps: 66.96849
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 441.46511
-  tps: 667.99023
-  dtps: 1234.35974
-  hps: 79.18241
+  dps: 440.71032
+  tps: 666.86182
+  dtps: 1241.3137
+  hps: 79.0552
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 358.8819
-  tps: 546.05641
-  dtps: 1592.13981
-  hps: 66.59492
+  dps: 358.20898
+  tps: 545.12515
+  dtps: 1598.22091
+  hps: 66.49182
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-HandofJustice-11815"
  value: {
-  dps: 438.67622
-  tps: 676.84472
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 437.60127
+  tps: 675.24367
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Heartrazor-29962"
  value: {
-  dps: 439.77332
-  tps: 678.21285
-  dtps: 1081.53892
-  hps: 76.92983
+  dps: 438.06173
+  tps: 675.60285
+  dtps: 1082.08349
+  hps: 76.35467
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 445.07685
-  tps: 686.60511
-  dtps: 1113.60006
-  hps: 73.31565
+  dps: 443.66339
+  tps: 684.48785
+  dtps: 1115.65852
+  hps: 72.52996
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IceGuard-2682"
  value: {
-  dps: 431.84199
-  tps: 666.46149
-  dtps: 1115.14526
-  hps: 73.91879
+  dps: 431.34169
+  tps: 665.73672
+  dtps: 1117.20382
+  hps: 73.80753
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IdolofFeralShadows-28372"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IdolofTerror-33509"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IdolofUrsoc-27744"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IdoloftheAvenger-31025"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IdoloftheBeast-25667"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IdoloftheMoon-23197"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IdoloftheWild-28064"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ImbuedNetherweave"
  value: {
-  dps: 394.23203
-  tps: 610.02627
-  dtps: 1624.68853
-  hps: 64.10775
+  dps: 393.44889
+  tps: 608.93949
+  dtps: 1631.75837
+  hps: 63.99578
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-InfinityBlade-30312"
  value: {
-  dps: 447.645
-  tps: 690.52098
-  dtps: 1113.60006
-  hps: 77.47595
+  dps: 447.13707
+  tps: 689.78459
+  dtps: 1115.65852
+  hps: 77.3448
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-IvoryIdoloftheMoongoddess-27518"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-JomGabbar-23570"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-KhoriumScope-2723"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 438.2665
-  tps: 676.21999
-  dtps: 1113.60006
-  hps: 71.79277
+  dps: 437.76201
+  tps: 675.48883
+  dtps: 1115.65852
+  hps: 71.66133
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 436.78239
-  tps: 673.94892
-  dtps: 1096.63325
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.35198
+  dtps: 1098.53612
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 445.8218
-  tps: 687.74071
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 444.73032
+  tps: 686.11445
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-MalorneHarness"
  value: {
-  dps: 413.52586
-  tps: 626.46814
-  dtps: 1176.90645
-  hps: 66.23973
+  dps: 413.03971
+  tps: 625.77872
+  dtps: 1182.24439
+  hps: 66.1228
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-MalorneRegalia"
  value: {
-  dps: 359.07777
-  tps: 546.34924
-  dtps: 1774.89377
-  hps: 58.22393
+  dps: 358.40485
+  tps: 545.41798
+  dtps: 1781.69475
+  hps: 58.13427
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 359.27886
-  tps: 546.64987
-  dtps: 2079.87433
-  hps: 58.38595
+  dps: 358.60594
+  tps: 545.71861
+  dtps: 2087.88669
+  hps: 58.29316
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 420.40394
-  tps: 649.4361
-  dtps: 1243.75426
-  hps: 70.10192
+  dps: 419.65797
+  tps: 648.29858
+  dtps: 1248.37246
+  hps: 70.00064
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-MoongladeRaiment"
  value: {
-  dps: 386.93342
-  tps: 587.48407
-  dtps: 1721.9589
-  hps: 59.45335
+  dps: 385.84847
+  tps: 585.86208
+  dtps: 1721.29376
+  hps: 58.94249
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 436.08563
-  tps: 672.58941
-  dtps: 1077.91893
-  hps: 71.35766
+  dps: 435.08429
+  tps: 671.06247
+  dtps: 1080.70278
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-NetherweaveVestments"
  value: {
-  dps: 371.29786
-  tps: 564.39403
-  dtps: 2054.11042
-  hps: 59.79012
+  dps: 370.75993
+  tps: 563.58982
+  dtps: 2055.14561
+  hps: 59.69138
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-NordrassilHarness"
  value: {
-  dps: 422.48873
-  tps: 639.76309
-  dtps: 1158.81051
-  hps: 68.95254
+  dps: 421.76927
+  tps: 638.72488
+  dtps: 1157.27083
+  hps: 68.84978
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-NordrassilRegalia"
  value: {
-  dps: 359.48604
-  tps: 546.95961
-  dtps: 1729.32251
-  hps: 59.68211
+  dps: 358.81313
+  tps: 546.02835
+  dtps: 1735.94357
+  hps: 59.56427
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Oathbound'sDragonhideBattlegear"
  value: {
-  dps: 388.27057
-  tps: 589.0485
-  dtps: 1601.91318
-  hps: 62.3252
+  dps: 387.09233
+  tps: 587.28704
+  dtps: 1603.83666
+  hps: 62.23231
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Oathbound'sKodohideBattlegear"
  value: {
-  dps: 358.8819
-  tps: 546.05641
-  dtps: 1829.00578
-  hps: 59.19605
+  dps: 358.20898
+  tps: 545.12515
+  dtps: 1836.02078
+  hps: 59.0876
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Oathbound'sWyrmhideBattlegear"
  value: {
-  dps: 358.8819
-  tps: 546.05641
-  dtps: 1829.00578
-  hps: 58.70999
+  dps: 358.20898
+  tps: 545.12515
+  dtps: 1836.02078
+  hps: 58.61093
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 441.32758
-  tps: 680.88768
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 440.2489
+  tps: 679.28094
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 428.09096
-  tps: 660.97021
-  dtps: 1136.95426
-  hps: 73.69274
+  dps: 426.98597
+  tps: 659.32335
+  dtps: 1136.89636
+  hps: 73.35611
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 428.09096
-  tps: 660.97021
-  dtps: 1136.95426
-  hps: 73.69274
+  dps: 426.98597
+  tps: 659.32335
+  dtps: 1136.89636
+  hps: 73.35611
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-PendantofThawing-24093"
  value: {
-  dps: 428.09096
-  tps: 660.97021
-  dtps: 1136.95426
-  hps: 73.69274
+  dps: 426.98597
+  tps: 659.32335
+  dtps: 1136.89636
+  hps: 73.35611
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-PendantofWithering-24095"
  value: {
-  dps: 428.09096
-  tps: 660.97021
-  dtps: 1136.95426
-  hps: 73.69274
+  dps: 426.98597
+  tps: 659.32335
+  dtps: 1136.89636
+  hps: 73.35611
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 428.09096
-  tps: 660.97021
-  dtps: 1136.95426
-  hps: 73.69274
+  dps: 426.98597
+  tps: 659.32335
+  dtps: 1136.89636
+  hps: 73.35611
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-PrimalIntent"
  value: {
-  dps: 442.90956
-  tps: 683.51664
-  dtps: 1204.87736
-  hps: 69.13382
+  dps: 442.46194
+  tps: 682.83407
+  dtps: 1205.22215
+  hps: 69.02756
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-PrimalMooncloth"
  value: {
-  dps: 400.1333
-  tps: 619.00129
-  dtps: 1506.00462
-  hps: 60.42173
+  dps: 399.013
+  tps: 617.29297
+  dtps: 1507.64323
+  hps: 60.30189
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Prismcharm-15867"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 436.64963
-  tps: 673.71631
-  dtps: 1106.94158
-  hps: 71.35766
+  dps: 435.59076
+  tps: 672.10165
+  dtps: 1110.21078
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 420.40394
-  tps: 649.4361
-  dtps: 1243.75426
-  hps: 69.68289
+  dps: 419.65797
+  tps: 648.29858
+  dtps: 1248.37246
+  hps: 69.57798
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 441.70634
-  tps: 681.46523
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 440.62713
+  tps: 679.85769
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-RuneofForce-25994"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 73.21578
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 73.08569
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-SavageGuard-2681"
  value: {
-  dps: 431.84199
-  tps: 666.46149
-  dtps: 1115.14526
-  hps: 73.91879
+  dps: 431.34169
+  tps: 665.73672
+  dtps: 1117.20382
+  hps: 73.80753
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 436.56998
-  tps: 673.59485
-  dtps: 1102.76126
-  hps: 71.35766
+  dps: 435.48455
+  tps: 671.9397
+  dtps: 1103.37008
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 437.0268
-  tps: 674.32958
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.95452
+  tps: 672.7326
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 397.92069
-  tps: 615.62334
-  dtps: 1541.10808
-  hps: 64.47016
+  dps: 397.50411
+  tps: 614.98116
+  dtps: 1549.44444
+  hps: 64.3472
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 435.89425
-  tps: 672.29757
-  dtps: 1071.96764
-  hps: 71.35766
+  dps: 434.9471
+  tps: 670.85328
+  dtps: 1076.73322
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ShardofContempt-34472"
  value: {
-  dps: 464.86587
-  tps: 716.84866
-  dtps: 1104.04741
-  hps: 72.22788
+  dps: 463.69856
+  tps: 715.10675
+  dtps: 1106.10403
+  hps: 72.09564
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 442.84264
-  tps: 683.1979
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 441.76183
+  tps: 681.58791
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-SoulclothEmbrace"
  value: {
-  dps: 398.29884
-  tps: 604.07877
-  dtps: 1557.71296
-  hps: 65.97743
+  dps: 397.82339
+  tps: 603.36799
+  dtps: 1565.33267
+  hps: 65.8822
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 392.74854
-  tps: 607.66461
-  dtps: 1476.17881
-  hps: 64.56384
+  dps: 391.72521
+  tps: 606.10416
+  dtps: 1480.72815
+  hps: 64.45413
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 73.83516
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 73.70524
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-StaffofNaturalFury-31334"
  value: {
-  dps: 511.71263
-  tps: 788.21353
-  dtps: 1068.90739
-  hps: 76.0649
+  dps: 510.60008
+  tps: 786.55524
+  dtps: 1070.87813
+  hps: 75.9648
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 75.44553
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 75.34524
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 436.97318
-  tps: 674.24781
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.9009
+  tps: 672.65083
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 73.21578
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 73.08569
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 462.38949
-  tps: 713.0343
-  dtps: 1103.57261
-  hps: 72.88054
+  dps: 461.21949
+  tps: 711.28828
+  dtps: 1105.62942
+  hps: 72.3128
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 394.08285
-  tps: 609.74853
-  dtps: 1365.17316
-  hps: 64.74129
+  dps: 393.08306
+  tps: 608.22397
+  dtps: 1372.00847
+  hps: 64.63967
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 427.50485
-  tps: 660.00006
-  dtps: 1129.90995
-  hps: 74.14484
+  dps: 426.9773
+  tps: 659.19562
+  dtps: 1127.16826
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 441.51696
-  tps: 681.17645
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 440.43801
+  tps: 679.56932
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 436.93296
-  tps: 674.18648
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.86068
+  tps: 672.5895
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-TheBladefist-29348"
  value: {
-  dps: 357.86296
-  tps: 553.88861
-  dtps: 1154.16237
-  hps: 68.568
+  dps: 357.40454
+  tps: 553.18958
+  dtps: 1157.54629
+  hps: 68.4456
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-TheNightBlade-31331"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 74.14484
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 74.03324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 436.97318
-  tps: 674.24781
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.9009
+  tps: 672.65083
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ThickDraenicArmor"
  value: {
-  dps: 413.34963
-  tps: 626.28702
-  dtps: 1540.18969
-  hps: 66.45045
+  dps: 412.06045
+  tps: 624.3597
+  dtps: 1544.92133
+  hps: 66.33753
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ThunderheartHarness"
  value: {
-  dps: 454.80745
-  tps: 687.51895
-  dtps: 1027.65917
-  hps: 72.57286
+  dps: 453.54803
+  tps: 685.6735
+  dtps: 1028.8068
+  hps: 72.248
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-ThunderheartRegalia"
  value: {
-  dps: 333.52765
-  tps: 509.04187
-  dtps: 1881.8007
-  hps: 50.96468
+  dps: 333.25833
+  tps: 508.6766
+  dtps: 1889.63435
+  hps: 50.86613
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 446.40027
-  tps: 688.62318
-  dtps: 1113.60006
-  hps: 73.31565
+  dps: 445.88973
+  tps: 687.88279
+  dtps: 1115.65852
+  hps: 73.18142
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-UnitingCharm-25633"
  value: {
-  dps: 441.32758
-  tps: 680.88768
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 440.2489
+  tps: 679.28094
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-WastewalkerArmor"
  value: {
-  dps: 397.64919
-  tps: 603.03217
-  dtps: 1631.11338
-  hps: 64.48465
+  dps: 397.05562
+  tps: 602.14478
+  dtps: 1632.12042
+  hps: 64.379
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-WhitemendWisdom"
  value: {
-  dps: 392.16242
-  tps: 606.77083
-  dtps: 1476.17881
-  hps: 65.02912
+  dps: 391.20242
+  tps: 605.30695
+  dtps: 1480.72815
+  hps: 64.93324
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-WindhawkArmor"
  value: {
-  dps: 405.33488
-  tps: 626.83381
-  dtps: 1335.06676
-  hps: 64.87596
+  dps: 404.90184
+  tps: 626.17348
+  dtps: 1336.52046
+  hps: 64.75653
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-WorldBreaker-30090"
  value: {
-  dps: 447.51092
-  tps: 690.31627
-  dtps: 1113.60006
-  hps: 77.30365
+  dps: 446.48973
+  tps: 688.79719
+  dtps: 1115.65852
+  hps: 77.20391
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 435.92507
-  tps: 672.79704
-  dtps: 1181.74571
-  hps: 72.03898
+  dps: 434.84101
+  tps: 671.14396
+  dtps: 1181.82096
+  hps: 71.91947
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-WrathofSpellfire"
  value: {
-  dps: 400.85945
-  tps: 607.91086
-  dtps: 1521.11827
-  hps: 61.83327
+  dps: 400.42455
+  tps: 607.2607
+  dtps: 1517.64513
+  hps: 61.7236
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 436.78239
-  tps: 673.95688
-  dtps: 1113.60006
-  hps: 71.35766
+  dps: 435.71011
+  tps: 672.3599
+  dtps: 1115.65852
+  hps: 71.22702
  }
 }
 dps_results: {
  key: "TestFeralBear-Average-Default"
  value: {
-  dps: 442.40361
-  tps: 681.28515
-  dtps: 1078.04165
-  hps: 75.05716
+  dps: 441.54784
+  tps: 680.00373
+  dtps: 1081.30155
+  hps: 74.86968
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 779.65285
-  tps: 1216.7983
-  dtps: 21087.34356
-  hps: 73.46669
+  dps: 779.70248
+  tps: 1216.87398
+  dtps: 21177.68062
+  hps: 73.35611
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 486.04606
-  tps: 748.89676
-  dtps: 1094.88074
-  hps: 73.46669
+  dps: 484.25859
+  tps: 746.20916
+  dtps: 1097.6542
+  hps: 73.35611
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 494.85936
-  tps: 763.14736
-  dtps: 1131.31753
-  hps: 76.63141
+  dps: 493.3119
+  tps: 761.01637
+  dtps: 1141.69933
+  hps: 76.51607
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 160.82216
-  tps: 245.2377
-  dtps: 46252.35715
-  hps: 37.19231
+  dps: 160.79463
+  tps: 245.19573
+  dtps: 46252.49693
+  hps: 37.1712
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 160.82216
-  tps: 245.28134
-  dtps: 2346.26206
-  hps: 37.19231
+  dps: 160.79463
+  tps: 245.23936
+  dtps: 2346.26915
+  hps: 37.1712
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 165.19031
-  tps: 252.02961
-  dtps: 2335.73254
-  hps: 38.72918
+  dps: 165.16178
+  tps: 251.98611
+  dtps: 2335.7396
+  hps: 38.7072
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 779.65285
-  tps: 1216.7983
-  dtps: 21087.34356
+  dps: 779.70248
+  tps: 1216.87398
+  dtps: 21177.68062
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 486.04606
-  tps: 748.89676
-  dtps: 1094.88074
+  dps: 484.25859
+  tps: 746.20916
+  dtps: 1097.6542
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 494.85936
-  tps: 763.14736
-  dtps: 1131.31753
+  dps: 493.3119
+  tps: 761.01637
+  dtps: 1141.69933
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 160.82216
-  tps: 245.2377
-  dtps: 46252.35715
+  dps: 160.79463
+  tps: 245.19573
+  dtps: 46252.49693
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 160.82216
-  tps: 245.28134
-  dtps: 2346.26206
+  dps: 160.79463
+  tps: 245.23936
+  dtps: 2346.26915
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p1-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 165.19031
-  tps: 252.02961
-  dtps: 2335.73254
+  dps: 165.16178
+  tps: 251.98611
+  dtps: 2335.7396
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 796.0432
-  tps: 1241.10575
-  dtps: 18646.39914
-  hps: 75.13546
+  dps: 796.32069
+  tps: 1241.52889
+  dtps: 18701.91134
+  hps: 75.01173
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 555.23457
-  tps: 853.28982
-  dtps: 951.00606
-  hps: 75.13546
+  dps: 554.52219
+  tps: 852.24163
+  dtps: 959.04741
+  hps: 75.01173
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 558.87446
-  tps: 858.57018
-  dtps: 953.22413
-  hps: 77.50363
+  dps: 558.38648
+  tps: 857.94042
+  dtps: 959.15175
+  hps: 77.376
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 196.7375
-  tps: 300.00501
-  dtps: 43282.01294
-  hps: 40.58043
+  dps: 196.65276
+  tps: 299.87579
+  dtps: 43308.48584
+  hps: 40.55787
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 196.7375
-  tps: 300.05096
-  dtps: 2117.40685
-  hps: 40.58043
+  dps: 196.65276
+  tps: 299.92175
+  dtps: 2117.47692
+  hps: 40.55787
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 199.06909
-  tps: 303.69831
-  dtps: 2182.63305
-  hps: 42.30725
+  dps: 198.98278
+  tps: 303.56674
+  dtps: 2182.70527
+  hps: 42.28373
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 796.0432
-  tps: 1241.10575
-  dtps: 18646.39914
+  dps: 796.32069
+  tps: 1241.52889
+  dtps: 18701.91134
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 555.23457
-  tps: 853.28982
-  dtps: 951.00606
+  dps: 554.52219
+  tps: 852.24163
+  dtps: 959.04741
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 558.87446
-  tps: 858.57018
-  dtps: 953.22413
+  dps: 558.38648
+  tps: 857.94042
+  dtps: 959.15175
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 196.7375
-  tps: 300.00501
-  dtps: 43282.01294
+  dps: 196.65276
+  tps: 299.87579
+  dtps: 43308.48584
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 196.7375
-  tps: 300.05096
-  dtps: 2117.40685
+  dps: 196.65276
+  tps: 299.92175
+  dtps: 2117.47692
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_balanced-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 199.06909
-  tps: 303.69831
-  dtps: 2182.63305
+  dps: 198.98278
+  tps: 303.56674
+  dtps: 2182.70527
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 786.60783
-  tps: 1203.82308
-  dtps: 43800.41627
-  hps: 53.90904
+  dps: 786.4931
+  tps: 1203.65156
+  dtps: 43868.60131
+  hps: 53.6108
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 413.16758
-  tps: 626.51032
-  dtps: 2164.56072
-  hps: 53.90904
+  dps: 412.20345
+  tps: 625.06896
+  dtps: 2167.78723
+  hps: 53.6108
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 422.74533
-  tps: 642.1084
-  dtps: 2319.56224
-  hps: 54.7957
+  dps: 422.22942
+  tps: 641.33711
+  dtps: 2319.94716
+  hps: 54.6724
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 129.15255
-  tps: 193.08306
-  dtps: 92458.14303
-  hps: 23.95799
+  dps: 129.0502
+  tps: 192.93006
+  dtps: 92506.93468
+  hps: 23.84436
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 129.15255
-  tps: 193.09
-  dtps: 4641.67031
-  hps: 23.95799
+  dps: 129.0502
+  tps: 192.937
+  dtps: 4641.89618
+  hps: 23.84436
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 131.20116
-  tps: 196.16657
-  dtps: 4658.98006
-  hps: 24.28618
+  dps: 131.19026
+  tps: 196.15028
+  dtps: 4659.20677
+  hps: 24.28187
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 786.60783
-  tps: 1203.82308
-  dtps: 43800.41627
+  dps: 786.4931
+  tps: 1203.65156
+  dtps: 43868.60131
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 413.16758
-  tps: 626.51032
-  dtps: 2164.56072
+  dps: 412.20345
+  tps: 625.06896
+  dtps: 2167.78723
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 422.74533
-  tps: 642.1084
-  dtps: 2319.56224
+  dps: 422.22942
+  tps: 641.33711
+  dtps: 2319.94716
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 129.15255
-  tps: 193.08306
-  dtps: 92458.14303
+  dps: 129.0502
+  tps: 192.93006
+  dtps: 92506.93468
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 129.15255
-  tps: 193.09
-  dtps: 4641.67031
+  dps: 129.0502
+  tps: 192.937
+  dtps: 4641.89618
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_frost-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 131.20116
-  tps: 196.16657
-  dtps: 4658.98006
+  dps: 131.19026
+  tps: 196.15028
+  dtps: 4659.20677
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 808.53535
-  tps: 1236.67947
-  dtps: 47991.65961
-  hps: 58.94916
+  dps: 808.45207
+  tps: 1236.55497
+  dtps: 48130.84469
+  hps: 58.83476
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 401.11996
-  tps: 608.82162
-  dtps: 2342.9628
-  hps: 58.94916
+  dps: 399.90914
+  tps: 607.01145
+  dtps: 2350.54805
+  hps: 58.83476
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 409.06509
-  tps: 622.06327
-  dtps: 2426.94543
-  hps: 59.95856
+  dps: 408.58904
+  tps: 621.35157
+  dtps: 2431.86867
+  hps: 59.8422
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 125.17634
-  tps: 187.13863
-  dtps: 98479.70355
-  hps: 27.79163
+  dps: 125.04924
+  tps: 186.94861
+  dtps: 98569.11388
+  hps: 27.65933
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 125.17634
-  tps: 187.13863
-  dtps: 4894.87977
-  hps: 27.79163
+  dps: 125.04924
+  tps: 186.94861
+  dtps: 4903.02878
+  hps: 27.65933
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 127.36736
-  tps: 190.41421
-  dtps: 4936.08309
-  hps: 28.4502
+  dps: 127.34105
+  tps: 190.37487
+  dtps: 4936.42871
+  hps: 28.4496
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 808.53535
-  tps: 1236.67947
-  dtps: 47991.65961
+  dps: 808.45207
+  tps: 1236.55497
+  dtps: 48130.84469
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 401.11996
-  tps: 608.82162
-  dtps: 2342.9628
+  dps: 399.90914
+  tps: 607.01145
+  dtps: 2350.54805
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 409.06509
-  tps: 622.06327
-  dtps: 2426.94543
+  dps: 408.58904
+  tps: 621.35157
+  dtps: 2431.86867
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 125.17634
-  tps: 187.13863
-  dtps: 98479.70355
+  dps: 125.04924
+  tps: 186.94861
+  dtps: 98569.11388
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 125.17634
-  tps: 187.13863
-  dtps: 4894.87977
+  dps: 125.04924
+  tps: 186.94861
+  dtps: 4903.02878
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_hydross_nature-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 127.36736
-  tps: 190.41421
-  dtps: 4936.08309
+  dps: 127.34105
+  tps: 190.37487
+  dtps: 4936.42871
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 836.01023
-  tps: 1302.31832
-  dtps: 22004.71959
-  hps: 74.9542
+  dps: 835.85254
+  tps: 1302.07787
+  dtps: 22051.70287
+  hps: 74.83778
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 574.25404
-  tps: 882.74314
-  dtps: 1147.66422
-  hps: 74.9542
+  dps: 573.37946
+  tps: 881.40949
+  dtps: 1150.47593
+  hps: 74.83778
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 579.34774
-  tps: 890.68399
-  dtps: 1128.04822
-  hps: 77.09575
+  dps: 577.83856
+  tps: 888.38263
+  dtps: 1128.18011
+  hps: 76.976
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 204.69991
-  tps: 312.14689
-  dtps: 50755.99579
-  hps: 40.86146
+  dps: 204.58632
+  tps: 311.97368
+  dtps: 50797.51337
+  hps: 40.84716
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 204.69991
-  tps: 312.18413
-  dtps: 2521.517
-  hps: 40.86146
+  dps: 204.58632
+  tps: 312.01095
+  dtps: 2524.21155
+  hps: 40.84716
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 208.53201
-  tps: 318.1022
-  dtps: 2538.07505
-  hps: 42.00443
+  dps: 208.41624
+  tps: 317.92572
+  dtps: 2538.13897
+  hps: 41.98973
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 836.01023
-  tps: 1302.31832
-  dtps: 22004.71959
+  dps: 835.85254
+  tps: 1302.07787
+  dtps: 22051.70287
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 574.25404
-  tps: 882.74314
-  dtps: 1147.66422
+  dps: 573.37946
+  tps: 881.40949
+  dtps: 1150.47593
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 579.34774
-  tps: 890.68399
-  dtps: 1128.04822
+  dps: 577.83856
+  tps: 888.38263
+  dtps: 1128.18011
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 204.69991
-  tps: 312.14689
-  dtps: 50755.99579
+  dps: 204.58632
+  tps: 311.97368
+  dtps: 50797.51337
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 204.69991
-  tps: 312.18413
-  dtps: 2521.517
+  dps: 204.58632
+  tps: 312.01095
+  dtps: 2524.21155
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_offensive-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 208.53201
-  tps: 318.1022
-  dtps: 2538.07505
+  dps: 208.41624
+  tps: 317.92572
+  dtps: 2538.13897
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 765.34212
-  tps: 1194.55652
-  dtps: 17484.78981
-  hps: 78.37128
+  dps: 765.84862
+  tps: 1195.32889
+  dtps: 17574.44758
+  hps: 78.25449
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 500.64572
-  tps: 770.49086
-  dtps: 913.71527
-  hps: 78.37128
+  dps: 499.58223
+  tps: 768.90728
+  dtps: 914.97087
+  hps: 78.25449
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 504.89975
-  tps: 777.36616
-  dtps: 898.43022
-  hps: 80.0541
+  dps: 503.52691
+  tps: 775.2727
+  dtps: 895.40315
+  hps: 79.9348
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 169.83818
-  tps: 258.98624
-  dtps: 39358.39875
-  hps: 40.68307
+  dps: 169.69509
+  tps: 258.76804
+  dtps: 39390.3477
+  hps: 40.67751
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 169.83818
-  tps: 259.02693
-  dtps: 1955.60374
-  hps: 40.68307
+  dps: 169.69509
+  tps: 258.80874
+  dtps: 1957.74415
+  hps: 40.67751
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 174.50615
-  tps: 266.22652
-  dtps: 1966.39385
-  hps: 41.51674
+  dps: 174.47291
+  tps: 266.17586
+  dtps: 1972.72482
+  hps: 41.51107
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 765.34212
-  tps: 1194.55652
-  dtps: 17484.78981
+  dps: 765.84862
+  tps: 1195.32889
+  dtps: 17574.44758
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 500.64572
-  tps: 770.49086
-  dtps: 913.71527
+  dps: 499.58223
+  tps: 768.90728
+  dtps: 914.97087
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 504.89975
-  tps: 777.36616
-  dtps: 898.43022
+  dps: 503.52691
+  tps: 775.2727
+  dtps: 895.40315
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 169.83818
-  tps: 258.98624
-  dtps: 39358.39875
+  dps: 169.69509
+  tps: 258.76804
+  dtps: 39390.3477
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 169.83818
-  tps: 259.02693
-  dtps: 1955.60374
+  dps: 169.69509
+  tps: 258.80874
+  dtps: 1957.74415
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_survival-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 174.50615
-  tps: 266.22652
-  dtps: 1966.39385
+  dps: 174.47291
+  tps: 266.17586
+  dtps: 1972.72482
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 815.84561
-  tps: 1246.63657
-  dtps: 22711.16551
-  hps: 68.00441
+  dps: 816.31689
+  tps: 1247.34113
+  dtps: 22786.65236
+  hps: 67.87342
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 553.47874
-  tps: 834.38327
-  dtps: 1185.24115
-  hps: 68.00441
+  dps: 552.94131
+  tps: 833.57982
+  dtps: 1185.44187
+  hps: 67.87342
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 557.76231
-  tps: 840.97307
-  dtps: 1162.29363
-  hps: 70.12955
+  dps: 557.1954
+  tps: 840.12554
+  dtps: 1157.98033
+  hps: 69.99447
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 198.84661
-  tps: 297.27569
-  dtps: 52511.6339
-  hps: 36.52608
+  dps: 198.83966
+  tps: 297.26529
+  dtps: 52536.49742
+  hps: 36.49478
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 198.84661
-  tps: 297.31986
-  dtps: 2612.664
-  hps: 36.52608
+  dps: 198.83966
+  tps: 297.30251
+  dtps: 2618.29921
+  hps: 36.49478
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 206.91165
-  tps: 309.46542
-  dtps: 2628.96801
-  hps: 38.63097
+  dps: 206.90443
+  tps: 309.4338
+  dtps: 2639.87759
+  hps: 38.59787
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 815.84561
-  tps: 1246.63657
-  dtps: 22711.16551
+  dps: 816.31689
+  tps: 1247.34113
+  dtps: 22786.65236
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 553.47874
-  tps: 834.38327
-  dtps: 1185.24115
+  dps: 552.94131
+  tps: 833.57982
+  dtps: 1185.44187
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 557.76231
-  tps: 840.97307
-  dtps: 1162.29363
+  dps: 557.1954
+  tps: 840.12554
+  dtps: 1157.98033
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 198.84661
-  tps: 297.27569
-  dtps: 52511.6339
+  dps: 198.83966
+  tps: 297.26529
+  dtps: 52536.49742
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 198.84661
-  tps: 297.31986
-  dtps: 2612.664
+  dps: 198.83966
+  tps: 297.30251
+  dtps: 2618.29921
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p2_warden-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 206.91165
-  tps: 309.46542
-  dtps: 2628.96801
+  dps: 206.90443
+  tps: 309.4338
+  dtps: 2639.87759
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 745.14864
-  tps: 1162.35295
-  dtps: 13702.99242
-  hps: 83.76766
+  dps: 745.04703
+  tps: 1162.19801
+  dtps: 13743.92773
+  hps: 83.6532
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 545.32173
-  tps: 837.30385
-  dtps: 688.05401
-  hps: 83.76766
+  dps: 544.41068
+  tps: 835.9146
+  dtps: 689.12466
+  hps: 83.6532
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 551.93622
-  tps: 846.98158
-  dtps: 688.74855
-  hps: 86.70688
+  dps: 550.3835
+  tps: 844.72821
+  dtps: 691.85341
+  hps: 86.5884
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 189.20041
-  tps: 288.51171
-  dtps: 33347.25738
-  hps: 46.3014
+  dps: 189.03494
+  tps: 288.25939
+  dtps: 33381.11786
+  hps: 46.29282
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 189.20041
-  tps: 288.55653
-  dtps: 1656.39519
-  hps: 46.3014
+  dps: 189.03494
+  tps: 288.30421
+  dtps: 1656.43066
+  hps: 46.29282
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 195.60545
-  tps: 298.41321
-  dtps: 1736.60436
-  hps: 48.69336
+  dps: 195.56164
+  tps: 298.34642
+  dtps: 1736.64155
+  hps: 48.68433
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 745.14864
-  tps: 1162.35295
-  dtps: 13702.99242
+  dps: 745.04703
+  tps: 1162.19801
+  dtps: 13743.92773
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 545.32173
-  tps: 837.30385
-  dtps: 688.05401
+  dps: 544.41068
+  tps: 835.9146
+  dtps: 689.12466
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 551.93622
-  tps: 846.98158
-  dtps: 688.74855
+  dps: 550.3835
+  tps: 844.72821
+  dtps: 691.85341
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 189.20041
-  tps: 288.51171
-  dtps: 33347.25738
+  dps: 189.03494
+  tps: 288.25939
+  dtps: 33381.11786
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 189.20041
-  tps: 288.55653
-  dtps: 1656.39519
+  dps: 189.03494
+  tps: 288.30421
+  dtps: 1656.43066
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p3-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 195.60545
-  tps: 298.41321
-  dtps: 1736.60436
+  dps: 195.56164
+  tps: 298.34642
+  dtps: 1736.64155
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 760.77926
-  tps: 1185.99747
-  dtps: 14294.19769
-  hps: 84.99234
+  dps: 761.02045
+  tps: 1186.36526
+  dtps: 14344.14627
+  hps: 84.8762
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 566.06004
-  tps: 868.71198
-  dtps: 714.06455
-  hps: 84.99234
+  dps: 565.39899
+  tps: 867.70401
+  dtps: 715.12274
+  hps: 84.8762
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 574.46853
-  tps: 881.03703
-  dtps: 708.57769
-  hps: 88.91129
+  dps: 573.78415
+  tps: 879.99359
+  dtps: 708.63456
+  hps: 88.7898
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 198.62549
-  tps: 302.88401
-  dtps: 35230.88925
-  hps: 47.66824
+  dps: 198.40954
+  tps: 302.55471
+  dtps: 35272.98056
+  hps: 47.6594
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 198.62549
-  tps: 302.94154
-  dtps: 1748.46362
-  hps: 47.66824
+  dps: 198.40954
+  tps: 302.61225
+  dtps: 1752.81217
+  hps: 47.6594
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 206.34367
-  tps: 314.82605
-  dtps: 1821.71387
-  hps: 50.74361
+  dps: 205.81785
+  tps: 314.02426
+  dtps: 1829.21677
+  hps: 50.7342
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 760.77926
-  tps: 1185.99747
-  dtps: 14294.19769
+  dps: 761.02045
+  tps: 1186.36526
+  dtps: 14344.14627
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 566.06004
-  tps: 868.71198
-  dtps: 714.06455
+  dps: 565.39899
+  tps: 867.70401
+  dtps: 715.12274
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 574.46853
-  tps: 881.03703
-  dtps: 708.57769
+  dps: 573.78415
+  tps: 879.99359
+  dtps: 708.63456
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 198.62549
-  tps: 302.88401
-  dtps: 35230.88925
+  dps: 198.40954
+  tps: 302.55471
+  dtps: 35272.98056
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 198.62549
-  tps: 302.94154
-  dtps: 1748.46362
+  dps: 198.40954
+  tps: 302.61225
+  dtps: 1752.81217
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p4-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 206.34367
-  tps: 314.82605
-  dtps: 1821.71387
+  dps: 205.81785
+  tps: 314.02426
+  dtps: 1829.21677
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 791.75354
-  tps: 1234.22134
-  dtps: 14995.56073
-  hps: 109.56855
+  dps: 792.11222
+  tps: 1234.80642
+  dtps: 15069.80821
+  hps: 109.44107
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 571.1654
-  tps: 877.21541
-  dtps: 755.22559
-  hps: 109.56855
+  dps: 570.26353
+  tps: 875.84014
+  dtps: 752.50129
+  hps: 109.44107
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 579.29839
-  tps: 889.29882
-  dtps: 748.47862
-  hps: 113.28274
+  dps: 577.79776
+  tps: 887.01052
+  dtps: 746.61565
+  hps: 113.15093
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 199.11014
-  tps: 303.62305
-  dtps: 35171.34281
-  hps: 65.88484
+  dps: 198.92753
+  tps: 303.34459
+  dtps: 35211.85388
+  hps: 65.86331
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 199.11014
-  tps: 303.67534
-  dtps: 1724.95596
-  hps: 65.88484
+  dps: 198.92753
+  tps: 303.39689
+  dtps: 1729.71118
+  hps: 65.86331
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 207.74762
-  tps: 316.95121
-  dtps: 1791.54321
-  hps: 70.24655
+  dps: 207.30579
+  tps: 316.27749
+  dtps: 1805.67952
+  hps: 70.2236
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 791.75354
-  tps: 1234.22134
-  dtps: 14995.56073
+  dps: 792.11222
+  tps: 1234.80642
+  dtps: 15069.80821
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 571.1654
-  tps: 877.21541
-  dtps: 755.22559
+  dps: 570.26353
+  tps: 875.84014
+  dtps: 752.50129
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 579.29839
-  tps: 889.29882
-  dtps: 748.47862
+  dps: 577.79776
+  tps: 887.01052
+  dtps: 746.61565
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 199.11014
-  tps: 303.62305
-  dtps: 35171.34281
+  dps: 198.92753
+  tps: 303.34459
+  dtps: 35211.85388
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 199.11014
-  tps: 303.67534
-  dtps: 1724.95596
+  dps: 198.92753
+  tps: 303.39689
+  dtps: 1729.71118
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-p5-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 207.74762
-  tps: 316.95121
-  dtps: 1791.54321
+  dps: 207.30579
+  tps: 316.27749
+  dtps: 1805.67952
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 758.47609
-  tps: 1184.58211
-  dtps: 28263.93672
-  hps: 70.64066
+  dps: 758.96917
+  tps: 1185.334
+  dtps: 28334.46007
+  hps: 70.52898
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 443.96633
-  tps: 684.89221
-  dtps: 1430.86131
-  hps: 70.64066
+  dps: 443.50432
+  tps: 684.1877
+  dtps: 1432.7594
+  hps: 70.52898
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 445.50261
-  tps: 688.37176
-  dtps: 1504.81628
-  hps: 70.8635
+  dps: 445.0665
+  tps: 687.8211
+  dtps: 1510.68261
+  hps: 70.75147
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 139.00819
-  tps: 211.97358
-  dtps: 61578.07718
-  hps: 35.883
+  dps: 138.97683
+  tps: 211.92576
+  dtps: 61599.32753
+  hps: 35.86924
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 139.00819
-  tps: 211.98747
-  dtps: 3130.39873
-  hps: 35.883
+  dps: 138.97683
+  tps: 211.93965
+  dtps: 3130.45557
+  hps: 35.86924
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 142.43816
-  tps: 217.24561
-  dtps: 3076.73538
-  hps: 37.08915
+  dps: 142.40604
+  tps: 217.19663
+  dtps: 3076.79124
+  hps: 37.07493
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 758.47609
-  tps: 1184.58211
-  dtps: 28263.93672
+  dps: 758.96917
+  tps: 1185.334
+  dtps: 28334.46007
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 443.96633
-  tps: 684.89221
-  dtps: 1430.86131
+  dps: 443.50432
+  tps: 684.1877
+  dtps: 1432.7594
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 445.50261
-  tps: 688.37176
-  dtps: 1504.81628
+  dps: 445.0665
+  tps: 687.8211
+  dtps: 1510.68261
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 139.00819
-  tps: 211.97358
-  dtps: 61578.07718
+  dps: 138.97683
+  tps: 211.92576
+  dtps: 61599.32753
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 139.00819
-  tps: 211.98747
-  dtps: 3130.39873
+  dps: 138.97683
+  tps: 211.93965
+  dtps: 3130.45557
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-NightElf-preraid-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 142.43816
-  tps: 217.24561
-  dtps: 3076.73538
+  dps: 142.40604
+  tps: 217.19663
+  dtps: 3076.79124
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 789.27804
-  tps: 1231.51388
-  dtps: 21773.13344
-  hps: 76.72936
+  dps: 789.82922
+  tps: 1232.35437
+  dtps: 21850.54919
+  hps: 76.38806
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 485.64841
-  tps: 748.40476
-  dtps: 1118.89022
-  hps: 76.72936
+  dps: 484.7547
+  tps: 747.04193
+  dtps: 1117.39783
+  hps: 76.38806
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 495.69848
-  tps: 764.99878
-  dtps: 1182.53743
-  hps: 79.81754
+  dps: 494.21004
+  tps: 762.72905
+  dtps: 1176.75653
+  hps: 78.99759
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 161.08025
-  tps: 245.63127
-  dtps: 47289.94876
-  hps: 38.44934
+  dps: 161.02438
+  tps: 245.54608
+  dtps: 47322.87642
+  hps: 38.44017
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 161.08025
-  tps: 245.67476
-  dtps: 2395.1325
-  hps: 38.44934
+  dps: 161.02438
+  tps: 245.58957
+  dtps: 2400.36798
+  hps: 38.44017
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 165.46931
-  tps: 252.45462
-  dtps: 2375.26698
-  hps: 39.74175
+  dps: 165.4114
+  tps: 252.36631
+  dtps: 2375.36513
+  hps: 39.73228
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 789.27804
-  tps: 1231.51388
-  dtps: 21773.13344
+  dps: 789.82922
+  tps: 1232.35437
+  dtps: 21850.54919
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 485.64841
-  tps: 748.40476
-  dtps: 1118.89022
+  dps: 484.7547
+  tps: 747.04193
+  dtps: 1117.39783
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 495.69848
-  tps: 764.99878
-  dtps: 1182.53743
+  dps: 494.21004
+  tps: 762.72905
+  dtps: 1176.75653
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 161.08025
-  tps: 245.63127
-  dtps: 47289.94876
+  dps: 161.02438
+  tps: 245.54608
+  dtps: 47322.87642
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 161.08025
-  tps: 245.67476
-  dtps: 2395.1325
+  dps: 161.02438
+  tps: 245.58957
+  dtps: 2400.36798
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p1-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 165.46931
-  tps: 252.45462
-  dtps: 2375.26698
+  dps: 165.4114
+  tps: 252.36631
+  dtps: 2375.36513
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 806.65051
-  tps: 1257.35707
-  dtps: 19235.46757
-  hps: 78.73518
+  dps: 806.31177
+  tps: 1256.84052
+  dtps: 19283.57394
+  hps: 78.61784
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 557.12989
-  tps: 856.47803
-  dtps: 1003.24777
-  hps: 78.73518
+  dps: 556.37677
+  tps: 855.3296
+  dtps: 1005.0091
+  hps: 78.61784
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 559.89427
-  tps: 860.67629
-  dtps: 986.92259
-  hps: 80.77144
+  dps: 559.28348
+  tps: 859.7449
+  dtps: 987.03918
+  hps: 80.65106
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 196.88536
-  tps: 300.23049
-  dtps: 44451.80767
-  hps: 42.20645
+  dps: 196.7694
+  tps: 300.05365
+  dtps: 44476.39708
+  hps: 42.19782
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 196.88536
-  tps: 300.26931
-  dtps: 2208.06242
-  hps: 42.20645
+  dps: 196.7694
+  tps: 300.0925
+  dtps: 2209.87931
+  hps: 42.19782
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 199.79862
-  tps: 304.7894
-  dtps: 2234.45015
-  hps: 44.47561
+  dps: 199.68019
+  tps: 304.60885
+  dtps: 2231.83387
+  hps: 44.46652
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 806.65051
-  tps: 1257.35707
-  dtps: 19235.46757
+  dps: 806.31177
+  tps: 1256.84052
+  dtps: 19283.57394
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 557.12989
-  tps: 856.47803
-  dtps: 1003.24777
+  dps: 556.37677
+  tps: 855.3296
+  dtps: 1005.0091
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 559.89427
-  tps: 860.67629
-  dtps: 986.92259
+  dps: 559.28348
+  tps: 859.7449
+  dtps: 987.03918
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 196.88536
-  tps: 300.23049
-  dtps: 44451.80767
+  dps: 196.7694
+  tps: 300.05365
+  dtps: 44476.39708
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 196.88536
-  tps: 300.26931
-  dtps: 2208.06242
+  dps: 196.7694
+  tps: 300.0925
+  dtps: 2209.87931
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_balanced-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 199.79862
-  tps: 304.7894
-  dtps: 2234.45015
+  dps: 199.68019
+  tps: 304.60885
+  dtps: 2231.83387
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 792.23721
-  tps: 1212.27638
-  dtps: 45039.30753
-  hps: 56.10557
+  dps: 792.4657
+  tps: 1212.61798
+  dtps: 45148.55696
+  hps: 55.99001
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 409.15076
-  tps: 620.6851
-  dtps: 2213.01194
-  hps: 56.10557
+  dps: 408.41102
+  tps: 619.5792
+  dtps: 2215.96414
+  hps: 55.99001
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 419.41688
-  tps: 637.22366
-  dtps: 2344.62562
-  hps: 57.59675
+  dps: 418.17558
+  tps: 635.36791
+  dtps: 2340.92955
+  hps: 57.47812
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 129.7722
-  tps: 194.00944
-  dtps: 94201.78232
-  hps: 24.96527
+  dps: 129.73524
+  tps: 193.95419
+  dtps: 94226.32734
+  hps: 24.94704
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 129.7722
-  tps: 194.01639
-  dtps: 4704.22729
-  hps: 24.96527
+  dps: 129.73524
+  tps: 193.96113
+  dtps: 4709.81203
+  hps: 24.94704
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 131.54415
-  tps: 196.67934
-  dtps: 4745.75019
-  hps: 25.19537
+  dps: 131.50668
+  tps: 196.62332
+  dtps: 4745.88044
+  hps: 25.17697
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 792.23721
-  tps: 1212.27638
-  dtps: 45039.30753
+  dps: 792.4657
+  tps: 1212.61798
+  dtps: 45148.55696
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 409.15076
-  tps: 620.6851
-  dtps: 2213.01194
+  dps: 408.41102
+  tps: 619.5792
+  dtps: 2215.96414
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 419.41688
-  tps: 637.22366
-  dtps: 2344.62562
+  dps: 418.17558
+  tps: 635.36791
+  dtps: 2340.92955
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 129.7722
-  tps: 194.00944
-  dtps: 94201.78232
+  dps: 129.73524
+  tps: 193.95419
+  dtps: 94226.32734
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 129.7722
-  tps: 194.01639
-  dtps: 4704.22729
+  dps: 129.73524
+  tps: 193.96113
+  dtps: 4709.81203
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_frost-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 131.54415
-  tps: 196.67934
-  dtps: 4745.75019
+  dps: 131.50668
+  tps: 196.62332
+  dtps: 4745.88044
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 815.82235
-  tps: 1247.61092
-  dtps: 49273.87568
-  hps: 61.74234
+  dps: 815.34473
+  tps: 1246.89687
+  dtps: 49346.93958
+  hps: 61.42103
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 399.29284
-  tps: 606.32128
-  dtps: 2441.25815
-  hps: 61.74234
+  dps: 398.01919
+  tps: 604.41716
+  dtps: 2448.60069
+  hps: 61.42103
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 406.50212
-  tps: 618.36459
-  dtps: 2443.58235
-  hps: 62.37886
+  dps: 405.9952
+  tps: 617.60674
+  dtps: 2455.79766
+  hps: 62.26822
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 125.74474
-  tps: 187.98838
-  dtps: 100431.56196
-  hps: 28.94229
+  dps: 125.69311
+  tps: 187.9112
+  dtps: 100501.80961
+  hps: 28.92839
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 125.74474
-  tps: 187.98838
-  dtps: 4995.83989
-  hps: 28.94229
+  dps: 125.69311
+  tps: 187.9112
+  dtps: 5010.6254
+  hps: 28.92839
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 128.27092
-  tps: 191.76502
-  dtps: 5053.8131
-  hps: 29.91164
+  dps: 128.21828
+  tps: 191.68633
+  dtps: 5082.28073
+  hps: 29.89728
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 815.82235
-  tps: 1247.61092
-  dtps: 49273.87568
+  dps: 815.34473
+  tps: 1246.89687
+  dtps: 49346.93958
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 399.29284
-  tps: 606.32128
-  dtps: 2441.25815
+  dps: 398.01919
+  tps: 604.41716
+  dtps: 2448.60069
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 406.50212
-  tps: 618.36459
-  dtps: 2443.58235
+  dps: 405.9952
+  tps: 617.60674
+  dtps: 2455.79766
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 125.74474
-  tps: 187.98838
-  dtps: 100431.56196
+  dps: 125.69311
+  tps: 187.9112
+  dtps: 100501.80961
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 125.74474
-  tps: 187.98838
-  dtps: 4995.83989
+  dps: 125.69311
+  tps: 187.9112
+  dtps: 5010.6254
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_hydross_nature-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 128.27092
-  tps: 191.76502
-  dtps: 5053.8131
+  dps: 128.21828
+  tps: 191.68633
+  dtps: 5082.28073
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 846.79318
-  tps: 1318.98998
-  dtps: 22882.42703
-  hps: 78.54624
+  dps: 846.84941
+  tps: 1319.11385
+  dtps: 22955.4988
+  hps: 78.17124
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 575.02337
-  tps: 884.14502
-  dtps: 1192.0687
-  hps: 78.54624
+  dps: 574.16421
+  tps: 882.94926
+  dtps: 1199.24823
+  hps: 78.17124
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 580.36239
-  tps: 892.68869
-  dtps: 1184.07459
-  hps: 81.02191
+  dps: 578.904
+  tps: 890.57916
+  dtps: 1198.04025
+  hps: 80.19291
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 204.64444
-  tps: 312.06231
-  dtps: 51906.36983
-  hps: 42.50549
+  dps: 204.61738
+  tps: 312.02104
+  dtps: 51916.22924
+  hps: 42.47264
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 204.64444
-  tps: 312.09243
-  dtps: 2589.34161
-  hps: 42.50549
+  dps: 204.61738
+  tps: 312.05116
+  dtps: 2593.00668
+  hps: 42.47264
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 208.32886
-  tps: 317.77104
-  dtps: 2587.6346
-  hps: 44.15765
+  dps: 208.30129
+  tps: 317.72901
+  dtps: 2587.66341
+  hps: 44.12352
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 846.79318
-  tps: 1318.98998
-  dtps: 22882.42703
+  dps: 846.84941
+  tps: 1319.11385
+  dtps: 22955.4988
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 575.02337
-  tps: 884.14502
-  dtps: 1192.0687
+  dps: 574.16421
+  tps: 882.94926
+  dtps: 1199.24823
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 580.36239
-  tps: 892.68869
-  dtps: 1184.07459
+  dps: 578.904
+  tps: 890.57916
+  dtps: 1198.04025
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 204.64444
-  tps: 312.06231
-  dtps: 51906.36983
+  dps: 204.61738
+  tps: 312.02104
+  dtps: 51916.22924
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 204.64444
-  tps: 312.09243
-  dtps: 2589.34161
+  dps: 204.61738
+  tps: 312.05116
+  dtps: 2593.00668
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_offensive-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 208.32886
-  tps: 317.77104
-  dtps: 2587.6346
+  dps: 208.30129
+  tps: 317.72901
+  dtps: 2587.66341
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 772.1201
-  tps: 1205.15913
-  dtps: 18213.42204
-  hps: 81.09137
+  dps: 772.85537
+  tps: 1206.28033
+  dtps: 18275.09549
+  hps: 80.98188
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 496.85286
-  tps: 765.05023
-  dtps: 952.63066
-  hps: 81.09137
+  dps: 496.29144
+  tps: 764.19413
+  dtps: 953.44152
+  hps: 80.98188
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 502.77966
-  tps: 774.47632
-  dtps: 944.53289
-  hps: 83.36496
+  dps: 502.26374
+  tps: 773.6896
+  dtps: 951.1935
+  hps: 83.2524
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 170.23329
-  tps: 259.58875
-  dtps: 40232.98267
-  hps: 42.4107
+  dps: 170.17245
+  tps: 259.49597
+  dtps: 40242.84562
+  hps: 42.38953
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 170.23329
-  tps: 259.62232
-  dtps: 2008.71174
-  hps: 42.4107
+  dps: 170.17245
+  tps: 259.52955
+  dtps: 2008.73636
+  hps: 42.38953
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 174.81906
-  tps: 266.6823
-  dtps: 2004.5725
-  hps: 43.11171
+  dps: 174.75618
+  tps: 266.58645
+  dtps: 2004.59707
+  hps: 43.09018
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 772.1201
-  tps: 1205.15913
-  dtps: 18213.42204
+  dps: 772.85537
+  tps: 1206.28033
+  dtps: 18275.09549
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 496.85286
-  tps: 765.05023
-  dtps: 952.63066
+  dps: 496.29144
+  tps: 764.19413
+  dtps: 953.44152
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 502.77966
-  tps: 774.47632
-  dtps: 944.53289
+  dps: 502.26374
+  tps: 773.6896
+  dtps: 951.1935
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 170.23329
-  tps: 259.58875
-  dtps: 40232.98267
+  dps: 170.17245
+  tps: 259.49597
+  dtps: 40242.84562
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 170.23329
-  tps: 259.62232
-  dtps: 2008.71174
+  dps: 170.17245
+  tps: 259.52955
+  dtps: 2008.73636
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_survival-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 174.81906
-  tps: 266.6823
-  dtps: 2004.5725
+  dps: 174.75618
+  tps: 266.58645
+  dtps: 2004.59707
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 827.0184
-  tps: 1263.6015
-  dtps: 23641.58746
-  hps: 70.86527
+  dps: 827.62027
+  tps: 1264.5013
+  dtps: 23724.91606
+  hps: 70.74114
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 554.46595
-  tps: 836.19553
-  dtps: 1235.50994
-  hps: 70.86527
+  dps: 553.95317
+  tps: 835.42892
+  dtps: 1244.62188
+  hps: 70.74114
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 559.88072
-  tps: 844.70072
-  dtps: 1234.28758
-  hps: 73.09885
+  dps: 559.3506
+  tps: 843.90819
+  dtps: 1237.69695
+  hps: 72.9708
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 199.40482
-  tps: 298.1102
-  dtps: 53647.95503
-  hps: 38.14518
+  dps: 199.36665
+  tps: 298.05315
+  dtps: 53655.26048
+  hps: 38.12809
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 199.40482
-  tps: 298.14725
-  dtps: 2679.68998
-  hps: 38.14518
+  dps: 199.36665
+  tps: 298.0902
+  dtps: 2679.70133
+  hps: 38.12809
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 207.64568
-  tps: 310.54144
-  dtps: 2678.91012
-  hps: 40.61876
+  dps: 207.60604
+  tps: 310.4822
+  dtps: 2678.92147
+  hps: 40.60056
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 827.0184
-  tps: 1263.6015
-  dtps: 23641.58746
+  dps: 827.62027
+  tps: 1264.5013
+  dtps: 23724.91606
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 554.46595
-  tps: 836.19553
-  dtps: 1235.50994
+  dps: 553.95317
+  tps: 835.42892
+  dtps: 1244.62188
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 559.88072
-  tps: 844.70072
-  dtps: 1234.28758
+  dps: 559.3506
+  tps: 843.90819
+  dtps: 1237.69695
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 199.40482
-  tps: 298.1102
-  dtps: 53647.95503
+  dps: 199.36665
+  tps: 298.05315
+  dtps: 53655.26048
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 199.40482
-  tps: 298.14725
-  dtps: 2679.68998
+  dps: 199.36665
+  tps: 298.0902
+  dtps: 2679.70133
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p2_warden-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 207.64568
-  tps: 310.54144
-  dtps: 2678.91012
+  dps: 207.60604
+  tps: 310.4822
+  dtps: 2678.92147
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 751.79785
-  tps: 1172.94979
-  dtps: 14358.91363
-  hps: 86.99434
+  dps: 752.04146
+  tps: 1173.32128
+  dtps: 14456.07829
+  hps: 86.59103
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 541.63738
-  tps: 832.02869
-  dtps: 730.44395
-  hps: 86.99434
+  dps: 540.46138
+  tps: 830.27354
+  dtps: 735.65978
+  hps: 86.59103
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 550.23056
-  tps: 844.83808
-  dtps: 726.28434
-  hps: 90.34027
+  dps: 548.69399
+  tps: 842.49497
+  dtps: 724.53721
+  hps: 89.41744
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 189.25921
-  tps: 288.60137
-  dtps: 34276.49309
-  hps: 48.30617
+  dps: 189.18712
+  tps: 288.49144
+  dtps: 34279.09792
+  hps: 48.28012
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 189.25921
-  tps: 288.63907
-  dtps: 1684.3353
-  hps: 48.30617
+  dps: 189.18712
+  tps: 288.52915
+  dtps: 1684.35334
+  hps: 48.28012
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 194.95062
-  tps: 297.39328
-  dtps: 1752.00698
-  hps: 50.10194
+  dps: 194.8763
+  tps: 297.27998
+  dtps: 1752.02574
+  hps: 50.07492
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 751.79785
-  tps: 1172.94979
-  dtps: 14358.91363
+  dps: 752.04146
+  tps: 1173.32128
+  dtps: 14456.07829
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 541.63738
-  tps: 832.02869
-  dtps: 730.44395
+  dps: 540.46138
+  tps: 830.27354
+  dtps: 735.65978
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 550.23056
-  tps: 844.83808
-  dtps: 726.28434
+  dps: 548.69399
+  tps: 842.49497
+  dtps: 724.53721
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 189.25921
-  tps: 288.60137
-  dtps: 34276.49309
+  dps: 189.18712
+  tps: 288.49144
+  dtps: 34279.09792
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 189.25921
-  tps: 288.63907
-  dtps: 1684.3353
+  dps: 189.18712
+  tps: 288.52915
+  dtps: 1684.35334
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p3-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 194.95062
-  tps: 297.39328
-  dtps: 1752.00698
+  dps: 194.8763
+  tps: 297.27998
+  dtps: 1752.02574
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 765.97384
-  tps: 1194.37616
-  dtps: 14972.37891
-  hps: 88.796
+  dps: 766.60593
+  tps: 1195.37815
+  dtps: 15050.055
+  hps: 88.6466
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 560.84141
-  tps: 861.28174
-  dtps: 753.60436
-  hps: 88.796
+  dps: 560.26578
+  tps: 860.44209
+  dtps: 763.56893
+  hps: 88.6466
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 567.16663
-  tps: 870.57036
-  dtps: 761.39978
-  hps: 91.88455
+  dps: 566.4507
+  tps: 869.47864
+  dtps: 761.48282
+  hps: 91.72996
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 199.13203
-  tps: 303.65643
-  dtps: 36313.03775
-  hps: 49.92236
+  dps: 198.90292
+  tps: 303.30707
+  dtps: 36340.26383
+  hps: 49.89544
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 199.13203
-  tps: 303.70683
-  dtps: 1795.12676
-  hps: 49.92236
+  dps: 198.90292
+  tps: 303.35749
+  dtps: 1797.18352
+  hps: 49.89544
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 206.18255
-  tps: 314.55897
-  dtps: 1870.71589
-  hps: 52.79559
+  dps: 205.67808
+  tps: 313.78975
+  dtps: 1879.52582
+  hps: 52.76712
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 765.97384
-  tps: 1194.37616
-  dtps: 14972.37891
+  dps: 766.60593
+  tps: 1195.37815
+  dtps: 15050.055
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 560.84141
-  tps: 861.28174
-  dtps: 753.60436
+  dps: 560.26578
+  tps: 860.44209
+  dtps: 763.56893
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 567.16663
-  tps: 870.57036
-  dtps: 761.39978
+  dps: 566.4507
+  tps: 869.47864
+  dtps: 761.48282
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 199.13203
-  tps: 303.65643
-  dtps: 36313.03775
+  dps: 198.90292
+  tps: 303.30707
+  dtps: 36340.26383
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 199.13203
-  tps: 303.70683
-  dtps: 1795.12676
+  dps: 198.90292
+  tps: 303.35749
+  dtps: 1797.18352
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p4-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 206.18255
-  tps: 314.55897
-  dtps: 1870.71589
+  dps: 205.67808
+  tps: 313.78975
+  dtps: 1879.52582
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 796.13707
-  tps: 1241.0964
-  dtps: 15578.27009
-  hps: 113.49122
+  dps: 796.47012
+  tps: 1241.64239
+  dtps: 15652.44792
+  hps: 113.04664
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 565.78585
-  tps: 869.27205
-  dtps: 776.38109
-  hps: 113.49122
+  dps: 564.88463
+  tps: 867.9359
+  dtps: 778.89998
+  hps: 113.04664
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 575.88915
-  tps: 884.30797
-  dtps: 751.1271
-  hps: 117.06831
+  dps: 575.31351
+  tps: 883.43019
+  dtps: 756.8897
+  hps: 116.9448
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 199.95217
-  tps: 304.90706
-  dtps: 36087.18988
-  hps: 69.23081
+  dps: 199.74099
+  tps: 304.58503
+  dtps: 36095.66125
+  hps: 69.22344
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 199.95217
-  tps: 304.95916
-  dtps: 1779.87648
-  hps: 69.23081
+  dps: 199.74099
+  tps: 304.63715
+  dtps: 1779.92533
+  hps: 69.22344
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 208.09014
-  tps: 317.47297
-  dtps: 1830.1078
-  hps: 73.81403
+  dps: 207.6262
+  tps: 316.76555
+  dtps: 1830.15803
+  hps: 73.80618
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 796.13707
-  tps: 1241.0964
-  dtps: 15578.27009
+  dps: 796.47012
+  tps: 1241.64239
+  dtps: 15652.44792
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 565.78585
-  tps: 869.27205
-  dtps: 776.38109
+  dps: 564.88463
+  tps: 867.9359
+  dtps: 778.89998
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 575.88915
-  tps: 884.30797
-  dtps: 751.1271
+  dps: 575.31351
+  tps: 883.43019
+  dtps: 756.8897
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 199.95217
-  tps: 304.90706
-  dtps: 36087.18988
+  dps: 199.74099
+  tps: 304.58503
+  dtps: 36095.66125
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 199.95217
-  tps: 304.95916
-  dtps: 1779.87648
+  dps: 199.74099
+  tps: 304.63715
+  dtps: 1779.92533
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-p5-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 208.09014
-  tps: 317.47297
-  dtps: 1830.1078
+  dps: 207.6262
+  tps: 316.76555
+  dtps: 1830.15803
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 764.33504
-  tps: 1193.6689
-  dtps: 29077.9048
-  hps: 73.533
+  dps: 764.82016
+  tps: 1194.40866
+  dtps: 29160.79968
+  hps: 73.42785
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 440.74616
-  tps: 680.363
-  dtps: 1473.17474
-  hps: 73.533
+  dps: 440.19629
+  tps: 679.5245
+  dtps: 1472.53953
+  hps: 73.42785
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 444.49968
-  tps: 687.07113
-  dtps: 1565.08345
-  hps: 75.17227
+  dps: 443.94631
+  tps: 686.2273
+  dtps: 1565.28275
+  hps: 75.06478
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 139.50457
-  tps: 212.73052
-  dtps: 62756.47267
-  hps: 37.56156
+  dps: 139.44424
+  tps: 212.63852
+  dtps: 62755.50216
+  hps: 37.55976
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 139.50457
-  tps: 212.7444
-  dtps: 3195.7701
-  hps: 37.56156
+  dps: 139.44424
+  tps: 212.65241
+  dtps: 3195.77839
+  hps: 37.55976
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 142.86888
-  tps: 217.90242
-  dtps: 3142.65559
-  hps: 38.98795
+  dps: 142.80712
+  tps: 217.80825
+  dtps: 3142.66375
+  hps: 38.98608
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 764.33504
-  tps: 1193.6689
-  dtps: 29077.9048
+  dps: 764.82016
+  tps: 1194.40866
+  dtps: 29160.79968
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DemoRoar-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 440.74616
-  tps: 680.363
-  dtps: 1473.17474
+  dps: 440.19629
+  tps: 679.5245
+  dtps: 1472.53953
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DemoRoar-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 444.49968
-  tps: 687.07113
-  dtps: 1565.08345
+  dps: 443.94631
+  tps: 686.2273
+  dtps: 1565.28275
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 139.50457
-  tps: 212.73052
-  dtps: 62756.47267
+  dps: 139.44424
+  tps: 212.63852
+  dtps: 62755.50216
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DemoRoar-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 139.50457
-  tps: 212.7444
-  dtps: 3195.7701
+  dps: 139.44424
+  tps: 212.65241
+  dtps: 3195.77839
  }
 }
 dps_results: {
  key: "TestFeralBear-Settings-Tauren-preraid-DemoRoar-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 142.86888
-  tps: 217.90242
-  dtps: 3142.65559
+  dps: 142.80712
+  tps: 217.80825
+  dtps: 3142.66375
  }
 }
 dps_results: {
  key: "TestFeralBear-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 486.04606
-  tps: 748.89676
-  dtps: 1094.88074
-  hps: 73.46669
+  dps: 484.25859
+  tps: 746.20916
+  dtps: 1097.6542
+  hps: 73.35611
  }
 }

--- a/sim/druid/feralcat/TestFeralCat.results
+++ b/sim/druid/feralcat/TestFeralCat.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestFeralCat-CharacterStats-Default"
  value: {
-  final_stats: 406.5204
-  final_stats: 884.24985
-  final_stats: 694.0758
-  final_stats: 322.08924
-  final_stats: 246.35307
-  final_stats: 233.35307
+  final_stats: 404
+  final_stats: 882
+  final_stats: 692
+  final_stats: 320
+  final_stats: 246.2
+  final_stats: 233.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 303.5307
-  final_stats: 4901.45669
+  final_stats: 302
+  final_stats: 4892.03
   final_stats: 917
   final_stats: 829
   final_stats: 99
@@ -29,24 +29,24 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1213.51657
+  final_stats: 1210.62154
   final_stats: 0
   final_stats: 0
-  final_stats: 6105.8997
+  final_stats: 6101
   final_stats: 446.6
-  final_stats: 11724.758
-  final_stats: 6921.3386
-  final_stats: 122.7
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 43.75
+  final_stats: 11704
+  final_stats: 6890
+  final_stats: 122.5
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 43
   final_stats: 70
   final_stats: 4
   final_stats: 7.27805
   final_stats: 4
-  final_stats: 53.49127
-  final_stats: 18.05183
+  final_stats: 53.40128
+  final_stats: 18.02572
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -55,8 +55,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestFeralCat-StatWeights-Default"
  value: {
-  weights: 2.266
-  weights: 3.11089
+  weights: 2.2
+  weights: 3.09703
   weights: 0
   weights: 0
   weights: 0
@@ -76,10 +76,10 @@ stat_weights_results: {
   weights: 0
   weights: 1
   weights: 0
-  weights: 1.97817
-  weights: 4.34399
-  weights: 0.38185
-  weights: 2.61084
+  weights: 2.03592
+  weights: 4.33199
+  weights: 0.38126
+  weights: 2.62463
   weights: 0
   weights: 0
   weights: 0
@@ -109,4464 +109,4464 @@ stat_weights_results: {
 dps_results: {
  key: "TestFeralCat-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 758.85704
-  tps: 538.7885
-  hps: 68.5247
+  dps: 756.89383
+  tps: 537.39462
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 756.6363
-  tps: 537.21178
-  hps: 68.91552
+  dps: 754.95035
+  tps: 536.01475
+  hps: 68.79351
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 670.05971
-  tps: 475.7424
-  hps: 66.85161
+  dps: 668.93697
+  tps: 474.94525
+  hps: 66.73253
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 70.90853
+  dps: 748.31964
+  tps: 531.30694
+  hps: 70.7996
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 761.39953
-  tps: 540.59367
-  hps: 70.18014
+  dps: 760.27584
+  tps: 539.79584
+  hps: 70.03982
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 737.59436
-  tps: 523.692
-  hps: 68.66074
+  dps: 736.30754
+  tps: 522.77835
+  hps: 68.5212
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 737.59436
-  tps: 523.692
-  hps: 68.66074
+  dps: 736.30754
+  tps: 522.77835
+  hps: 68.5212
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-BattlecastGarb"
  value: {
-  dps: 701.66733
-  tps: 498.1838
-  hps: 71.47439
+  dps: 700.13043
+  tps: 497.09261
+  hps: 71.18373
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 763.07912
-  tps: 541.78618
-  hps: 69.17607
+  dps: 760.61714
+  tps: 540.03817
+  hps: 69.0536
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 761.00326
-  tps: 540.31231
-  hps: 68.5247
+  dps: 759.03737
+  tps: 538.91654
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 762.34464
-  tps: 541.2647
-  hps: 68.5247
+  dps: 760.37709
+  tps: 539.86773
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 791.12995
-  tps: 561.70227
-  hps: 63.44397
+  dps: 789.43553
+  tps: 560.49922
+  hps: 63.2016
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 757.43573
-  tps: 537.77937
-  hps: 69.0458
+  dps: 756.07066
+  tps: 536.81017
+  hps: 68.92356
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 747.48946
-  tps: 530.71751
-  hps: 68.39442
+  dps: 746.30591
+  tps: 529.87719
+  hps: 68.27333
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 739.81618
-  tps: 525.26949
-  hps: 68.39442
+  dps: 738.63585
+  tps: 524.43145
+  hps: 68.27333
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 755.36944
-  tps: 536.3123
-  hps: 71.10718
+  dps: 753.41056
+  tps: 534.9215
+  hps: 70.97493
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 72.2991
+  dps: 748.31964
+  tps: 531.30694
+  hps: 72.14382
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 757.24738
-  tps: 537.64564
-  hps: 68.5247
+  dps: 755.28617
+  tps: 536.25318
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 755.36944
-  tps: 536.3123
-  hps: 70.90853
+  dps: 753.41056
+  tps: 534.9215
+  hps: 70.7996
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 761.13629
-  tps: 540.40676
-  hps: 68.5247
+  dps: 759.17024
+  tps: 539.01087
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 765.50534
-  tps: 543.50879
-  hps: 68.5247
+  dps: 763.53312
+  tps: 542.10852
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 71.90179
+  dps: 748.31964
+  tps: 531.30694
+  hps: 71.79316
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 754.38225
-  tps: 535.6114
-  hps: 68.91552
+  dps: 752.5718
+  tps: 534.32597
+  hps: 68.79351
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-DirebrewHops-38288"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Dragonmaw-28438"
  value: {
-  dps: 656.12136
-  tps: 465.84617
-  hps: 63.30954
+  dps: 654.77252
+  tps: 464.88849
+  hps: 63.0784
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 777.9347
-  tps: 552.33364
-  hps: 68.26415
+  dps: 775.94503
+  tps: 550.92097
+  hps: 68.14329
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Dragonstrike-28439"
  value: {
-  dps: 668.37641
-  tps: 474.54725
-  hps: 64.19853
+  dps: 666.87245
+  tps: 473.47944
+  hps: 63.94716
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 646.08948
-  tps: 458.72353
-  hps: 62.86161
+  dps: 644.44108
+  tps: 457.55317
+  hps: 62.4624
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Earthstrike-21180"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 70.51122
+  dps: 748.31964
+  tps: 531.30694
+  hps: 70.39049
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EnchantBoots-Boar'sSpeed-2940"
  value: {
-  dps: 756.33854
-  tps: 537.00036
-  hps: 69.12065
+  dps: 754.64564
+  tps: 535.7984
+  hps: 68.98782
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 753.64861
-  tps: 524.3887
-  hps: 68.5247
+  dps: 752.69574
+  tps: 523.72569
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 753.03425
-  tps: 545.3474
-  hps: 68.5247
+  dps: 750.75939
+  tps: 543.69995
+  hps: 68.27333
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 745.69475
-  tps: 529.44327
-  hps: 68.39442
+  dps: 743.70366
+  tps: 528.0296
+  hps: 68.14329
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 750.10795
-  tps: 532.57665
-  hps: 68.39442
+  dps: 748.11576
+  tps: 531.16219
+  hps: 68.14329
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 751.49993
-  tps: 533.56495
-  hps: 68.39442
+  dps: 749.46354
+  tps: 532.11911
+  hps: 68.14329
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 757.03546
-  tps: 537.49518
-  hps: 67.35222
+  dps: 755.01744
+  tps: 536.06238
+  hps: 67.23298
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EyeofMoam-21473"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 739.81618
-  tps: 525.26949
-  hps: 68.39442
+  dps: 738.63585
+  tps: 524.43145
+  hps: 68.27333
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-FelSkin"
  value: {
-  dps: 686.80827
-  tps: 487.63387
-  hps: 61.07107
+  dps: 684.9249
+  tps: 486.29668
+  hps: 60.79871
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 757.51565
-  tps: 537.83611
-  hps: 68.5247
+  dps: 755.55411
+  tps: 536.44342
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-FrostscytheofLordAhune-278953"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 71.37205
+  dps: 757.9656
+  tps: 538.15558
+  hps: 71.20871
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Gladiator'sRefuge"
  value: {
-  dps: 598.40141
-  tps: 424.865
-  hps: 73.25591
+  dps: 597.1451
+  tps: 423.97302
+  hps: 73.14862
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 775.87837
-  tps: 550.87364
-  hps: 79.98806
+  dps: 774.44035
+  tps: 549.85265
+  hps: 79.87689
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 598.40141
-  tps: 424.865
-  hps: 72.7132
+  dps: 597.1451
+  tps: 423.97302
+  hps: 72.6164
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-HandofJustice-11815"
  value: {
-  dps: 752.95494
-  tps: 534.59801
-  hps: 68.5247
+  dps: 750.99907
+  tps: 533.20934
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Heartrazor-29962"
  value: {
-  dps: 769.12767
-  tps: 546.08065
-  hps: 70.91338
+  dps: 767.16226
+  tps: 544.6852
+  hps: 70.79196
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IceGuard-2682"
  value: {
-  dps: 755.36944
-  tps: 536.3123
-  hps: 68.5247
+  dps: 753.41056
+  tps: 534.9215
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IdolofBrutality-23198"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IdolofFeralShadows-28372"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IdolofTerror-33509"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IdolofUrsoc-27744"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IdoloftheAvenger-31025"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IdoloftheBeast-25667"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IdoloftheMoon-23197"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IdoloftheWild-28064"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ImbuedNetherweave"
  value: {
-  dps: 642.18988
-  tps: 455.95481
-  hps: 64.2937
+  dps: 640.97454
+  tps: 455.09192
+  hps: 63.9272
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-InfinityBlade-30312"
  value: {
-  dps: 776.66449
-  tps: 551.43179
-  hps: 71.38104
+  dps: 775.12108
+  tps: 550.33597
+  hps: 71.22022
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-IvoryIdoloftheMoongoddess-27518"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-JomGabbar-23570"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-KhoriumScope-2723"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 754.04054
-  tps: 535.36879
-  hps: 68.78525
+  dps: 751.93
+  tps: 533.8703
+  hps: 68.66347
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-LivingRootoftheWildheart-30664"
  value: {
-  dps: 758.05933
-  tps: 538.22212
-  hps: 68.5247
+  dps: 756.03579
+  tps: 536.78541
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 764.34868
-  tps: 542.68756
-  hps: 68.5247
+  dps: 762.37782
+  tps: 541.28825
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-MalorneHarness"
  value: {
-  dps: 718.62061
-  tps: 510.22064
-  hps: 68.80176
+  dps: 717.27843
+  tps: 509.26768
+  hps: 68.65902
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-MalorneRegalia"
  value: {
-  dps: 598.40141
-  tps: 424.865
-  hps: 63.36658
+  dps: 597.1451
+  tps: 423.97302
+  hps: 63.24929
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 598.40141
-  tps: 424.865
-  hps: 63.54748
+  dps: 597.1451
+  tps: 423.97302
+  hps: 63.40896
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 716.64148
-  tps: 508.81545
-  hps: 66.70228
+  dps: 715.59428
+  tps: 508.07194
+  hps: 66.58693
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-MoongladeRaiment"
  value: {
-  dps: 654.86908
-  tps: 464.95705
-  hps: 62.79816
+  dps: 653.0127
+  tps: 463.63902
+  hps: 62.68769
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-NetherweaveVestments"
  value: {
-  dps: 573.12293
-  tps: 406.91728
-  hps: 63.24218
+  dps: 571.49276
+  tps: 405.75986
+  hps: 62.98258
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-NordrassilHarness"
  value: {
-  dps: 727.73411
-  tps: 516.69122
-  hps: 71.51236
+  dps: 726.42619
+  tps: 515.76259
+  hps: 71.22607
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-NordrassilRegalia"
  value: {
-  dps: 598.40141
-  tps: 424.865
-  hps: 64.9947
+  dps: 597.1451
+  tps: 423.97302
+  hps: 64.84596
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Oathbound'sDragonhideBattlegear"
  value: {
-  dps: 662.61735
-  tps: 470.45832
-  hps: 65.692
+  dps: 660.98795
+  tps: 469.30145
+  hps: 65.4052
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Oathbound'sKodohideBattlegear"
  value: {
-  dps: 598.40141
-  tps: 424.865
-  hps: 64.45199
+  dps: 597.1451
+  tps: 423.97302
+  hps: 64.31373
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Oathbound'sWyrmhideBattlegear"
  value: {
-  dps: 598.40141
-  tps: 424.865
-  hps: 63.90929
+  dps: 597.1451
+  tps: 423.97302
+  hps: 63.78151
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 756.71082
-  tps: 537.26468
-  hps: 68.5247
+  dps: 754.75028
+  tps: 535.8727
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 739.81618
-  tps: 525.26949
-  hps: 69.58407
+  dps: 738.63585
+  tps: 524.43145
+  hps: 69.44
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 739.81618
-  tps: 525.26949
-  hps: 69.58407
+  dps: 738.63585
+  tps: 524.43145
+  hps: 69.44
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-PendantofThawing-24093"
  value: {
-  dps: 739.81618
-  tps: 525.26949
-  hps: 69.58407
+  dps: 738.63585
+  tps: 524.43145
+  hps: 69.44
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-PendantofWithering-24095"
  value: {
-  dps: 739.81618
-  tps: 525.26949
-  hps: 69.58407
+  dps: 738.63585
+  tps: 524.43145
+  hps: 69.44
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 739.81618
-  tps: 525.26949
-  hps: 69.58407
+  dps: 738.63585
+  tps: 524.43145
+  hps: 69.44
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-PrimalIntent"
  value: {
-  dps: 743.63147
-  tps: 527.97835
-  hps: 67.15389
+  dps: 741.77845
+  tps: 526.6627
+  hps: 66.9164
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-PrimalMooncloth"
  value: {
-  dps: 660.40404
-  tps: 468.88687
-  hps: 58.59132
+  dps: 659.0445
+  tps: 467.92159
+  hps: 58.34973
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Prismcharm-15867"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 716.64148
-  tps: 508.81545
-  hps: 66.24757
+  dps: 715.59428
+  tps: 508.07194
+  hps: 66.12827
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 766.90535
-  tps: 544.5028
-  hps: 68.5247
+  dps: 764.93213
+  tps: 543.10181
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 754.94816
-  tps: 536.01319
-  hps: 68.5247
+  dps: 752.99562
+  tps: 534.62689
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-RuneofForce-25994"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 70.51122
+  dps: 748.31964
+  tps: 531.30694
+  hps: 70.39049
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-SavageGuard-2681"
  value: {
-  dps: 755.36944
-  tps: 536.3123
-  hps: 68.5247
+  dps: 753.41056
+  tps: 534.9215
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 656.90614
-  tps: 466.40336
-  hps: 62.93228
+  dps: 655.22197
+  tps: 465.2076
+  hps: 62.80976
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ShardofContempt-34472"
  value: {
-  dps: 772.20223
-  tps: 548.26358
-  hps: 68.0036
+  dps: 770.36109
+  tps: 546.95637
+  hps: 67.75316
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 758.85704
-  tps: 538.7885
-  hps: 68.5247
+  dps: 756.89383
+  tps: 537.39462
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-SoulclothEmbrace"
  value: {
-  dps: 650.20473
-  tps: 461.64536
-  hps: 63.8007
+  dps: 648.99696
+  tps: 460.78784
+  hps: 63.657
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 701.66733
-  tps: 498.1838
-  hps: 67.74305
+  dps: 700.13043
+  tps: 497.09261
+  hps: 67.49307
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 71.1734
+  dps: 748.31964
+  tps: 531.30694
+  hps: 71.03338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-StaffofNaturalFury-31334"
  value: {
-  dps: 866.07533
-  tps: 614.91349
-  hps: 70.57744
+  dps: 864.07121
+  tps: 613.49056
+  hps: 70.44893
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 69.91527
+  dps: 757.9656
+  tps: 538.15558
+  hps: 69.80604
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 70.51122
+  dps: 748.31964
+  tps: 531.30694
+  hps: 70.39049
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 761.79667
-  tps: 540.87564
-  hps: 67.74305
+  dps: 760.11577
+  tps: 539.68219
+  hps: 67.62311
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 642.18988
-  tps: 455.95481
-  hps: 64.97779
+  dps: 640.97454
+  tps: 455.09192
+  hps: 64.5832
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 766.63708
-  tps: 544.31232
-  hps: 68.5247
+  dps: 764.66419
+  tps: 542.91157
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-TheBladefist-29348"
  value: {
-  dps: 638.66912
-  tps: 453.45507
-  hps: 63.35854
+  dps: 637.10203
+  tps: 452.34244
+  hps: 63.08207
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-TheNightBlade-31331"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ThickDraenicArmor"
  value: {
-  dps: 671.19285
-  tps: 476.54692
-  hps: 64.87185
+  dps: 670.27462
+  tps: 475.89498
+  hps: 64.74253
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ThunderheartHarness"
  value: {
-  dps: 763.31763
-  tps: 541.95551
-  hps: 75.51233
+  dps: 762.05979
+  tps: 541.06245
+  hps: 75.36682
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-ThunderheartRegalia"
  value: {
-  dps: 534.14491
-  tps: 379.24288
-  hps: 62.24943
+  dps: 533.13577
+  tps: 378.52639
+  hps: 61.99871
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 769.42953
-  tps: 546.29496
-  hps: 69.17607
+  dps: 767.42404
+  tps: 544.87107
+  hps: 68.92356
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-UnitingCharm-25633"
  value: {
-  dps: 756.71082
-  tps: 537.26468
-  hps: 68.5247
+  dps: 754.75028
+  tps: 535.8727
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-WastewalkerArmor"
  value: {
-  dps: 686.80348
-  tps: 487.63047
-  hps: 67.45363
+  dps: 685.27423
+  tps: 486.5447
+  hps: 67.34087
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-WhitemendWisdom"
  value: {
-  dps: 701.66733
-  tps: 498.1838
-  hps: 68.26674
+  dps: 700.13043
+  tps: 497.09261
+  hps: 68.01207
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-WindhawkArmor"
  value: {
-  dps: 673.37883
-  tps: 478.09897
-  hps: 63.62741
+  dps: 671.5828
+  tps: 476.82379
+  hps: 63.48411
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-WorldBreaker-30090"
  value: {
-  dps: 775.12805
-  tps: 550.34091
-  hps: 71.90179
+  dps: 773.23838
+  tps: 548.99925
+  hps: 71.79316
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 737.59436
-  tps: 523.692
-  hps: 66.82074
+  dps: 736.30754
+  tps: 522.77835
+  hps: 66.6652
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-WrathofSpellfire"
  value: {
-  dps: 661.73651
-  tps: 469.83292
-  hps: 58.42747
+  dps: 660.54143
+  tps: 468.98441
+  hps: 58.28153
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 750.27217
-  tps: 532.69324
-  hps: 68.5247
+  dps: 748.31964
+  tps: 531.30694
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-Average-Default"
  value: {
-  dps: 762.02667
-  tps: 541.03893
-  hps: 67.7873
+  dps: 760.41357
+  tps: 539.89363
+  hps: 67.64
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 746.13201
-  tps: 529.75372
-  hps: 68.46065
+  dps: 744.32677
+  tps: 528.47201
+  hps: 68.0776
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 746.13201
-  tps: 529.75372
-  hps: 68.46065
+  dps: 744.32677
+  tps: 528.47201
+  hps: 68.0776
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 847.54043
-  tps: 601.7537
-  hps: 68.98931
+  dps: 845.46136
+  tps: 600.27757
+  hps: 68.8692
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 223.05023
-  tps: 158.36566
-  hps: 38.28555
+  dps: 222.94561
+  tps: 158.29138
+  hps: 38.2632
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 223.05023
-  tps: 158.36566
-  hps: 38.28555
+  dps: 222.94561
+  tps: 158.29138
+  hps: 38.2632
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 222.92386
-  tps: 158.27594
-  hps: 37.77165
+  dps: 222.81904
+  tps: 158.20152
+  hps: 37.7496
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 746.13201
-  tps: 529.75372
+  dps: 744.32677
+  tps: 528.47201
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 746.13201
-  tps: 529.75372
+  dps: 744.32677
+  tps: 528.47201
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 847.54043
-  tps: 601.7537
+  dps: 845.46136
+  tps: 600.27757
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 223.05023
-  tps: 158.36566
+  dps: 222.94561
+  tps: 158.29138
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 223.05023
-  tps: 158.36566
+  dps: 222.94561
+  tps: 158.29138
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 222.92386
-  tps: 158.27594
+  dps: 222.81904
+  tps: 158.20152
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 737.0509
-  tps: 523.30614
-  hps: 68.51436
+  dps: 735.53513
+  tps: 522.22995
+  hps: 68.38484
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 737.0509
-  tps: 523.30614
-  hps: 68.51436
+  dps: 735.53513
+  tps: 522.22995
+  hps: 68.38484
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 836.92243
-  tps: 594.21493
-  hps: 69.58073
+  dps: 835.26933
+  tps: 593.04122
+  hps: 69.4492
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 224.18036
-  tps: 159.16805
-  hps: 38.31256
+  dps: 224.01081
+  tps: 159.04768
+  hps: 38.2772
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 224.18036
-  tps: 159.16805
-  hps: 38.31256
+  dps: 224.01081
+  tps: 159.04768
+  hps: 38.2772
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 225.17674
-  tps: 159.87548
-  hps: 39.52608
+  dps: 225.00601
+  tps: 159.75426
+  hps: 39.4896
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 737.0509
-  tps: 523.30614
+  dps: 735.53513
+  tps: 522.22995
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 737.0509
-  tps: 523.30614
+  dps: 735.53513
+  tps: 522.22995
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 836.92243
-  tps: 594.21493
+  dps: 835.26933
+  tps: 593.04122
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 224.18036
-  tps: 159.16805
+  dps: 224.01081
+  tps: 159.04768
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 224.18036
-  tps: 159.16805
+  dps: 224.01081
+  tps: 159.04768
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 225.17674
-  tps: 159.87548
+  dps: 225.00601
+  tps: 159.75426
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 749.5513
-  tps: 532.18143
-  hps: 64.49501
+  dps: 747.14766
+  tps: 530.47484
+  hps: 64.365
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 749.5513
-  tps: 532.18143
-  hps: 64.49501
+  dps: 747.14766
+  tps: 530.47484
+  hps: 64.365
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 847.88547
-  tps: 601.99868
-  hps: 64.86356
+  dps: 844.72436
+  tps: 599.7543
+  hps: 64.7328
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 223.18965
-  tps: 158.46465
-  hps: 34.88586
+  dps: 223.12484
+  tps: 158.41864
+  hps: 34.87431
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 223.18965
-  tps: 158.46465
-  hps: 34.88586
+  dps: 223.12484
+  tps: 158.41864
+  hps: 34.87431
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 224.45038
-  tps: 159.35977
-  hps: 35.19459
+  dps: 224.38516
+  tps: 159.31346
+  hps: 35.18293
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 749.5513
-  tps: 532.18143
+  dps: 747.14766
+  tps: 530.47484
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 749.5513
-  tps: 532.18143
+  dps: 747.14766
+  tps: 530.47484
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 847.88547
-  tps: 601.99868
+  dps: 844.72436
+  tps: 599.7543
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 223.18965
-  tps: 158.46465
+  dps: 223.12484
+  tps: 158.41864
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 223.18965
-  tps: 158.46465
+  dps: 223.12484
+  tps: 158.41864
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 224.45038
-  tps: 159.35977
+  dps: 224.38516
+  tps: 159.31346
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 737.62982
-  tps: 523.71717
-  hps: 65.05303
+  dps: 736.35927
+  tps: 522.81509
+  hps: 64.9166
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 737.62982
-  tps: 523.71717
-  hps: 65.05303
+  dps: 736.35927
+  tps: 522.81509
+  hps: 64.9166
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 835.73053
-  tps: 593.36868
-  hps: 65.55248
+  dps: 834.19121
+  tps: 592.27576
+  hps: 65.415
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 224.55775
-  tps: 159.436
-  hps: 35.63451
+  dps: 224.36506
+  tps: 159.2992
+  hps: 35.59893
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 224.55775
-  tps: 159.436
-  hps: 35.63451
+  dps: 224.36506
+  tps: 159.2992
+  hps: 35.59893
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 226.06434
-  tps: 160.50568
-  hps: 36.97772
+  dps: 225.75394
+  tps: 160.28529
+  hps: 36.9408
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 737.62982
-  tps: 523.71717
+  dps: 736.35927
+  tps: 522.81509
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 737.62982
-  tps: 523.71717
+  dps: 736.35927
+  tps: 522.81509
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 835.73053
-  tps: 593.36868
+  dps: 834.19121
+  tps: 592.27576
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 224.55775
-  tps: 159.436
+  dps: 224.36506
+  tps: 159.2992
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 224.55775
-  tps: 159.436
+  dps: 224.36506
+  tps: 159.2992
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_bis_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 226.06434
-  tps: 160.50568
+  dps: 225.75394
+  tps: 160.28529
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 759.93015
-  tps: 539.5504
-  hps: 68.5247
+  dps: 757.9656
+  tps: 538.15558
+  hps: 68.40338
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 860.39721
-  tps: 610.88202
-  hps: 68.78525
+  dps: 857.81064
+  tps: 609.04555
+  hps: 68.66347
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 227.06328
-  tps: 161.21493
+  dps: 226.81413
+  tps: 161.03803
   hps: 38.94507
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 227.06328
-  tps: 161.21493
+  dps: 226.81413
+  tps: 161.03803
   hps: 38.94507
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 227.73469
-  tps: 161.69163
+  dps: 227.59497
+  tps: 161.59243
   hps: 38.7772
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 759.93015
-  tps: 539.5504
+  dps: 757.9656
+  tps: 538.15558
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 759.93015
-  tps: 539.5504
+  dps: 757.9656
+  tps: 538.15558
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 860.39721
-  tps: 610.88202
+  dps: 857.81064
+  tps: 609.04555
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 227.06328
-  tps: 161.21493
+  dps: 226.81413
+  tps: 161.03803
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 227.06328
-  tps: 161.21493
+  dps: 226.81413
+  tps: 161.03803
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 227.73469
-  tps: 161.69163
+  dps: 227.59497
+  tps: 161.59243
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 749.52565
-  tps: 532.16321
-  hps: 69.58418
+  dps: 748.69493
+  tps: 531.5734
+  hps: 69.45538
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 749.52565
-  tps: 532.16321
-  hps: 69.58418
+  dps: 748.69493
+  tps: 531.5734
+  hps: 69.45538
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 847.98874
-  tps: 602.072
-  hps: 69.84876
+  dps: 847.05276
+  tps: 601.40746
+  hps: 69.71947
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 228.13589
-  tps: 161.97648
-  hps: 39.28012
+  dps: 227.93953
+  tps: 161.83707
+  hps: 39.25569
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 228.13589
-  tps: 161.97648
-  hps: 39.28012
+  dps: 227.93953
+  tps: 161.83707
+  hps: 39.25569
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 229.60986
-  tps: 163.023
-  hps: 40.13776
+  dps: 229.31231
+  tps: 162.81174
+  hps: 40.1128
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 749.52565
-  tps: 532.16321
+  dps: 748.69493
+  tps: 531.5734
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 749.52565
-  tps: 532.16321
+  dps: 748.69493
+  tps: 531.5734
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 847.98874
-  tps: 602.072
+  dps: 847.05276
+  tps: 601.40746
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 228.13589
-  tps: 161.97648
+  dps: 227.93953
+  tps: 161.83707
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 228.13589
-  tps: 161.97648
+  dps: 227.93953
+  tps: 161.83707
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p1_realistic_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 229.60986
-  tps: 163.023
+  dps: 229.31231
+  tps: 162.81174
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 827.33963
-  tps: 587.41114
-  hps: 72.85266
+  dps: 825.77909
+  tps: 586.30315
+  hps: 72.7116
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 827.33963
-  tps: 587.41114
-  hps: 72.85266
+  dps: 825.77909
+  tps: 586.30315
+  hps: 72.7116
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 938.68714
-  tps: 666.46787
-  hps: 73.26425
+  dps: 936.97127
+  tps: 665.2496
+  hps: 73.1224
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 258.01909
-  tps: 183.19355
-  hps: 42.31683
+  dps: 257.66219
+  tps: 182.94015
+  hps: 42.28296
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 258.01909
-  tps: 183.19355
-  hps: 42.31683
+  dps: 257.66219
+  tps: 182.94015
+  hps: 42.28296
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 259.81495
-  tps: 184.46862
-  hps: 42.76797
+  dps: 259.62968
+  tps: 184.33707
+  hps: 42.73373
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 827.33963
-  tps: 587.41114
+  dps: 825.77909
+  tps: 586.30315
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 827.33963
-  tps: 587.41114
+  dps: 825.77909
+  tps: 586.30315
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 938.68714
-  tps: 666.46787
+  dps: 936.97127
+  tps: 665.2496
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 258.01909
-  tps: 183.19355
+  dps: 257.66219
+  tps: 182.94015
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 258.01909
-  tps: 183.19355
+  dps: 257.66219
+  tps: 182.94015
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 259.81495
-  tps: 184.46862
+  dps: 259.62968
+  tps: 184.33707
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 810.52757
-  tps: 575.47457
-  hps: 71.77637
+  dps: 809.31939
+  tps: 574.61677
+  hps: 71.65547
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 810.52757
-  tps: 575.47457
-  hps: 71.77637
+  dps: 809.31939
+  tps: 574.61677
+  hps: 71.65547
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 919.97277
-  tps: 653.18067
-  hps: 72.59201
+  dps: 918.2883
+  tps: 651.98469
+  hps: 72.46973
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 256.36109
-  tps: 182.01638
-  hps: 41.33467
+  dps: 256.22782
+  tps: 181.92175
+  hps: 41.31662
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 256.36109
-  tps: 182.01638
-  hps: 41.33467
+  dps: 256.22782
+  tps: 181.92175
+  hps: 41.31662
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 260.08638
-  tps: 184.66133
-  hps: 42.2255
+  dps: 259.95114
+  tps: 184.56531
+  hps: 42.20707
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 810.52757
-  tps: 575.47457
+  dps: 809.31939
+  tps: 574.61677
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 810.52757
-  tps: 575.47457
+  dps: 809.31939
+  tps: 574.61677
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 919.97277
-  tps: 653.18067
+  dps: 918.2883
+  tps: 651.98469
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 256.36109
-  tps: 182.01638
+  dps: 256.22782
+  tps: 181.92175
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 256.36109
-  tps: 182.01638
+  dps: 256.22782
+  tps: 181.92175
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 260.08638
-  tps: 184.66133
+  dps: 259.95114
+  tps: 184.56531
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 818.34069
-  tps: 581.02189
-  hps: 73.57719
+  dps: 816.1753
+  tps: 579.48446
+  hps: 73.43696
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 818.34069
-  tps: 581.02189
-  hps: 73.57719
+  dps: 816.1753
+  tps: 579.48446
+  hps: 73.43696
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 926.15067
-  tps: 657.56698
-  hps: 74.27262
+  dps: 924.57061
+  tps: 656.44513
+  hps: 74.13107
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 253.70914
-  tps: 180.13349
-  hps: 42.75417
+  dps: 253.56573
+  tps: 180.03167
+  hps: 42.749
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 253.70914
-  tps: 180.13349
-  hps: 42.75417
+  dps: 253.56573
+  tps: 180.03167
+  hps: 42.749
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 255.62979
-  tps: 181.49715
-  hps: 42.75417
+  dps: 255.48528
+  tps: 181.39455
+  hps: 42.749
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 818.34069
-  tps: 581.02189
+  dps: 816.1753
+  tps: 579.48446
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 818.34069
-  tps: 581.02189
+  dps: 816.1753
+  tps: 579.48446
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 926.15067
-  tps: 657.56698
+  dps: 924.57061
+  tps: 656.44513
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 253.70914
-  tps: 180.13349
+  dps: 253.56573
+  tps: 180.03167
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 253.70914
-  tps: 180.13349
+  dps: 253.56573
+  tps: 180.03167
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 255.62979
-  tps: 181.49715
+  dps: 255.48528
+  tps: 181.39455
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 808.76531
-  tps: 574.22337
-  hps: 73.29236
+  dps: 807.31821
+  tps: 573.19593
+  hps: 73.13738
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 808.76531
-  tps: 574.22337
-  hps: 73.29236
+  dps: 807.31821
+  tps: 573.19593
+  hps: 73.13738
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 915.18154
-  tps: 649.7789
-  hps: 73.57104
+  dps: 914.13617
+  tps: 649.03668
+  hps: 73.41547
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 255.4514
-  tps: 181.3705
-  hps: 42.67625
+  dps: 255.1761
+  tps: 181.17503
+  hps: 42.66802
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 255.4514
-  tps: 181.3705
-  hps: 42.67625
+  dps: 255.1761
+  tps: 181.17503
+  hps: 42.66802
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 258.17686
-  tps: 183.30557
-  hps: 43.13712
+  dps: 257.64412
+  tps: 182.92733
+  hps: 43.1288
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 808.76531
-  tps: 574.22337
+  dps: 807.31821
+  tps: 573.19593
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 808.76531
-  tps: 574.22337
+  dps: 807.31821
+  tps: 573.19593
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 915.18154
-  tps: 649.7789
+  dps: 914.13617
+  tps: 649.03668
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 255.4514
-  tps: 181.3705
+  dps: 255.1761
+  tps: 181.17503
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 255.4514
-  tps: 181.3705
+  dps: 255.1761
+  tps: 181.17503
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p2_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 258.17686
-  tps: 183.30557
+  dps: 257.64412
+  tps: 182.92733
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 890.61258
-  tps: 632.33493
-  hps: 77.8672
+  dps: 888.61443
+  tps: 630.91625
+  hps: 77.70987
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 890.61258
-  tps: 632.33493
-  hps: 77.8672
+  dps: 888.61443
+  tps: 630.91625
+  hps: 77.70987
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1004.80239
-  tps: 713.4097
-  hps: 76.99717
+  dps: 1002.99891
+  tps: 712.12923
+  hps: 76.8416
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 282.57466
-  tps: 200.62801
-  hps: 46.61788
+  dps: 282.22898
+  tps: 200.38257
+  hps: 46.59073
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 282.57466
-  tps: 200.62801
-  hps: 46.61788
+  dps: 282.22898
+  tps: 200.38257
+  hps: 46.59073
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 285.58648
-  tps: 202.7664
-  hps: 46.7152
+  dps: 285.24092
+  tps: 202.52105
+  hps: 46.688
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 890.61258
-  tps: 632.33493
+  dps: 888.61443
+  tps: 630.91625
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 890.61258
-  tps: 632.33493
+  dps: 888.61443
+  tps: 630.91625
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1004.80239
-  tps: 713.4097
+  dps: 1002.99891
+  tps: 712.12923
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 282.57466
-  tps: 200.62801
+  dps: 282.22898
+  tps: 200.38257
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 282.57466
-  tps: 200.62801
+  dps: 282.22898
+  tps: 200.38257
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 285.58648
-  tps: 202.7664
+  dps: 285.24092
+  tps: 202.52105
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 881.39812
-  tps: 625.79267
-  hps: 77.35428
+  dps: 879.34263
+  tps: 624.33327
+  hps: 77.19024
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 881.39812
-  tps: 625.79267
-  hps: 77.35428
+  dps: 879.34263
+  tps: 624.33327
+  hps: 77.19024
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 994.84491
-  tps: 706.33989
-  hps: 77.06402
+  dps: 993.01108
+  tps: 705.03787
+  hps: 76.9006
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 285.06454
-  tps: 202.39583
-  hps: 47.15988
+  dps: 284.85659
+  tps: 202.24818
+  hps: 47.13084
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 285.06454
-  tps: 202.39583
-  hps: 47.15988
+  dps: 284.85659
+  tps: 202.24818
+  hps: 47.13084
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 289.04647
-  tps: 205.223
-  hps: 48.52401
+  dps: 288.90767
+  tps: 205.12444
+  hps: 48.49413
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 881.39812
-  tps: 625.79267
+  dps: 879.34263
+  tps: 624.33327
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 881.39812
-  tps: 625.79267
+  dps: 879.34263
+  tps: 624.33327
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 994.84491
-  tps: 706.33989
+  dps: 993.01108
+  tps: 705.03787
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 285.06454
-  tps: 202.39583
+  dps: 284.85659
+  tps: 202.24818
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 285.06454
-  tps: 202.39583
+  dps: 284.85659
+  tps: 202.24818
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p3_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 289.04647
-  tps: 205.223
+  dps: 288.90767
+  tps: 205.12444
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 900.92159
-  tps: 639.65433
-  hps: 78.0024
+  dps: 899.08686
+  tps: 638.35167
+  hps: 77.74382
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 900.92159
-  tps: 639.65433
-  hps: 78.0024
+  dps: 899.08686
+  tps: 638.35167
+  hps: 77.74382
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1016.54159
-  tps: 721.74453
-  hps: 77.13087
+  dps: 1014.75783
+  tps: 720.47806
+  hps: 77.0186
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 285.71331
-  tps: 202.85645
-  hps: 46.43486
+  dps: 285.59951
+  tps: 202.77565
+  hps: 46.40471
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 285.71331
-  tps: 202.85645
-  hps: 46.43486
+  dps: 285.59951
+  tps: 202.77565
+  hps: 46.40471
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 288.38819
-  tps: 204.75562
-  hps: 46.53241
+  dps: 288.27337
+  tps: 204.67409
+  hps: 46.5022
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 900.92159
-  tps: 639.65433
+  dps: 899.08686
+  tps: 638.35167
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 900.92159
-  tps: 639.65433
+  dps: 899.08686
+  tps: 638.35167
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1016.54159
-  tps: 721.74453
+  dps: 1014.75783
+  tps: 720.47806
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 285.71331
-  tps: 202.85645
+  dps: 285.59951
+  tps: 202.77565
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 285.71331
-  tps: 202.85645
+  dps: 285.59951
+  tps: 202.77565
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 288.38819
-  tps: 204.75562
+  dps: 288.27337
+  tps: 204.67409
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 887.10129
-  tps: 629.84191
-  hps: 76.48199
+  dps: 884.91896
+  tps: 628.29246
+  hps: 76.36113
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 887.10129
-  tps: 629.84191
-  hps: 76.48199
+  dps: 884.91896
+  tps: 628.29246
+  hps: 76.36113
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1001.2847
-  tps: 710.91214
-  hps: 76.19501
+  dps: 999.59885
+  tps: 709.71519
+  hps: 76.0746
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 286.13884
-  tps: 203.15858
-  hps: 46.4398
+  dps: 285.85011
+  tps: 202.95358
+  hps: 46.3358
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 286.13884
-  tps: 203.15858
-  hps: 46.4398
+  dps: 285.85011
+  tps: 202.95358
+  hps: 46.3358
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 290.12867
-  tps: 205.99136
-  hps: 47.7831
+  dps: 289.756
+  tps: 205.72676
+  hps: 47.487
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 887.10129
-  tps: 629.84191
+  dps: 884.91896
+  tps: 628.29246
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 887.10129
-  tps: 629.84191
+  dps: 884.91896
+  tps: 628.29246
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1001.2847
-  tps: 710.91214
+  dps: 999.59885
+  tps: 709.71519
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 286.13884
-  tps: 203.15858
+  dps: 285.85011
+  tps: 202.95358
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 286.13884
-  tps: 203.15858
+  dps: 285.85011
+  tps: 202.95358
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p4_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 290.12867
-  tps: 205.99136
+  dps: 289.756
+  tps: 205.72676
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1241.54149
-  tps: 881.49446
-  hps: 82.73631
+  dps: 1239.12562
+  tps: 879.77919
+  hps: 82.46596
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1241.54149
-  tps: 881.49446
-  hps: 82.73631
+  dps: 1239.12562
+  tps: 879.77919
+  hps: 82.46596
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1404.43366
-  tps: 997.1479
-  hps: 86.99132
+  dps: 1400.95224
+  tps: 994.67609
+  hps: 86.87253
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 402.5772
-  tps: 285.82981
-  hps: 52.42607
+  dps: 402.35527
+  tps: 285.67224
+  hps: 52.39876
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 402.5772
-  tps: 285.82981
-  hps: 52.42607
+  dps: 402.35527
+  tps: 285.67224
+  hps: 52.39876
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 408.5582
-  tps: 290.07632
-  hps: 53.84005
+  dps: 408.41714
+  tps: 289.97617
+  hps: 53.812
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1241.54149
-  tps: 881.49446
+  dps: 1239.12562
+  tps: 879.77919
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1241.54149
-  tps: 881.49446
+  dps: 1239.12562
+  tps: 879.77919
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1404.43366
-  tps: 997.1479
+  dps: 1400.95224
+  tps: 994.67609
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 402.5772
-  tps: 285.82981
+  dps: 402.35527
+  tps: 285.67224
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 402.5772
-  tps: 285.82981
+  dps: 402.35527
+  tps: 285.67224
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-p5-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 408.5582
-  tps: 290.07632
+  dps: 408.41714
+  tps: 289.97617
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 726.99986
-  tps: 516.1699
-  hps: 64.24023
+  dps: 725.30449
+  tps: 514.96619
+  hps: 64.00358
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 726.99986
-  tps: 516.1699
-  hps: 64.24023
+  dps: 725.30449
+  tps: 514.96619
+  hps: 64.00358
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 824.71959
-  tps: 585.55091
-  hps: 64.36283
+  dps: 823.49296
+  tps: 584.68
+  hps: 64.24833
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 214.842
-  tps: 152.53782
-  hps: 34.6285
+  dps: 214.63546
+  tps: 152.39118
+  hps: 34.62
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 214.842
-  tps: 152.53782
-  hps: 34.6285
+  dps: 214.63546
+  tps: 152.39118
+  hps: 34.62
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 215.35313
-  tps: 152.90072
-  hps: 34.6285
+  dps: 215.09669
+  tps: 152.71865
+  hps: 34.62
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 726.99986
-  tps: 516.1699
+  dps: 725.30449
+  tps: 514.96619
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 726.99986
-  tps: 516.1699
+  dps: 725.30449
+  tps: 514.96619
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 824.71959
-  tps: 585.55091
+  dps: 823.49296
+  tps: 584.68
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 214.842
-  tps: 152.53782
+  dps: 214.63546
+  tps: 152.39118
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 214.842
-  tps: 152.53782
+  dps: 214.63546
+  tps: 152.39118
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-NightElf-pre_raid-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 215.35313
-  tps: 152.90072
+  dps: 215.09669
+  tps: 152.71865
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 745.24887
-  tps: 529.1267
-  hps: 71.67435
+  dps: 743.45514
+  tps: 527.85315
+  hps: 71.40303
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 745.24887
-  tps: 529.1267
-  hps: 71.67435
+  dps: 743.45514
+  tps: 527.85315
+  hps: 71.40303
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 846.02027
-  tps: 600.67439
-  hps: 72.50777
+  dps: 843.9899
+  tps: 599.23283
+  hps: 72.37356
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 223.34278
-  tps: 158.57337
-  hps: 40.16349
+  dps: 223.22924
+  tps: 158.49276
+  hps: 40.13851
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 223.34278
-  tps: 158.57337
-  hps: 40.16349
+  dps: 223.22924
+  tps: 158.49276
+  hps: 40.13851
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 223.16348
-  tps: 158.44607
-  hps: 39.71323
+  dps: 222.93066
+  tps: 158.28077
+  hps: 39.68853
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 745.24887
-  tps: 529.1267
+  dps: 743.45514
+  tps: 527.85315
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 745.24887
-  tps: 529.1267
+  dps: 743.45514
+  tps: 527.85315
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 846.02027
-  tps: 600.67439
+  dps: 843.9899
+  tps: 599.23283
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 223.34278
-  tps: 158.57337
+  dps: 223.22924
+  tps: 158.49276
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 223.34278
-  tps: 158.57337
+  dps: 223.22924
+  tps: 158.49276
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 223.16348
-  tps: 158.44607
+  dps: 222.93066
+  tps: 158.28077
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 735.88718
-  tps: 522.4799
-  hps: 72.00802
+  dps: 734.16534
+  tps: 521.25739
+  hps: 71.86405
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 735.88718
-  tps: 522.4799
-  hps: 72.00802
+  dps: 734.16534
+  tps: 521.25739
+  hps: 71.86405
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 835.64952
-  tps: 593.31116
-  hps: 73.12877
+  dps: 833.28692
+  tps: 591.63371
+  hps: 72.98256
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 224.40961
-  tps: 159.33082
-  hps: 40.2813
+  dps: 224.28881
+  tps: 159.24505
+  hps: 40.24263
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 224.40961
-  tps: 159.33082
-  hps: 40.2813
+  dps: 224.28881
+  tps: 159.24505
+  hps: 40.24263
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 225.42209
-  tps: 160.04969
-  hps: 41.55718
+  dps: 225.18309
+  tps: 159.87999
+  hps: 41.51728
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 735.88718
-  tps: 522.4799
+  dps: 734.16534
+  tps: 521.25739
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 735.88718
-  tps: 522.4799
+  dps: 734.16534
+  tps: 521.25739
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 835.64952
-  tps: 593.31116
+  dps: 833.28692
+  tps: 591.63371
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 224.40961
-  tps: 159.33082
+  dps: 224.28881
+  tps: 159.24505
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 224.40961
-  tps: 159.33082
+  dps: 224.28881
+  tps: 159.24505
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 225.42209
-  tps: 160.04969
+  dps: 225.18309
+  tps: 159.87999
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 746.66379
-  tps: 530.13129
-  hps: 67.66004
+  dps: 744.9751
+  tps: 528.93232
+  hps: 67.25796
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 746.66379
-  tps: 530.13129
-  hps: 67.66004
+  dps: 744.9751
+  tps: 528.93232
+  hps: 67.25796
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 845.39593
-  tps: 600.23111
-  hps: 67.78916
+  dps: 844.37821
+  tps: 599.50853
+  hps: 67.6445
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 222.52143
-  tps: 157.99021
-  hps: 36.52215
+  dps: 222.31647
+  tps: 157.84469
+  hps: 36.5085
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 222.52143
-  tps: 157.99021
-  hps: 36.52215
+  dps: 222.31647
+  tps: 157.84469
+  hps: 36.5085
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 223.12768
-  tps: 158.42065
-  hps: 36.52215
+  dps: 222.98222
+  tps: 158.31738
+  hps: 36.5085
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 746.66379
-  tps: 530.13129
+  dps: 744.9751
+  tps: 528.93232
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 746.66379
-  tps: 530.13129
+  dps: 744.9751
+  tps: 528.93232
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 845.39593
-  tps: 600.23111
+  dps: 844.37821
+  tps: 599.50853
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 222.52143
-  tps: 157.99021
+  dps: 222.31647
+  tps: 157.84469
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 222.52143
-  tps: 157.99021
+  dps: 222.31647
+  tps: 157.84469
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 223.12768
-  tps: 158.42065
+  dps: 222.98222
+  tps: 158.31738
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 736.91212
-  tps: 523.2076
-  hps: 68.24331
+  dps: 735.45346
+  tps: 522.17196
+  hps: 68.09227
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 736.91212
-  tps: 523.2076
-  hps: 68.24331
+  dps: 735.45346
+  tps: 522.17196
+  hps: 68.09227
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 835.08058
-  tps: 592.90721
-  hps: 68.8995
+  dps: 833.95834
+  tps: 592.11042
+  hps: 68.747
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 224.42649
-  tps: 159.34281
-  hps: 37.30427
+  dps: 224.34386
+  tps: 159.28414
+  hps: 37.2655
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 224.42649
-  tps: 159.34281
-  hps: 37.30427
+  dps: 224.34386
+  tps: 159.28414
+  hps: 37.2655
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 225.81921
-  tps: 160.33164
-  hps: 38.88284
+  dps: 225.7925
+  tps: 160.31268
+  hps: 38.84244
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 736.91212
-  tps: 523.2076
+  dps: 735.45346
+  tps: 522.17196
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 736.91212
-  tps: 523.2076
+  dps: 735.45346
+  tps: 522.17196
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 835.08058
-  tps: 592.90721
+  dps: 833.95834
+  tps: 592.11042
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 224.42649
-  tps: 159.34281
+  dps: 224.34386
+  tps: 159.28414
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 224.42649
-  tps: 159.34281
+  dps: 224.34386
+  tps: 159.28414
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_bis_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 225.81921
-  tps: 160.33164
+  dps: 225.7925
+  tps: 160.31268
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 758.10725
-  tps: 538.25615
-  hps: 72.02046
+  dps: 756.85909
+  tps: 537.36995
+  hps: 71.88491
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 758.10725
-  tps: 538.25615
-  hps: 72.02046
+  dps: 756.85909
+  tps: 537.36995
+  hps: 71.88491
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 857.40745
-  tps: 608.75929
-  hps: 72.2943
+  dps: 856.19201
+  tps: 607.89633
+  hps: 72.15824
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 226.89599
-  tps: 161.09616
-  hps: 40.77158
+  dps: 226.67395
+  tps: 160.93851
+  hps: 40.76996
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 226.89599
-  tps: 161.09616
-  hps: 40.77158
+  dps: 226.67395
+  tps: 160.93851
+  hps: 40.76996
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 227.60214
-  tps: 161.59752
-  hps: 40.77158
+  dps: 227.25007
+  tps: 161.34755
+  hps: 40.76996
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 758.10725
-  tps: 538.25615
+  dps: 756.85909
+  tps: 537.36995
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 758.10725
-  tps: 538.25615
+  dps: 756.85909
+  tps: 537.36995
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 857.40745
-  tps: 608.75929
+  dps: 856.19201
+  tps: 607.89633
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 226.89599
-  tps: 161.09616
+  dps: 226.67395
+  tps: 160.93851
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 226.89599
-  tps: 161.09616
+  dps: 226.67395
+  tps: 160.93851
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 227.60214
-  tps: 161.59752
+  dps: 227.25007
+  tps: 161.34755
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 748.69335
-  tps: 531.57228
-  hps: 72.99388
+  dps: 746.32191
+  tps: 529.88855
+  hps: 72.85075
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 748.69335
-  tps: 531.57228
-  hps: 72.99388
+  dps: 746.32191
+  tps: 529.88855
+  hps: 72.85075
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 846.84773
-  tps: 601.26189
-  hps: 73.41099
+  dps: 844.34429
+  tps: 599.48445
+  hps: 73.26704
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 228.18532
-  tps: 162.01157
-  hps: 41.20898
+  dps: 228.14818
+  tps: 161.9852
+  hps: 41.18179
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 228.18532
-  tps: 162.01157
-  hps: 41.20898
+  dps: 228.14818
+  tps: 161.9852
+  hps: 41.18179
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 229.19624
-  tps: 162.72933
-  hps: 42.20089
+  dps: 229.15886
+  tps: 162.70279
+  hps: 42.17304
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 748.69335
-  tps: 531.57228
+  dps: 746.32191
+  tps: 529.88855
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 748.69335
-  tps: 531.57228
+  dps: 746.32191
+  tps: 529.88855
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 846.84773
-  tps: 601.26189
+  dps: 844.34429
+  tps: 599.48445
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 228.18532
-  tps: 162.01157
+  dps: 228.14818
+  tps: 161.9852
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 228.18532
-  tps: 162.01157
+  dps: 228.14818
+  tps: 161.9852
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p1_realistic_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 229.19624
-  tps: 162.72933
+  dps: 229.15886
+  tps: 162.70279
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 826.25411
-  tps: 586.64042
-  hps: 76.2771
+  dps: 824.45216
+  tps: 585.36103
+  hps: 75.97744
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 826.25411
-  tps: 586.64042
-  hps: 76.2771
+  dps: 824.45216
+  tps: 585.36103
+  hps: 75.97744
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 939.0168
-  tps: 666.70193
-  hps: 76.99805
+  dps: 937.27841
+  tps: 665.46767
+  hps: 76.84082
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 257.7672
-  tps: 183.01471
-  hps: 44.48903
+  dps: 257.69474
+  tps: 182.96327
+  hps: 44.45182
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 257.7672
-  tps: 183.01471
-  hps: 44.48903
+  dps: 257.69474
+  tps: 182.96327
+  hps: 44.45182
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 259.84854
-  tps: 184.49246
-  hps: 44.96332
+  dps: 259.77552
+  tps: 184.44062
+  hps: 44.92572
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 826.25411
-  tps: 586.64042
+  dps: 824.45216
+  tps: 585.36103
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 826.25411
-  tps: 586.64042
+  dps: 824.45216
+  tps: 585.36103
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 939.0168
-  tps: 666.70193
+  dps: 937.27841
+  tps: 665.46767
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 257.7672
-  tps: 183.01471
+  dps: 257.69474
+  tps: 182.96327
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 257.7672
-  tps: 183.01471
+  dps: 257.69474
+  tps: 182.96327
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 259.84854
-  tps: 184.49246
+  dps: 259.77552
+  tps: 184.44062
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 808.5352
-  tps: 574.05999
-  hps: 75.29211
+  dps: 806.94899
+  tps: 572.93378
+  hps: 75.15723
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 808.5352
-  tps: 574.05999
-  hps: 75.29211
+  dps: 806.94899
+  tps: 572.93378
+  hps: 75.15723
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 917.70612
-  tps: 651.57134
-  hps: 76.29219
+  dps: 915.94827
+  tps: 650.32327
+  hps: 76.15552
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 256.71388
-  tps: 182.26685
-  hps: 43.45716
+  dps: 256.55758
+  tps: 182.15588
+  hps: 43.43659
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 256.71388
-  tps: 182.26685
-  hps: 43.45716
+  dps: 256.55758
+  tps: 182.15588
+  hps: 43.43659
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 260.35949
-  tps: 184.85524
-  hps: 44.39373
+  dps: 260.06331
+  tps: 184.64495
+  hps: 44.37272
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 808.5352
-  tps: 574.05999
+  dps: 806.94899
+  tps: 572.93378
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 808.5352
-  tps: 574.05999
+  dps: 806.94899
+  tps: 572.93378
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 917.70612
-  tps: 651.57134
+  dps: 915.94827
+  tps: 650.32327
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 256.71388
-  tps: 182.26685
+  dps: 256.55758
+  tps: 182.15588
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 256.71388
-  tps: 182.26685
+  dps: 256.55758
+  tps: 182.15588
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 260.35949
-  tps: 184.85524
+  dps: 260.06331
+  tps: 184.64495
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 815.57979
-  tps: 579.06165
-  hps: 77.03362
+  dps: 813.73173
+  tps: 577.74953
+  hps: 76.44112
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 815.57979
-  tps: 579.06165
-  hps: 77.03362
+  dps: 813.73173
+  tps: 577.74953
+  hps: 76.44112
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 925.90778
-  tps: 657.39452
-  hps: 77.61832
+  dps: 924.76506
+  tps: 656.58319
+  hps: 77.46228
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 253.51149
-  tps: 179.99316
-  hps: 44.75443
+  dps: 253.47752
+  tps: 179.96904
+  hps: 44.74741
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 253.51149
-  tps: 179.99316
-  hps: 44.75443
+  dps: 253.47752
+  tps: 179.96904
+  hps: 44.74741
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 255.25044
-  tps: 181.22781
-  hps: 44.94775
+  dps: 255.21622
+  tps: 181.20352
+  hps: 44.9407
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 815.57979
-  tps: 579.06165
+  dps: 813.73173
+  tps: 577.74953
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 815.57979
-  tps: 579.06165
+  dps: 813.73173
+  tps: 577.74953
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 925.90778
-  tps: 657.39452
+  dps: 924.76506
+  tps: 656.58319
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 253.51149
-  tps: 179.99316
+  dps: 253.47752
+  tps: 179.96904
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 253.51149
-  tps: 179.99316
+  dps: 253.47752
+  tps: 179.96904
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 255.25044
-  tps: 181.22781
+  dps: 255.21622
+  tps: 181.20352
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 808.07272
-  tps: 573.73163
-  hps: 76.88007
+  dps: 806.45226
+  tps: 572.5811
+  hps: 76.7095
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 808.07272
-  tps: 573.73163
-  hps: 76.88007
+  dps: 806.45226
+  tps: 572.5811
+  hps: 76.7095
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 915.33062
-  tps: 649.88474
-  hps: 77.31938
+  dps: 913.23649
+  tps: 648.39791
+  hps: 77.14784
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 255.12001
-  tps: 181.13521
-  hps: 44.7688
+  dps: 255.08315
+  tps: 181.10903
+  hps: 44.75856
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 255.12001
-  tps: 181.13521
-  hps: 44.7688
+  dps: 255.08315
+  tps: 181.10903
+  hps: 44.75856
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 257.69119
-  tps: 182.96075
-  hps: 45.35021
+  dps: 257.65395
+  tps: 182.9343
+  hps: 45.33984
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 808.07272
-  tps: 573.73163
+  dps: 806.45226
+  tps: 572.5811
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 808.07272
-  tps: 573.73163
+  dps: 806.45226
+  tps: 572.5811
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 915.33062
-  tps: 649.88474
+  dps: 913.23649
+  tps: 648.39791
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 255.12001
-  tps: 181.13521
+  dps: 255.08315
+  tps: 181.10903
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 255.12001
-  tps: 181.13521
+  dps: 255.08315
+  tps: 181.10903
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p2_alt_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 257.69119
-  tps: 182.96075
+  dps: 257.65395
+  tps: 182.9343
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 888.27719
-  tps: 630.67681
-  hps: 81.67915
+  dps: 886.61189
+  tps: 629.49444
+  hps: 81.50595
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 888.27719
-  tps: 630.67681
-  hps: 81.67915
+  dps: 886.61189
+  tps: 629.49444
+  hps: 81.50595
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1002.89696
-  tps: 712.05684
-  hps: 80.91722
+  dps: 1000.53618
+  tps: 710.38069
+  hps: 80.74563
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 282.10621
-  tps: 200.29541
-  hps: 48.6994
+  dps: 281.80131
+  tps: 200.07893
+  hps: 48.66941
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 282.10621
-  tps: 200.29541
-  hps: 48.6994
+  dps: 281.80131
+  tps: 200.07893
+  hps: 48.66941
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 284.39223
-  tps: 201.91848
-  hps: 48.80171
+  dps: 284.02681
+  tps: 201.65903
+  hps: 48.77166
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 888.27719
-  tps: 630.67681
+  dps: 886.61189
+  tps: 629.49444
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 888.27719
-  tps: 630.67681
+  dps: 886.61189
+  tps: 629.49444
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1002.89696
-  tps: 712.05684
+  dps: 1000.53618
+  tps: 710.38069
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 282.10621
-  tps: 200.29541
+  dps: 281.80131
+  tps: 200.07893
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 282.10621
-  tps: 200.29541
+  dps: 281.80131
+  tps: 200.07893
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 284.39223
-  tps: 201.91848
+  dps: 284.02681
+  tps: 201.65903
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 880.15663
-  tps: 624.91121
-  hps: 81.29245
+  dps: 878.56591
+  tps: 623.7818
+  hps: 81.17412
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 880.15663
-  tps: 624.91121
-  hps: 81.29245
+  dps: 878.56591
+  tps: 623.7818
+  hps: 81.17412
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 993.05189
-  tps: 705.06684
-  hps: 80.98741
+  dps: 990.57062
+  tps: 703.30514
+  hps: 80.86953
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 285.0319
-  tps: 202.37265
-  hps: 49.47361
+  dps: 284.80297
+  tps: 202.21011
+  hps: 49.44149
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 285.0319
-  tps: 202.37265
-  hps: 49.47361
+  dps: 284.80297
+  tps: 202.21011
+  hps: 49.44149
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 289.11027
-  tps: 205.26829
-  hps: 50.70277
+  dps: 288.73528
+  tps: 205.00205
+  hps: 50.66985
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 880.15663
-  tps: 624.91121
+  dps: 878.56591
+  tps: 623.7818
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 880.15663
-  tps: 624.91121
+  dps: 878.56591
+  tps: 623.7818
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 993.05189
-  tps: 705.06684
+  dps: 990.57062
+  tps: 703.30514
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 285.0319
-  tps: 202.37265
+  dps: 284.80297
+  tps: 202.21011
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 285.0319
-  tps: 202.37265
+  dps: 284.80297
+  tps: 202.21011
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p3_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 289.11027
-  tps: 205.26829
+  dps: 288.73528
+  tps: 205.00205
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 899.13523
-  tps: 638.38601
-  hps: 81.82085
+  dps: 897.38818
+  tps: 637.14561
+  hps: 81.69355
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 899.13523
-  tps: 638.38601
-  hps: 81.82085
+  dps: 897.38818
+  tps: 637.14561
+  hps: 81.69355
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1014.58747
-  tps: 720.3571
-  hps: 81.0576
+  dps: 1012.70454
+  tps: 719.02022
+  hps: 80.93148
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 285.81993
-  tps: 202.93215
-  hps: 48.8138
+  dps: 285.466
+  tps: 202.68086
+  hps: 48.78048
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 285.81993
-  tps: 202.93215
-  hps: 48.8138
+  dps: 285.466
+  tps: 202.68086
+  hps: 48.78048
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 287.99716
-  tps: 204.47798
-  hps: 48.91635
+  dps: 287.62039
+  tps: 204.21048
+  hps: 48.88296
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 899.13523
-  tps: 638.38601
+  dps: 897.38818
+  tps: 637.14561
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 899.13523
-  tps: 638.38601
+  dps: 897.38818
+  tps: 637.14561
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1014.58747
-  tps: 720.3571
+  dps: 1012.70454
+  tps: 719.02022
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 285.81993
-  tps: 202.93215
+  dps: 285.466
+  tps: 202.68086
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 285.81993
-  tps: 202.93215
+  dps: 285.466
+  tps: 202.68086
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_6p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 287.99716
-  tps: 204.47798
+  dps: 287.62039
+  tps: 204.21048
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 886.01034
-  tps: 629.06734
-  hps: 80.37655
+  dps: 884.59217
+  tps: 628.06044
+  hps: 80.24137
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 886.01034
-  tps: 629.06734
-  hps: 80.37655
+  dps: 884.59217
+  tps: 628.06044
+  hps: 80.24137
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 998.88691
-  tps: 709.2097
-  hps: 80.07495
+  dps: 996.93549
+  tps: 707.8242
+  hps: 79.94028
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 286.11052
-  tps: 203.13847
-  hps: 48.71908
+  dps: 285.95455
+  tps: 203.02773
+  hps: 48.70894
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 286.11052
-  tps: 203.13847
-  hps: 48.71908
+  dps: 285.95455
+  tps: 203.02773
+  hps: 48.70894
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 289.98856
-  tps: 205.89188
-  hps: 49.92949
+  dps: 289.83056
+  tps: 205.7797
+  hps: 49.9191
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 886.01034
-  tps: 629.06734
+  dps: 884.59217
+  tps: 628.06044
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 886.01034
-  tps: 629.06734
+  dps: 884.59217
+  tps: 628.06044
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 998.88691
-  tps: 709.2097
+  dps: 996.93549
+  tps: 707.8242
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 286.11052
-  tps: 203.13847
+  dps: 285.95455
+  tps: 203.02773
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 286.11052
-  tps: 203.13847
+  dps: 285.95455
+  tps: 203.02773
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p4_9p-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 289.98856
-  tps: 205.89188
+  dps: 289.83056
+  tps: 205.7797
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1239.92705
-  tps: 880.3482
-  hps: 86.61132
+  dps: 1238.14872
+  tps: 879.08559
+  hps: 86.48502
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1239.92705
-  tps: 880.3482
-  hps: 86.61132
+  dps: 1238.14872
+  tps: 879.08559
+  hps: 86.48502
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1400.82005
-  tps: 994.58223
-  hps: 90.91704
+  dps: 1399.29132
+  tps: 993.49684
+  hps: 90.78447
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 402.49396
-  tps: 285.77071
-  hps: 54.99097
+  dps: 402.33046
+  tps: 285.65463
+  hps: 54.96066
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 402.49396
-  tps: 285.77071
-  hps: 54.99097
+  dps: 402.33046
+  tps: 285.65463
+  hps: 54.96066
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 408.92961
-  tps: 290.34002
-  hps: 56.59153
+  dps: 408.76281
+  tps: 290.2216
+  hps: 56.56035
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1239.92705
-  tps: 880.3482
+  dps: 1238.14872
+  tps: 879.08559
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1239.92705
-  tps: 880.3482
+  dps: 1238.14872
+  tps: 879.08559
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1400.82005
-  tps: 994.58223
+  dps: 1399.29132
+  tps: 993.49684
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 402.49396
-  tps: 285.77071
+  dps: 402.33046
+  tps: 285.65463
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 402.49396
-  tps: 285.77071
+  dps: 402.33046
+  tps: 285.65463
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-p5-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 408.92961
-  tps: 290.34002
+  dps: 408.76281
+  tps: 290.2216
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 725.57063
-  tps: 515.15515
-  hps: 67.00608
+  dps: 724.12836
+  tps: 514.13113
+  hps: 66.87893
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 725.57063
-  tps: 515.15515
-  hps: 67.00608
+  dps: 724.12836
+  tps: 514.13113
+  hps: 66.87893
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-DefaultTalents-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 823.64864
-  tps: 584.79053
-  hps: 67.65037
+  dps: 821.89899
+  tps: 583.54828
+  hps: 67.522
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 214.29267
-  tps: 152.1478
-  hps: 36.25216
+  dps: 214.12592
+  tps: 152.0294
+  hps: 36.24171
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 214.29267
-  tps: 152.1478
-  hps: 36.25216
+  dps: 214.12592
+  tps: 152.0294
+  hps: 36.24171
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-DefaultTalents-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 214.36976
-  tps: 152.20253
-  hps: 35.92848
+  dps: 214.25966
+  tps: 152.12436
+  hps: 35.91812
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-Monocat-Standard-Default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 725.57063
-  tps: 515.15515
+  dps: 724.12836
+  tps: 514.13113
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-Monocat-Standard-Default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 725.57063
-  tps: 515.15515
+  dps: 724.12836
+  tps: 514.13113
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-Monocat-Standard-Default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 823.64864
-  tps: 584.79053
+  dps: 821.89899
+  tps: 583.54828
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-Monocat-Standard-Default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 214.29267
-  tps: 152.1478
+  dps: 214.12592
+  tps: 152.0294
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-Monocat-Standard-Default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 214.29267
-  tps: 152.1478
+  dps: 214.12592
+  tps: 152.0294
  }
 }
 dps_results: {
  key: "TestFeralCat-Settings-Tauren-pre_raid-Monocat-Standard-Default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 214.36976
-  tps: 152.20253
+  dps: 214.25966
+  tps: 152.12436
  }
 }
 dps_results: {
  key: "TestFeralCat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 694.89119
-  tps: 493.37275
-  hps: 67.74305
+  dps: 693.62423
+  tps: 492.47321
+  hps: 67.62311
  }
 }

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -3,10 +3,10 @@ character_stats_results: {
  value: {
   final_stats: 257
   final_stats: 948
-  final_stats: 817
+  final_stats: 818
   final_stats: 280
-  final_stats: 235.3
-  final_stats: 222.3
+  final_stats: 235.4
+  final_stats: 222.4
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,7 +17,7 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 193
+  final_stats: 194
   final_stats: 3658.6
   final_stats: 2840
   final_stats: 0
@@ -34,7 +34,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 8101
   final_stats: 0
-  final_stats: 12855.28
+  final_stats: 12865.38
   final_stats: 7303
   final_stats: 155.5
   final_stats: 33
@@ -1168,7 +1168,7 @@ dps_results: {
  key: "TestHunter-AllItems-PrimalMooncloth"
  value: {
   dps: 3147.96612
-  tps: 2160.15703
+  tps: 2160.15601
   dtps: 13.00325
  }
 }
@@ -1913,15 +1913,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1337.64724
-  tps: 1283.1704
+  dps: 1336.76904
+  tps: 1282.37322
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 967.0575
-  tps: 733.84463
+  dps: 966.02873
+  tps: 732.75712
  }
 }
 dps_results: {
@@ -1958,15 +1958,15 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-Turret-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1336.15381
-  tps: 1434.76328
+  dps: 1335.56743
+  tps: 1434.73893
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-Turret-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 747.78593
-  tps: 614.04159
+  dps: 747.73544
+  tps: 613.84322
  }
 }
 dps_results: {
@@ -2010,8 +2010,8 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 908.31552
-  tps: 775.76283
+  dps: 907.53719
+  tps: 775.04596
  }
 }
 dps_results: {

--- a/sim/hunter/TestHunter.results
+++ b/sim/hunter/TestHunter.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestHunter-CharacterStats-Default"
  value: {
-  final_stats: 259.38
-  final_stats: 949.795
-  final_stats: 819.06
-  final_stats: 281.49
-  final_stats: 235.459
-  final_stats: 222.459
+  final_stats: 257
+  final_stats: 948
+  final_stats: 817
+  final_stats: 280
+  final_stats: 235.3
+  final_stats: 222.3
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,9 +17,9 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 194.59
-  final_stats: 3663.7425
-  final_stats: 2841.795
+  final_stats: 193
+  final_stats: 3658.6
+  final_stats: 2840
   final_stats: 0
   final_stats: 103
   final_stats: 227
@@ -29,24 +29,24 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 718.92183
+  final_stats: 717.56316
   final_stats: 0
   final_stats: 0
-  final_stats: 8104.99
+  final_stats: 8101
   final_stats: 0
-  final_stats: 12876.086
-  final_stats: 7325.35
-  final_stats: 155.7
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
+  final_stats: 12855.28
+  final_stats: 7303
+  final_stats: 155.5
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
   final_stats: 70
   final_stats: 0
   final_stats: 6.53171
   final_stats: 3
-  final_stats: 37.49511
-  final_stats: 19.29484
+  final_stats: 37.45023
+  final_stats: 19.27622
   final_stats: 0
   final_stats: 0
   final_stats: 6.26829
@@ -55,1634 +55,1634 @@ character_stats_results: {
 dps_results: {
  key: "TestHunter-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 3482.8101
-  tps: 2457.00555
+  dps: 3484.84578
+  tps: 2460.17401
   dtps: 13.63644
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 3543.88384
-  tps: 2508.79634
-  dtps: 13.26766
+  dps: 3536.2294
+  tps: 2505.26907
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 3437.62529
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.51391
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 3437.59471
-  tps: 2408.10193
-  dtps: 13.86832
+  dps: 3434.45617
+  tps: 2406.32778
+  dtps: 13.91467
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 3477.62898
-  tps: 2445.50064
-  dtps: 13.72406
+  dps: 3474.05603
+  tps: 2443.29117
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Annihilator-12798"
  value: {
-  dps: 3215.19678
-  tps: 2197.88549
+  dps: 3213.37704
+  tps: 2198.63511
   dtps: 13.34338
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 3437.62529
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.51391
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 3231.8534
-  tps: 2226.74735
-  dtps: 13.03102
+  dps: 3230.38575
+  tps: 2230.18188
+  dtps: 13.07979
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 3480.71966
-  tps: 2442.86554
-  dtps: 13.72406
+  dps: 3477.60117
+  tps: 2441.11199
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 3475.9298
-  tps: 2443.61209
-  dtps: 13.72406
+  dps: 3472.81719
+  tps: 2441.84953
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 3475.25998
-  tps: 2445.39566
-  dtps: 13.72406
+  dps: 3472.09662
+  tps: 2443.58873
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 3581.61873
-  tps: 2543.49431
-  dtps: 13.26766
+  dps: 3574.65037
+  tps: 2540.6664
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 3503.97864
-  tps: 2473.22313
-  dtps: 13.41191
+  dps: 3497.86172
+  tps: 2471.19829
+  dtps: 13.46068
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 3503.97864
-  tps: 2473.48446
-  dtps: 13.41191
+  dps: 3497.86172
+  tps: 2471.45892
+  dtps: 13.46068
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BattlecastGarb"
  value: {
-  dps: 3199.51902
-  tps: 2191.28751
-  dtps: 13.36749
+  dps: 3200.23335
+  tps: 2200.14749
+  dtps: 13.41625
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 3409.08743
-  tps: 2377.66155
-  dtps: 13.7195
+  dps: 3403.47074
+  tps: 2374.84167
+  dtps: 13.76585
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 3409.08743
-  tps: 2377.66155
-  dtps: 13.7195
+  dps: 3403.47074
+  tps: 2374.84167
+  dtps: 13.76585
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 3480.19118
-  tps: 2450.66255
-  dtps: 13.72406
+  dps: 3477.30949
+  tps: 2449.13698
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.86832
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.91467
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 3476.75007
-  tps: 2441.33215
-  dtps: 13.72406
+  dps: 3473.63286
+  tps: 2439.5667
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 3579.79192
-  tps: 2488.68867
-  dtps: 13.01228
+  dps: 3576.14235
+  tps: 2487.39347
+  dtps: 13.06104
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BeastLordArmor"
  value: {
-  dps: 3132.50055
-  tps: 2135.64496
+  dps: 3128.8239
+  tps: 2137.96318
   dtps: 12.8815
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 3521.87095
-  tps: 2480.39824
-  dtps: 13.72406
+  dps: 3518.76691
+  tps: 2478.63148
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 3535.14523
-  tps: 2500.05774
-  dtps: 13.26766
+  dps: 3527.50569
+  tps: 2496.54535
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 3538.04243
-  tps: 2505.85318
-  dtps: 13.26766
+  dps: 3530.28369
+  tps: 2502.17501
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 3578.05981
-  tps: 2538.99617
+  dps: 3569.48539
+  tps: 2532.27588
   dtps: 13.35407
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 3481.06487
-  tps: 2448.93653
-  dtps: 13.72406
+  dps: 3478.18831
+  tps: 2447.42345
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 3227.13439
-  tps: 2223.51074
+  dps: 3225.60202
+  tps: 2224.84538
   dtps: 13.07072
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Blinkstrike-31332"
  value: {
-  dps: 3492.59275
-  tps: 2460.87622
-  dtps: 13.36878
+  dps: 3488.19523
+  tps: 2459.74037
+  dtps: 13.41755
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BloodGuard'sChainVices-22862"
  value: {
-  dps: 3473.14212
-  tps: 2445.12944
-  dtps: 13.0594
+  dps: 3467.41156
+  tps: 2442.58912
+  dtps: 13.10816
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 3503.0069
-  tps: 2473.83516
-  dtps: 13.26766
+  dps: 3495.77278
+  tps: 2470.67939
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-BrutalGladiator'sChainGauntlets-34991"
  value: {
-  dps: 3529.3624
-  tps: 2493.72215
-  dtps: 13.30051
+  dps: 3522.63513
+  tps: 2490.30547
+  dtps: 13.34928
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 3494.26046
-  tps: 2465.11005
-  dtps: 13.41191
+  dps: 3487.03493
+  tps: 2461.96302
+  dtps: 13.46068
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 3355.74073
-  tps: 2335.10613
-  dtps: 13.20795
+  dps: 3349.8271
+  tps: 2332.56677
+  dtps: 13.25672
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 3485.40639
-  tps: 2448.95704
-  dtps: 13.72406
+  dps: 3482.29894
+  tps: 2447.19526
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 3355.74073
-  tps: 2335.12211
-  dtps: 13.40546
+  dps: 3349.8271
+  tps: 2332.5772
+  dtps: 13.45422
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CryptstalkerArmor"
  value: {
-  dps: 3066.50381
-  tps: 2080.0044
-  dtps: 12.32021
+  dps: 3069.14485
+  tps: 2083.93183
+  dtps: 12.35418
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 3466.79859
-  tps: 2434.61169
-  dtps: 13.72406
+  dps: 3463.66658
+  tps: 2432.83799
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 3437.62529
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.51391
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 3493.89044
-  tps: 2456.1528
-  dtps: 13.72406
+  dps: 3490.77033
+  tps: 2454.38212
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 3447.76888
-  tps: 2417.36271
-  dtps: 13.72406
+  dps: 3445.0247
+  tps: 2415.97432
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DemonStalkerArmor"
  value: {
-  dps: 3148.59021
-  tps: 2151.20871
-  dtps: 12.99799
+  dps: 3137.68211
+  tps: 2142.21231
+  dtps: 13.05543
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Despair-28573"
  value: {
-  dps: 3499.64315
-  tps: 2468.91664
-  dtps: 13.36878
+  dps: 3495.20299
+  tps: 2467.73667
+  dtps: 13.41755
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Devastation-30316"
  value: {
-  dps: 3614.62002
-  tps: 2572.56875
-  dtps: 13.36878
+  dps: 3614.34282
+  tps: 2571.8824
+  dtps: 13.41755
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DirebrewHops-38288"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DonSantos'FamousHuntingRifle-31323"
  value: {
-  dps: 3475.84671
-  tps: 2456.39734
-  dtps: 13.45907
+  dps: 3475.66454
+  tps: 2459.87906
+  dtps: 13.50253
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Earthstrike-21180"
  value: {
-  dps: 3468.92125
-  tps: 2434.88903
-  dtps: 13.72406
+  dps: 3465.82066
+  tps: 2433.13406
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 3503.90411
-  tps: 2464.90347
-  dtps: 13.72406
+  dps: 3500.79821
+  tps: 2463.13907
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantBoots-Boar'sSpeed-2940"
  value: {
-  dps: 3547.55979
-  tps: 2513.04014
-  dtps: 13.31565
+  dps: 3541.96714
+  tps: 2509.76272
+  dtps: 13.36441
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 3556.2545
-  tps: 2520.32789
-  dtps: 13.28846
+  dps: 3552.37628
+  tps: 2518.85538
+  dtps: 13.36441
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 3542.97941
-  tps: 2458.22334
-  dtps: 13.26766
+  dps: 3536.65017
+  tps: 2455.99391
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 3539.23625
-  tps: 2553.73019
-  dtps: 13.26766
+  dps: 3533.41503
+  tps: 2551.9796
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 3523.42422
-  tps: 2490.35348
-  dtps: 13.38363
+  dps: 3515.03619
+  tps: 2486.10148
+  dtps: 13.4324
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 3531.05681
-  tps: 2497.61211
+  dps: 3522.11176
+  tps: 2492.76169
   dtps: 11.77579
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 3556.32142
-  tps: 2522.88443
-  dtps: 13.26766
+  dps: 3547.47194
+  tps: 2518.13569
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 3539.58589
-  tps: 2506.49835
+  dps: 3542.27693
+  tps: 2507.0657
   dtps: 13.26438
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeofMoam-21473"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 3494.26046
-  tps: 2465.08873
+  dps: 3487.03493
+  tps: 2461.94155
   dtps: 13.75447
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FelSkin"
  value: {
-  dps: 3302.11333
-  tps: 2290.55984
-  dtps: 12.89992
+  dps: 3292.94623
+  tps: 2288.40902
+  dtps: 12.94868
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FelscaleArmor"
  value: {
-  dps: 3242.00186
-  tps: 2236.46374
-  dtps: 12.53157
+  dps: 3234.0119
+  tps: 2231.71431
+  dtps: 12.56581
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 3476.00054
-  tps: 2440.64689
-  dtps: 13.72406
+  dps: 3472.88521
+  tps: 2438.88485
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-FrostscytheofLordAhune-278953"
  value: {
-  dps: 3494.06931
-  tps: 2462.97725
-  dtps: 13.57813
+  dps: 3489.6729
+  tps: 2461.8412
+  dtps: 13.6269
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-General'sChainGloves-16571"
  value: {
-  dps: 3484.57564
-  tps: 2456.43236
-  dtps: 13.0594
+  dps: 3477.78028
+  tps: 2452.98827
+  dtps: 13.10816
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gladiator'sChainGauntlets-28335"
  value: {
-  dps: 3497.53253
-  tps: 2464.24081
-  dtps: 13.30051
+  dps: 3491.05463
+  tps: 2461.12364
+  dtps: 13.03248
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 3437.62529
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.51391
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-GrandMarshal'sChainGauntlets-28614"
  value: {
-  dps: 3485.98544
-  tps: 2457.8658
-  dtps: 13.0594
+  dps: 3478.58428
+  tps: 2453.79453
+  dtps: 13.10816
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 3427.5285
-  tps: 2414.74796
-  dtps: 13.06846
+  dps: 3414.91463
+  tps: 2403.87412
+  dtps: 13.12591
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HandofJustice-11815"
  value: {
-  dps: 3463.38989
-  tps: 2430.22685
-  dtps: 13.72406
+  dps: 3460.30519
+  tps: 2428.46369
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 3437.62529
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.51391
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 3420.25561
-  tps: 2391.10141
-  dtps: 13.72089
+  dps: 3416.07519
+  tps: 2388.78318
+  dtps: 13.76724
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 3437.62529
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.51391
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.31297
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.34768
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Heartrazor-29962"
  value: {
-  dps: 3520.38267
-  tps: 2483.25407
-  dtps: 13.36878
+  dps: 3515.49286
+  tps: 2481.63698
+  dtps: 13.41755
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 3437.63185
-  tps: 2407.5381
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2405.78228
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 3437.62529
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.51391
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HighWarlord'sChainGauntlets-28806"
  value: {
-  dps: 3485.98544
-  tps: 2457.8658
-  dtps: 13.0594
+  dps: 3478.58428
+  tps: 2453.79453
+  dtps: 13.10816
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 3494.22766
-  tps: 2460.89448
-  dtps: 13.72406
+  dps: 3490.60746
+  tps: 2458.62959
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IceGuard-2682"
  value: {
-  dps: 3531.38688
-  tps: 2499.72204
-  dtps: 13.36192
+  dps: 3525.90581
+  tps: 2500.21662
+  dtps: 13.41068
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 3458.64876
-  tps: 2428.79099
-  dtps: 13.72406
+  dps: 3455.52696
+  tps: 2427.0256
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 3437.62529
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.51391
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ImbuedNetherweave"
  value: {
-  dps: 3131.694
-  tps: 2134.28427
-  dtps: 13.55243
+  dps: 3131.50533
+  tps: 2137.76779
+  dtps: 13.59003
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-InfinityBlade-30312"
  value: {
-  dps: 3557.99319
-  tps: 2514.79178
-  dtps: 13.36878
+  dps: 3555.28314
+  tps: 2514.7181
+  dtps: 13.41755
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-JomGabbar-23570"
  value: {
-  dps: 3477.28618
-  tps: 2442.15677
-  dtps: 13.72406
+  dps: 3474.21783
+  tps: 2440.41881
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KhoriumScope-2723"
  value: {
-  dps: 3545.63156
-  tps: 2510.54406
-  dtps: 13.26766
+  dps: 3537.97415
+  tps: 2507.01382
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 3468.23252
-  tps: 2443.15674
+  dps: 3461.22066
+  tps: 2436.97728
   dtps: 13.96032
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Knight-Lieutenant'sChainVices-23279"
  value: {
-  dps: 3473.14212
-  tps: 2445.12944
-  dtps: 13.0594
+  dps: 3467.41156
+  tps: 2442.58912
+  dtps: 13.10816
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartChampion-28429"
  value: {
-  dps: 3554.31654
-  tps: 2513.58472
-  dtps: 13.36878
+  dps: 3550.62917
+  tps: 2512.558
+  dtps: 13.41755
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 3554.6414
-  tps: 2513.90958
-  dtps: 13.36878
+  dps: 3550.92322
+  tps: 2512.85205
+  dtps: 13.41755
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
+  dps: 3434.52044
+  tps: 2406.01255
   dtps: 12.34561
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 3501.53875
-  tps: 2464.32132
-  dtps: 13.72406
+  dps: 3498.40771
+  tps: 2462.54372
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 2853.98496
-  tps: 1883.15113
-  dtps: 13.91723
+  dps: 2850.24502
+  tps: 1881.39036
+  dtps: 13.91224
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Marshal'sChainGrips-16463"
  value: {
-  dps: 3484.57564
-  tps: 2456.43236
-  dtps: 13.0594
+  dps: 3477.78028
+  tps: 2452.98827
+  dtps: 13.10816
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 3406.66308
-  tps: 2382.65508
-  dtps: 13.58554
+  dps: 3401.12829
+  tps: 2380.96671
+  dtps: 13.63431
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MercilessGladiator'sChainGauntlets-31961"
  value: {
-  dps: 3510.12148
-  tps: 2475.96602
-  dtps: 13.30051
+  dps: 3502.35762
+  tps: 2471.53197
+  dtps: 13.34928
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 3417.97967
-  tps: 2396.27535
-  dtps: 13.57163
+  dps: 3413.5408
+  tps: 2393.65556
+  dtps: 13.6204
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 3437.75858
-  tps: 2407.94832
-  dtps: 13.72406
+  dps: 3434.64714
+  tps: 2406.19322
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 3437.62529
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.51391
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherscaleArmor"
  value: {
-  dps: 3392.87558
-  tps: 2372.17317
-  dtps: 13.57127
+  dps: 3385.61748
+  tps: 2368.32985
+  dtps: 13.62003
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherstrikeArmor"
  value: {
-  dps: 3200.7584
-  tps: 2204.54754
-  dtps: 13.27144
+  dps: 3194.7701
+  tps: 2199.91513
+  dtps: 13.09195
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-NetherweaveVestments"
  value: {
-  dps: 2869.89564
-  tps: 1898.37609
-  dtps: 12.59606
+  dps: 2863.61435
+  tps: 1896.09748
+  dtps: 12.6535
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 3476.90218
-  tps: 2441.59878
-  dtps: 13.72406
+  dps: 3473.78564
+  tps: 2439.83752
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 3494.26046
-  tps: 2465.08873
+  dps: 3487.03493
+  tps: 2461.94155
   dtps: 12.16278
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 3494.26046
-  tps: 2465.08873
-  dtps: 13.26766
+  dps: 3487.03493
+  tps: 2461.94155
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofThawing-24093"
  value: {
-  dps: 3494.26046
-  tps: 2465.08873
-  dtps: 13.26766
+  dps: 3487.03493
+  tps: 2461.94155
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantofWithering-24095"
  value: {
-  dps: 3494.26046
-  tps: 2465.08873
-  dtps: 13.26766
+  dps: 3487.03493
+  tps: 2461.94155
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 3494.26046
-  tps: 2465.08873
-  dtps: 13.26766
+  dps: 3487.03493
+  tps: 2461.94155
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 3437.63185
-  tps: 2407.83294
-  dtps: 13.86832
+  dps: 3434.52044
+  tps: 2406.07795
+  dtps: 13.91467
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrimalIntent"
  value: {
-  dps: 3440.3476
-  tps: 2411.21787
-  dtps: 12.88762
+  dps: 3434.21498
+  tps: 2412.62123
+  dtps: 12.93638
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrimalMooncloth"
  value: {
-  dps: 3164.89022
-  tps: 2173.09605
-  dtps: 12.94581
+  dps: 3147.96612
+  tps: 2160.15703
+  dtps: 13.00325
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Prismcharm-15867"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.64052
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.68687
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 3432.93002
-  tps: 2402.24247
-  dtps: 13.72104
+  dps: 3423.86472
+  tps: 2395.16012
+  dtps: 13.76739
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RiftStalkerArmor"
  value: {
-  dps: 3301.00001
-  tps: 2273.49015
-  dtps: 13.24059
+  dps: 3293.87259
+  tps: 2273.98174
+  dtps: 13.28935
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 3406.66308
-  tps: 2382.65047
-  dtps: 13.58554
+  dps: 3401.12829
+  tps: 2380.96321
+  dtps: 13.63431
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 3455.16844
-  tps: 2425.11025
+  dps: 3452.07051
+  tps: 2423.35549
   dtps: 13.24269
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-RuneofForce-25994"
  value: {
-  dps: 3447.88011
-  tps: 2416.64913
-  dtps: 13.72406
+  dps: 3444.76763
+  tps: 2414.89416
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SavageGuard-2681"
  value: {
-  dps: 3531.38688
-  tps: 2499.72204
-  dtps: 13.36192
+  dps: 3525.90581
+  tps: 2500.21662
+  dtps: 13.41068
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 3418.98786
-  tps: 2392.15703
-  dtps: 13.72406
+  dps: 3415.87645
+  tps: 2390.40206
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 3467.34632
-  tps: 2438.50465
+  dps: 3464.09185
+  tps: 2440.29925
   dtps: 12.94517
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 3437.59471
-  tps: 2408.10193
-  dtps: 13.72406
+  dps: 3434.45617
+  tps: 2406.32778
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 3437.62529
-  tps: 2407.76752
-  dtps: 13.86832
+  dps: 3434.51391
+  tps: 2406.01255
+  dtps: 13.91467
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 3175.75962
-  tps: 2176.95343
-  dtps: 12.76841
+  dps: 3164.65977
+  tps: 2173.94782
+  dtps: 12.80265
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShardofContempt-34472"
  value: {
-  dps: 3497.53541
-  tps: 2466.07898
-  dtps: 13.73972
+  dps: 3493.1507
+  tps: 2464.28683
+  dtps: 13.78607
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.86832
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.91467
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 3428.09522
-  tps: 2400.71478
-  dtps: 13.64512
+  dps: 3423.6368
+  tps: 2399.15233
+  dtps: 13.69147
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 3497.9804
-  tps: 2459.80348
-  dtps: 13.72406
+  dps: 3494.8744
+  tps: 2458.04013
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SoulclothEmbrace"
  value: {
-  dps: 3158.39657
-  tps: 2167.9516
-  dtps: 12.62902
+  dps: 3145.05358
+  tps: 2157.93682
+  dtps: 12.68646
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 3199.51902
-  tps: 2191.25225
-  dtps: 13.36749
+  dps: 3200.23335
+  tps: 2200.12044
+  dtps: 13.41625
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 3493.43534
-  tps: 2461.72323
+  dps: 3489.03741
+  tps: 2460.58869
   dtps: 13.28082
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Stalker'sChainGauntlets-35377"
  value: {
-  dps: 3485.98544
-  tps: 2457.8658
-  dtps: 13.0594
+  dps: 3478.58428
+  tps: 2453.79453
+  dtps: 13.10816
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Stalker'sChainGauntlets-35475"
  value: {
-  dps: 3485.98544
-  tps: 2457.8658
-  dtps: 13.0594
+  dps: 3478.58428
+  tps: 2453.79453
+  dtps: 13.10816
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 3437.59471
-  tps: 2408.10193
-  dtps: 13.72406
+  dps: 3434.45617
+  tps: 2406.32778
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 3451.321
-  tps: 2426.82908
-  dtps: 13.73972
+  dps: 3446.96342
+  tps: 2425.0488
+  dtps: 13.78607
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 3131.694
-  tps: 2134.93151
-  dtps: 13.02628
+  dps: 3131.50533
+  tps: 2138.4182
+  dtps: 13.06388
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 3508.37482
-  tps: 2472.45574
-  dtps: 13.16051
+  dps: 3502.89284
+  tps: 2469.28885
+  dtps: 13.20927
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 3437.61362
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.50229
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 3437.59471
-  tps: 2408.10193
-  dtps: 13.72406
+  dps: 3434.45617
+  tps: 2406.32778
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TalonofAl'ar-30448"
  value: {
-  dps: 3458.72106
-  tps: 2428.85674
-  dtps: 13.72406
+  dps: 3455.59656
+  tps: 2427.08867
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 3449.79513
-  tps: 2418.49115
-  dtps: 13.72406
+  dps: 3446.65742
+  tps: 2416.71699
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 3437.59471
-  tps: 2408.10193
-  dtps: 13.72406
+  dps: 3434.45617
+  tps: 2406.32778
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheBladefist-29348"
  value: {
-  dps: 3290.08726
-  tps: 2273.73472
+  dps: 3286.62068
+  tps: 2272.32412
   dtps: 13.51732
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 3437.63185
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheNightBlade-31331"
  value: {
-  dps: 3493.48251
-  tps: 2461.80401
-  dtps: 13.36878
+  dps: 3489.08464
+  tps: 2460.66784
+  dtps: 13.41755
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 3437.62529
-  tps: 2407.76752
-  dtps: 13.72406
+  dps: 3434.51391
+  tps: 2406.01255
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 3418.81876
-  tps: 2393.55585
-  dtps: 13.75753
+  dps: 3417.98856
+  tps: 2394.0335
+  dtps: 13.80388
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 3353.91073
-  tps: 2333.35606
+  dps: 3354.61494
+  tps: 2337.03227
   dtps: 13.4964
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-ThickDraenicArmor"
  value: {
-  dps: 3231.51895
-  tps: 2220.53811
-  dtps: 12.98465
+  dps: 3223.73361
+  tps: 2219.25708
+  dtps: 12.99992
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Thori'dal,theStars'Fury-34334"
  value: {
-  dps: 3743.68695
-  tps: 2724.69264
-  dtps: 13.45907
+  dps: 3740.09132
+  tps: 2727.97916
+  dtps: 13.50253
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 3504.88698
-  tps: 2469.77599
+  dps: 3492.07626
+  tps: 2462.20272
   dtps: 13.24537
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 3437.63185
-  tps: 2407.34167
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2405.58665
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 3506.74762
-  tps: 2472.68964
-  dtps: 13.72406
+  dps: 3503.93803
+  tps: 2471.23677
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-UnitingCharm-25633"
  value: {
-  dps: 3476.90218
-  tps: 2441.59878
-  dtps: 13.72406
+  dps: 3473.78564
+  tps: 2439.83752
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 3437.59471
-  tps: 2408.10193
-  dtps: 13.86832
+  dps: 3434.45617
+  tps: 2406.32778
+  dtps: 13.91467
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-VengefulGladiator'sChainGauntlets-33665"
  value: {
-  dps: 3517.37382
-  tps: 2482.59933
-  dtps: 13.30051
+  dps: 3511.01269
+  tps: 2479.59023
+  dtps: 13.34928
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 3437.63185
-  tps: 2407.46326
-  dtps: 13.72406
+  dps: 3434.52044
+  tps: 2405.70803
+  dtps: 13.77041
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WarpSlicer-30311"
  value: {
-  dps: 3557.92962
-  tps: 2514.67753
-  dtps: 13.36878
+  dps: 3555.21953
+  tps: 2514.60394
+  dtps: 13.41755
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WastewalkerArmor"
  value: {
-  dps: 3153.93192
-  tps: 2144.84571
-  dtps: 12.80476
+  dps: 3148.17797
+  tps: 2147.41231
+  dtps: 12.85534
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WhitemendWisdom"
  value: {
-  dps: 3199.51902
-  tps: 2190.69947
-  dtps: 13.36749
+  dps: 3200.23335
+  tps: 2199.55882
+  dtps: 13.41625
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WindhawkArmor"
  value: {
-  dps: 3200.7584
-  tps: 2204.95684
-  dtps: 13.05772
+  dps: 3194.7701
+  tps: 2200.31708
+  dtps: 13.09195
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 3503.97864
-  tps: 2473.45939
-  dtps: 13.26766
+  dps: 3497.86172
+  tps: 2471.43303
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-WrathofSpellfire"
  value: {
-  dps: 3173.60393
-  tps: 2172.29436
-  dtps: 13.15516
+  dps: 3165.11758
+  tps: 2169.79336
+  dtps: 13.21261
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 3420.25561
-  tps: 2391.10141
-  dtps: 13.72089
+  dps: 3416.07519
+  tps: 2388.78318
+  dtps: 13.76724
  }
 }
 dps_results: {
  key: "TestHunter-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 3437.59471
-  tps: 2408.10193
-  dtps: 13.86832
+  dps: 3434.45617
+  tps: 2406.32778
+  dtps: 13.91467
  }
 }
 dps_results: {
  key: "TestHunter-Average-Default"
  value: {
-  dps: 3556.5281
-  tps: 2531.44207
-  dtps: 12.74925
+  dps: 3551.53605
+  tps: 2529.28412
+  dtps: 12.76453
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-Turret-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 5951.11619
-  tps: 5628.04071
+  dps: 5945.25074
+  tps: 5625.88373
   dtps: 11.01763
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-Turret-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 2966.39847
-  tps: 1985.7036
-  dtps: 12.88165
+  dps: 2966.02738
+  tps: 1987.00383
+  dtps: 12.96065
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-Turret-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3373.00039
-  tps: 2255.39258
-  dtps: 26.9188
+  dps: 3363.36457
+  tps: 2252.13373
+  dtps: 27.15579
  }
 }
 dps_results: {
@@ -1709,24 +1709,24 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 6387.69727
-  tps: 6226.39955
-  dtps: 11.45662
+  dps: 6388.81604
+  tps: 6233.78145
+  dtps: 11.45747
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 3491.23483
-  tps: 2505.12632
-  dtps: 13.26766
+  dps: 3485.19103
+  tps: 2503.05183
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3947.84212
-  tps: 2840.47121
+  dps: 3943.14455
+  tps: 2843.55867
   dtps: 27.69975
  }
 }
@@ -1754,115 +1754,115 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-Turret-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 6152.95056
-  tps: 6380.03998
+  dps: 6146.69953
+  tps: 6375.16686
   dtps: 10.36328
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-Turret-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 2568.70922
-  tps: 2029.50306
-  dtps: 12.35412
+  dps: 2565.61703
+  tps: 2026.98287
+  dtps: 12.42593
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-Turret-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 2839.69371
-  tps: 2273.28386
-  dtps: 24.51796
+  dps: 2837.42429
+  tps: 2272.15415
+  dtps: 24.7334
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-Turret-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1335.35362
-  tps: 1442.61709
+  dps: 1335.30052
+  tps: 1442.56717
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-Turret-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 740.98345
-  tps: 613.76994
+  dps: 740.95236
+  tps: 613.74197
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-Turret-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 1022.89435
-  tps: 877.97417
+  dps: 1022.85206
+  tps: 877.93506
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 6687.43671
-  tps: 7055.41733
-  dtps: 10.43897
+  dps: 6682.63337
+  tps: 7052.48106
+  dtps: 10.31438
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 3168.1176
-  tps: 2627.71252
+  dps: 3162.55961
+  tps: 2623.7921
   dtps: 12.20574
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3515.32153
-  tps: 2958.17619
+  dps: 3509.67924
+  tps: 2953.63152
   dtps: 25.04025
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1369.51772
-  tps: 1478.81797
+  dps: 1369.46198
+  tps: 1478.7654
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 892.71967
-  tps: 765.3986
+  dps: 892.68165
+  tps: 765.36377
  }
 }
 dps_results: {
  key: "TestHunter-Settings-NightElf-2h_6p-SV-Default-weave-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 1184.164
-  tps: 1036.90458
+  dps: 1184.11465
+  tps: 1036.8585
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-Turret-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 6027.06042
-  tps: 5654.86607
+  dps: 6022.01471
+  tps: 5653.6632
   dtps: 11.01763
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-Turret-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 3029.93113
-  tps: 2000.51284
-  dtps: 12.88165
+  dps: 3032.34632
+  tps: 2002.52686
+  dtps: 12.96065
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-Turret-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3458.76963
-  tps: 2282.43004
-  dtps: 26.9188
+  dps: 3449.59847
+  tps: 2280.32318
+  dtps: 27.15579
  }
 }
 dps_results: {
@@ -1889,24 +1889,24 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 6471.85177
-  tps: 6263.80121
-  dtps: 11.45662
+  dps: 6467.3264
+  tps: 6263.7529
+  dtps: 11.45747
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 3559.37669
-  tps: 2524.07579
-  dtps: 13.26766
+  dps: 3552.31703
+  tps: 2521.11859
+  dtps: 13.31642
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-DefaultTalents-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 4039.20853
-  tps: 2873.56931
+  dps: 4033.22398
+  tps: 2875.68503
   dtps: 27.69975
  }
 }
@@ -1934,98 +1934,98 @@ dps_results: {
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-Turret-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 6200.18325
-  tps: 6402.02425
+  dps: 6193.53116
+  tps: 6396.94251
   dtps: 10.36328
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-Turret-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 2603.64859
-  tps: 2038.57692
-  dtps: 12.35412
+  dps: 2601.1151
+  tps: 2037.1258
+  dtps: 12.42593
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-Turret-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 2893.37871
-  tps: 2299.08603
-  dtps: 24.51796
+  dps: 2891.0859
+  tps: 2297.98586
+  dtps: 24.7334
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-Turret-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1336.19327
-  tps: 1434.80028
+  dps: 1336.15381
+  tps: 1434.76328
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-Turret-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 747.80914
-  tps: 614.06235
+  dps: 747.78593
+  tps: 614.04159
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-Turret-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 1041.40036
-  tps: 887.62304
+  dps: 1041.36863
+  tps: 887.59381
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 6738.07263
-  tps: 7080.43872
+  dps: 6732.79954
+  tps: 7076.5722
   dtps: 10.31438
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-FullBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 3211.66268
-  tps: 2645.08152
+  dps: 3205.98433
+  tps: 2640.58306
   dtps: 12.2154
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-FullBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 3572.51269
-  tps: 2988.4724
+  dps: 3568.27552
+  tps: 2985.44112
   dtps: 25.04025
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongMultiTarget"
  value: {
-  dps: 1367.48376
-  tps: 1464.6047
+  dps: 1367.20373
+  tps: 1464.32719
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-NoBuffs-7.0yards-LongSingleTarget"
  value: {
-  dps: 908.34424
-  tps: 775.78909
+  dps: 908.31552
+  tps: 775.76283
  }
 }
 dps_results: {
  key: "TestHunter-Settings-Orc-2h_6p-SV-Default-weave-NoBuffs-7.0yards-ShortSingleTarget"
  value: {
-  dps: 1197.03088
-  tps: 1043.84127
+  dps: 1196.99403
+  tps: 1043.80699
  }
 }
 dps_results: {
  key: "TestHunter-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3285.1065
-  tps: 2425.68324
+  dps: 3282.68357
+  tps: 2424.08185
   dtps: 13.33321
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestArcane-CharacterStats-Default"
  value: {
-  final_stats: 173.58
-  final_stats: 169.895
-  final_stats: 600.16
-  final_stats: 761.4035
-  final_stats: 926.449
-  final_stats: 1157.09812
+  final_stats: 171
+  final_stats: 168
+  final_stats: 598
+  final_stats: 760
+  final_stats: 926.3
+  final_stats: 1156.5
   final_stats: 272
   final_stats: 222
   final_stats: 0
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 289
   final_stats: 0
   final_stats: 0
-  final_stats: 314.49
-  final_stats: 848.65
+  final_stats: 313
+  final_stats: 848.1
   final_stats: 389
   final_stats: 0
   final_stats: 0
@@ -32,21 +32,21 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 11
-  final_stats: 3209.19
+  final_stats: 3205
   final_stats: 0
-  final_stats: 10384.6
-  final_stats: 13382.0525
-  final_stats: 122.7
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
+  final_stats: 10363
+  final_stats: 13361
+  final_stats: 122.5
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
   final_stats: 70
   final_stats: 0
   final_stats: 0
   final_stats: 9.10366
   final_stats: 10.63172
-  final_stats: 33.51564
+  final_stats: 33.49809
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -55,1261 +55,1261 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AldorRegalia"
  value: {
-  dps: 1723.49193
-  tps: 1176.41201
+  dps: 1724.62939
+  tps: 1177.59262
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 1929.21316
-  tps: 1345.79348
+  dps: 1930.62133
+  tps: 1349.03498
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 1916.69608
-  tps: 1337.56654
+  dps: 1917.13544
+  tps: 1340.15274
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 1888.28535
-  tps: 1318.14747
+  dps: 1889.74446
+  tps: 1321.3045
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 1926.61439
-  tps: 1345.00559
+  dps: 1929.26581
+  tps: 1348.29894
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1631.33665
-  tps: 1116.84652
+  dps: 1635.37766
+  tps: 1121.31903
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AshtongueTalismanofInsight-32488"
  value: {
-  dps: 1910.11675
-  tps: 1339.85433
+  dps: 1913.89946
+  tps: 1343.72796
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1884.95494
-  tps: 1277.03694
+  dps: 1882.49614
+  tps: 1279.06931
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 1951.03847
-  tps: 1318.29456
+  dps: 1944.76222
+  tps: 1316.65731
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1974.65174
-  tps: 1335.2064
+  dps: 1969.65007
+  tps: 1334.65207
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 1905.07621
-  tps: 1328.81372
+  dps: 1905.51011
+  tps: 1326.40514
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BattlecastGarb"
  value: {
-  dps: 1717.63737
-  tps: 1167.65517
+  dps: 1724.22067
+  tps: 1172.30892
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 1881.75907
-  tps: 1316.12034
+  dps: 1887.18629
+  tps: 1321.55316
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 1881.75907
-  tps: 1316.12034
+  dps: 1887.18629
+  tps: 1321.55316
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1928.45998
-  tps: 1345.85198
+  dps: 1929.92202
+  tps: 1349.15842
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1911.34003
-  tps: 1334.70099
+  dps: 1912.68226
+  tps: 1337.61509
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1914.55735
-  tps: 1336.32757
+  dps: 1915.99586
+  tps: 1339.60087
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1888.28535
-  tps: 1318.14747
+  dps: 1889.74446
+  tps: 1321.3045
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 1852.60149
-  tps: 1261.63114
+  dps: 1846.46184
+  tps: 1258.04627
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1867.51512
-  tps: 1265.39468
+  dps: 1869.64996
+  tps: 1268.93159
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1927.54455
-  tps: 1306.46924
+  dps: 1921.12416
+  tps: 1302.32142
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1824.21537
-  tps: 1237.21288
+  dps: 1820.11169
+  tps: 1233.37861
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1820.18423
-  tps: 1232.56832
+  dps: 1824.02161
+  tps: 1236.66769
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1951.90692
-  tps: 1361.05879
+  dps: 1953.32646
+  tps: 1364.32167
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1952.44354
-  tps: 1362.57426
+  dps: 1953.95125
+  tps: 1365.94502
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1899.41683
-  tps: 1325.76987
+  dps: 1900.27514
+  tps: 1328.66772
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Despair-28573"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DirebrewHops-38288"
  value: {
-  dps: 1936.25559
-  tps: 1350.72218
+  dps: 1937.81644
+  tps: 1354.12616
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 1902.0453
-  tps: 1327.48983
+  dps: 1903.3362
+  tps: 1330.59952
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 1942.12946
-  tps: 1344.95939
+  dps: 1945.816
+  tps: 1349.0652
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Earthstrike-21180"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1928.52541
-  tps: 1329.62687
+  dps: 1927.76879
+  tps: 1328.88585
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1917.80072
-  tps: 1299.96766
+  dps: 1917.18369
+  tps: 1299.35264
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1936.25559
-  tps: 1350.72218
+  dps: 1937.81644
+  tps: 1354.12616
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1942.4056
-  tps: 1355.18423
+  dps: 1943.88493
+  tps: 1358.58366
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeofMoam-21473"
  value: {
-  dps: 1897.87624
-  tps: 1324.20885
+  dps: 1899.25275
+  tps: 1327.41614
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 1954.69875
-  tps: 1363.17279
+  dps: 1956.38097
+  tps: 1366.67503
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1890.4617
-  tps: 1279.14027
+  dps: 1891.5455
+  tps: 1280.89754
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FrostscytheofLordAhune-278953"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 1929.21316
-  tps: 1345.79348
+  dps: 1930.62133
+  tps: 1349.03498
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 1895.09136
-  tps: 1322.49981
+  dps: 1896.4871
+  tps: 1325.71389
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HandofJustice-11815"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 1898.13421
-  tps: 1324.289
+  dps: 1899.5292
+  tps: 1327.50265
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 1894.24238
-  tps: 1327.84836
+  dps: 1891.97037
+  tps: 1327.70506
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 1910.42289
-  tps: 1331.51475
+  dps: 1911.81988
+  tps: 1334.72957
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartrazor-29962"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 1917.3225
-  tps: 1336.484
+  dps: 1911.24078
+  tps: 1334.0726
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1969.73795
-  tps: 1372.96512
+  dps: 1971.15796
+  tps: 1376.23457
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 1909.82305
-  tps: 1332.2125
+  dps: 1911.18913
+  tps: 1335.38413
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IceGuard-2682"
  value: {
-  dps: 1922.71608
-  tps: 1303.18162
+  dps: 1920.78029
+  tps: 1301.62533
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1734.18575
-  tps: 1185.02152
+  dps: 1733.3212
+  tps: 1184.65642
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InfinityBlade-30312"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-JomGabbar-23570"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1524.32302
-  tps: 1045.13243
+  dps: 1508.30744
+  tps: 1032.24368
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 1892.9651
-  tps: 1282.18306
+  dps: 1895.70647
+  tps: 1284.73157
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1935.17001
-  tps: 1349.32129
+  dps: 1937.19119
+  tps: 1350.71269
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1895.69745
-  tps: 1327.96883
+  dps: 1893.07208
+  tps: 1325.49726
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1915.52279
-  tps: 1334.51349
+  dps: 1916.91978
+  tps: 1337.72831
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NetherweaveVestments"
  value: {
-  dps: 1481.56467
-  tps: 1037.64006
+  dps: 1466.55472
+  tps: 1024.48755
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 1921.4781
-  tps: 1340.73147
+  dps: 1922.98973
+  tps: 1344.07789
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1867.51512
-  tps: 1265.39468
+  dps: 1869.64996
+  tps: 1268.93159
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1867.51512
-  tps: 1265.39468
+  dps: 1869.64996
+  tps: 1268.93159
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1867.51512
-  tps: 1265.39468
+  dps: 1869.64996
+  tps: 1268.93159
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1867.51512
-  tps: 1265.39468
+  dps: 1869.64996
+  tps: 1268.93159
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1867.51512
-  tps: 1265.39468
+  dps: 1869.64996
+  tps: 1268.93159
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1959.21589
-  tps: 1358.15639
+  dps: 1961.83073
+  tps: 1360.4647
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PrimalMooncloth"
  value: {
-  dps: 1822.84653
-  tps: 1249.33419
+  dps: 1816.85365
+  tps: 1244.07151
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Prismcharm-15867"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1928.75911
-  tps: 1353.06092
+  dps: 1922.73595
+  tps: 1347.80119
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1911.52819
-  tps: 1297.58388
+  dps: 1906.36506
+  tps: 1294.74634
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofForce-25994"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SavageGuard-2681"
  value: {
-  dps: 1922.71608
-  tps: 1303.18162
+  dps: 1920.78029
+  tps: 1301.62533
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 1909.65054
-  tps: 1332.96602
+  dps: 1911.08075
+  tps: 1336.22762
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 1895.69745
-  tps: 1327.96883
+  dps: 1893.07208
+  tps: 1325.49726
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1915.19947
-  tps: 1337.67103
+  dps: 1918.00288
+  tps: 1341.02132
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Serpent-CoilBraid-30720"
  value: {
-  dps: 1965.80443
-  tps: 1370.41352
+  dps: 1963.83615
+  tps: 1368.56577
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1952.5952
-  tps: 1362.60806
+  dps: 1953.8391
+  tps: 1365.35986
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1687.01827
-  tps: 1165.9929
+  dps: 1671.17166
+  tps: 1157.24645
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1936.9591
-  tps: 1351.08487
+  dps: 1937.64979
+  tps: 1353.79513
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1928.76876
-  tps: 1350.22284
+  dps: 1929.76791
+  tps: 1350.76491
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1678.13217
-  tps: 1151.43057
+  dps: 1672.1106
+  tps: 1145.9509
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1708.13852
-  tps: 1159.70988
+  dps: 1699.35274
+  tps: 1155.33463
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 1912.03043
-  tps: 1335.54843
+  dps: 1914.82274
+  tps: 1338.88212
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 1898.57375
-  tps: 1325.17079
+  dps: 1899.89506
+  tps: 1328.31981
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1891.20279
-  tps: 1279.64222
+  dps: 1887.87578
+  tps: 1278.1629
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 1899.71951
-  tps: 1326.13098
+  dps: 1901.10481
+  tps: 1329.34071
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 1910.43168
-  tps: 1332.96237
+  dps: 1911.96853
+  tps: 1336.23557
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TempestRegalia"
  value: {
-  dps: 2023.54309
-  tps: 1370.35633
+  dps: 2020.04945
+  tps: 1366.28449
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 1888.28535
-  tps: 1318.14747
+  dps: 1889.74446
+  tps: 1321.3045
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 1906.83321
-  tps: 1332.06737
+  dps: 1909.6073
+  tps: 1335.37384
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1945.14414
-  tps: 1356.56384
+  dps: 1946.56548
+  tps: 1359.82664
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1955.97759
-  tps: 1372.82666
+  dps: 1947.37893
+  tps: 1367.83834
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1666.07186
-  tps: 1138.93126
+  dps: 1666.77007
+  tps: 1138.74066
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TirisfalRegalia"
  value: {
-  dps: 1911.84611
-  tps: 1308.34197
+  dps: 1904.52859
+  tps: 1303.14707
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 1938.87371
-  tps: 1350.66654
+  dps: 1938.23308
+  tps: 1350.48647
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnitingCharm-25633"
  value: {
-  dps: 1890.0233
-  tps: 1319.51979
+  dps: 1891.42029
+  tps: 1322.73461
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 1917.4096
-  tps: 1337.9861
+  dps: 1918.34906
+  tps: 1340.86634
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 1926.46983
-  tps: 1342.14065
+  dps: 1925.55791
+  tps: 1342.14412
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WhitemendWisdom"
  value: {
-  dps: 1694.14889
-  tps: 1153.93504
+  dps: 1687.42155
+  tps: 1149.2151
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 1912.25737
-  tps: 1295.50845
+  dps: 1909.68337
+  tps: 1297.5402
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WrathofSpellfire"
  value: {
-  dps: 1829.25985
-  tps: 1244.78124
+  dps: 1824.97882
+  tps: 1242.68187
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 1894.24238
-  tps: 1327.84836
+  dps: 1891.97037
+  tps: 1327.70506
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1923.41748
-  tps: 1341.83347
+  dps: 1924.36973
+  tps: 1344.73332
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 1950.23015
-  tps: 1319.9462
+  dps: 1946.09377
+  tps: 1317.57391
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2179.11792
-  tps: 2542.28744
+  dps: 2175.20565
+  tps: 2539.36442
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1933.50271
-  tps: 1302.66032
+  dps: 1938.53127
+  tps: 1307.00048
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2598.67374
-  tps: 1587.70191
+  dps: 2599.47406
+  tps: 1588.88657
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 800.24692
-  tps: 1166.88357
+  dps: 796.40323
+  tps: 1164.05658
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 800.24692
-  tps: 531.67596
+  dps: 796.40323
+  tps: 529.23762
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1310.66427
-  tps: 821.2963
+  dps: 1310.38224
+  tps: 821.08621
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1Arcane-Arcane-arcane-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2190.49616
-  tps: 2551.18253
+  dps: 2193.93273
+  tps: 2554.01784
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1Arcane-Arcane-arcane-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1Arcane-Arcane-arcane-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2642.47778
-  tps: 1614.32201
+  dps: 2641.86555
+  tps: 1613.84995
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1Arcane-Arcane-arcane-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 802.40603
-  tps: 1168.16793
+  dps: 798.78373
+  tps: 1165.57703
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1Arcane-Arcane-arcane-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 802.40603
-  tps: 533.18123
+  dps: 798.78373
+  tps: 530.55417
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1Arcane-Arcane-arcane-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1360.42759
-  tps: 848.28757
+  dps: 1360.34259
+  tps: 848.20439
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1944.82108
-  tps: 1315.80191
+  dps: 1944.06743
+  tps: 1315.08365
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 171
   final_stats: 168
-  final_stats: 598
+  final_stats: 599
   final_stats: 760
   final_stats: 926.3
   final_stats: 1156.5
@@ -34,7 +34,7 @@ character_stats_results: {
   final_stats: 11
   final_stats: 3205
   final_stats: 0
-  final_stats: 10363
+  final_stats: 10373
   final_stats: 13361
   final_stats: 122.5
   final_stats: 33
@@ -1225,43 +1225,43 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2175.20565
-  tps: 2539.36442
+  dps: 2182.86253
+  tps: 2544.28962
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1938.53127
-  tps: 1307.00048
+  dps: 1932.84616
+  tps: 1301.87303
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2599.47406
-  tps: 1588.88657
+  dps: 2599.57466
+  tps: 1588.93924
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 796.40323
-  tps: 1164.05658
+  dps: 799.44491
+  tps: 1165.76983
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 796.40323
-  tps: 529.23762
+  dps: 799.44491
+  tps: 530.84722
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1Arcane-Arcane-arcane-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1310.38224
-  tps: 821.08621
+  dps: 1310.55488
+  tps: 821.18772
  }
 }
 dps_results: {

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -1762,24 +1762,24 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2472.83845
-  tps: 4333.24153
+  dps: 2472.23419
+  tps: 4332.07669
   dtps: 44391.92789
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 999.10417
-  tps: 1761.03762
+  dps: 998.74235
+  tps: 1760.37227
   dtps: 1254.13171
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1133.60845
-  tps: 1978.24298
+  dps: 1133.20721
+  tps: 1977.51215
   dtps: 1326.17281
  }
 }
@@ -1795,7 +1795,7 @@ dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
   dps: 421.80252
-  tps: 884.81838
+  tps: 884.84645
   dtps: 2281.72218
  }
 }
@@ -1803,7 +1803,7 @@ dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
   dps: 443.6182
-  tps: 924.0747
+  tps: 924.09664
   dtps: 2347.48218
  }
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestProtection-CharacterStats-Default"
  value: {
-  final_stats: 286.88
-  final_stats: 240.295
-  final_stats: 1460.36836
-  final_stats: 313.39
-  final_stats: 797.229
-  final_stats: 807.229
+  final_stats: 284
+  final_stats: 238
+  final_stats: 1458
+  final_stats: 312
+  final_stats: 797.1
+  final_stats: 807.1
   final_stats: 80
   final_stats: 0
   final_stats: 0
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 69
   final_stats: 0
   final_stats: 0
-  final_stats: 202.29
-  final_stats: 1688.786
+  final_stats: 201
+  final_stats: 1681.9
   final_stats: 389
   final_stats: 0
   final_stats: 15
@@ -29,24 +29,24 @@ character_stats_results: {
   final_stats: 385.3077
   final_stats: 158
   final_stats: 269
-  final_stats: 352.88485
+  final_stats: 351.14771
   final_stats: 29
   final_stats: 0
-  final_stats: 18747.289
+  final_stats: 18741.8
   final_stats: 0
-  final_stats: 19120.6836
-  final_stats: 7373.85
-  final_stats: 122.7
-  final_stats: 38.75
-  final_stats: 38.75
-  final_stats: 38.75
-  final_stats: 38.75
+  final_stats: 19097
+  final_stats: 7353
+  final_stats: 122.5
+  final_stats: 38
+  final_stats: 38
+  final_stats: 38
+  final_stats: 38
   final_stats: 75
   final_stats: 0
   final_stats: 3.95122
   final_stats: 6
-  final_stats: 17.43802
-  final_stats: 24.29569
+  final_stats: 17.34622
+  final_stats: 24.26094
   final_stats: 31.51903
   final_stats: 0
   final_stats: 0
@@ -55,1684 +55,1684 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 890.75914
-  tps: 1587.55867
-  dtps: 1295.48097
+  dps: 889.69259
+  tps: 1586.46556
+  dtps: 1295.6979
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 876.31076
-  tps: 1566.98187
-  dtps: 1246.84747
+  dps: 875.22431
+  tps: 1565.92445
+  dtps: 1247.16781
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 921.56171
-  tps: 1653.87612
-  dtps: 1294.28455
+  dps: 920.50983
+  tps: 1653.07252
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 880.16453
-  tps: 1574.26244
-  dtps: 1291.57463
+  dps: 878.70327
+  tps: 1572.66028
+  dtps: 1290.34519
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 875.59119
-  tps: 1564.08145
-  dtps: 1202.47962
+  dps: 875.11043
+  tps: 1564.13532
+  dtps: 1211.89479
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 898.96614
-  tps: 1610.39875
-  dtps: 1294.28455
+  dps: 897.477
+  tps: 1608.74582
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 888.62883
-  tps: 1590.49922
-  dtps: 1294.28455
+  dps: 887.12811
+  tps: 1588.82209
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 888.06834
-  tps: 1583.69246
-  dtps: 1294.28455
+  dps: 887.09504
+  tps: 1582.53797
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Annihilator-12798"
  value: {
-  dps: 815.28597
-  tps: 1451.5861
-  dtps: 1306.2087
+  dps: 814.17496
+  tps: 1450.4495
+  dtps: 1306.41947
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 905.04696
-  tps: 1622.34944
-  dtps: 1294.28455
+  dps: 903.54173
+  tps: 1620.66553
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 897.94173
-  tps: 1614.79491
-  dtps: 1518.66163
+  dps: 898.2398
+  tps: 1616.27535
+  dtps: 1525.93245
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 880.16453
-  tps: 1574.25291
-  dtps: 1291.43233
+  dps: 878.70327
+  tps: 1572.64938
+  dtps: 1290.22258
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 875.70047
-  tps: 1562.13434
-  dtps: 1224.69668
+  dps: 874.67436
+  tps: 1561.08219
+  dtps: 1224.89931
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 883.40784
-  tps: 1577.51221
-  dtps: 1294.28455
+  dps: 881.92315
+  tps: 1575.88664
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 929.0604
-  tps: 1659.01369
-  dtps: 1303.57219
+  dps: 930.10721
+  tps: 1661.31596
+  dtps: 1306.70266
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 928.207
-  tps: 1667.24365
-  dtps: 1314.90897
+  dps: 927.07202
+  tps: 1666.0823
+  dtps: 1315.12989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 934.15736
-  tps: 1679.27359
-  dtps: 1314.90897
+  dps: 933.02236
+  tps: 1678.11207
+  dtps: 1315.12989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 881.5145
-  tps: 1576.68041
-  dtps: 1294.28455
+  dps: 880.05428
+  tps: 1575.07986
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BattlecastGarb"
  value: {
-  dps: 927.65471
-  tps: 1672.80689
-  dtps: 1528.30421
+  dps: 926.17712
+  tps: 1670.68234
+  dtps: 1533.03242
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 878.71609
-  tps: 1572.08213
-  dtps: 1296.09458
+  dps: 877.17975
+  tps: 1570.35111
+  dtps: 1294.86629
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 878.71609
-  tps: 1572.08213
-  dtps: 1296.09458
+  dps: 877.17975
+  tps: 1570.35111
+  dtps: 1294.86629
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 897.811
-  tps: 1608.20067
-  dtps: 1294.28455
+  dps: 896.34063
+  tps: 1606.58254
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 886.40934
-  tps: 1581.84628
-  dtps: 1294.28455
+  dps: 885.39885
+  tps: 1580.69486
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 880.34284
-  tps: 1574.6077
-  dtps: 1294.28455
+  dps: 878.88156
+  tps: 1573.00552
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 886.89008
-  tps: 1580.99446
-  dtps: 1294.28455
+  dps: 885.41139
+  tps: 1579.37487
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 891.42823
-  tps: 1595.92748
-  dtps: 1294.28455
+  dps: 889.96116
+  tps: 1594.31513
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 894.24909
-  tps: 1588.35347
-  dtps: 1294.28455
+  dps: 892.74331
+  tps: 1586.7068
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 922.39319
-  tps: 1655.45114
-  dtps: 1294.28455
+  dps: 921.7022
+  tps: 1655.33082
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 898.30877
-  tps: 1595.8247
-  dtps: 1288.02322
+  dps: 898.86142
+  tps: 1597.48051
+  dtps: 1284.61558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 888.71542
-  tps: 1584.5758
-  dtps: 1294.28455
+  dps: 887.75506
+  tps: 1583.43424
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 877.3219
-  tps: 1571.42482
-  dtps: 1308.24136
+  dps: 875.9922
+  tps: 1569.9288
+  dtps: 1305.03923
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Blinkstrike-31332"
  value: {
-  dps: 921.56171
-  tps: 1653.87612
-  dtps: 1294.28455
+  dps: 920.50983
+  tps: 1653.07252
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 891.25111
-  tps: 1585.35549
-  dtps: 1294.28455
+  dps: 889.75493
+  tps: 1583.71842
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 934.22168
-  tps: 1674.64838
-  dtps: 1335.7269
+  dps: 935.07959
+  tps: 1677.32308
+  dtps: 1340.80138
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 876.31076
-  tps: 1567.06957
-  dtps: 1259.82996
+  dps: 875.22431
+  tps: 1566.01534
+  dtps: 1260.33053
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofFortitude-35039"
  value: {
-  dps: 917.5121
-  tps: 1646.18187
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1645.37511
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofVengeance-35041"
  value: {
-  dps: 917.50494
-  tps: 1646.16826
-  dtps: 1294.28455
+  dps: 916.4514
+  tps: 1645.3615
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 915.47028
-  tps: 1644.20008
-  dtps: 1222.58641
+  dps: 914.79634
+  tps: 1643.49946
+  dtps: 1222.7848
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 919.61384
-  tps: 1633.55175
-  dtps: 1294.27042
+  dps: 918.31083
+  tps: 1631.81768
+  dtps: 1293.49913
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 920.77202
-  tps: 1635.08405
-  dtps: 1284.01685
+  dps: 919.86054
+  tps: 1633.74015
+  dtps: 1283.25059
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BurningRage"
  value: {
-  dps: 909.6118
-  tps: 1597.78461
-  dtps: 1546.20737
+  dps: 908.78243
+  tps: 1596.77091
+  dtps: 1546.47627
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 930.19886
-  tps: 1671.65167
-  dtps: 1314.90897
+  dps: 929.06388
+  tps: 1670.48966
+  dtps: 1315.12989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 876.00373
-  tps: 1566.26049
-  dtps: 1245.67488
+  dps: 874.89292
+  tps: 1565.10376
+  dtps: 1240.79013
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 914.90753
-  tps: 1642.86831
-  dtps: 1401.27151
+  dps: 914.46445
+  tps: 1643.3821
+  dtps: 1409.54496
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CloudkeeperLegplates-14554"
  value: {
-  dps: 912.26521
-  tps: 1629.8492
-  dtps: 1349.43444
+  dps: 910.91783
+  tps: 1628.27548
+  dtps: 1348.40851
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 880.16453
-  tps: 1574.13975
-  dtps: 1275.54983
+  dps: 878.70327
+  tps: 1572.53213
+  dtps: 1274.3048
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 888.15742
-  tps: 1582.2618
-  dtps: 1294.28455
+  dps: 886.671
+  tps: 1580.63448
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 910.66146
-  tps: 1633.79376
-  dtps: 1401.27151
+  dps: 910.16233
+  tps: 1634.18608
+  dtps: 1409.54496
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeArmor"
  value: {
-  dps: 894.38057
-  tps: 1605.11418
-  dtps: 1290.08496
+  dps: 893.53801
+  tps: 1604.00457
+  dtps: 1290.28263
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeBattlegear"
  value: {
-  dps: 915.73935
-  tps: 1583.49678
-  dtps: 1405.86367
+  dps: 915.18558
+  tps: 1583.31808
+  dtps: 1410.45316
   hps: 1.16609
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 887.57536
-  tps: 1581.67973
-  dtps: 1294.28455
+  dps: 886.09024
+  tps: 1580.05372
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 876.1932
-  tps: 1567.19063
-  dtps: 1260.07345
+  dps: 875.66478
+  tps: 1566.9107
+  dtps: 1263.19743
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 909.78186
-  tps: 1631.18456
-  dtps: 1294.28455
+  dps: 908.27821
+  tps: 1629.50529
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 906.43096
-  tps: 1616.00408
-  dtps: 1294.28455
+  dps: 904.61421
+  tps: 1613.74134
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 876.66757
-  tps: 1568.33791
-  dtps: 1276.55653
+  dps: 875.39365
+  tps: 1567.20837
+  dtps: 1278.6796
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 896.89001
-  tps: 1596.74295
-  dtps: 1294.28455
+  dps: 896.05377
+  tps: 1595.76548
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DirebrewHops-38288"
  value: {
-  dps: 900.02326
-  tps: 1612.46441
-  dtps: 1294.28455
+  dps: 898.56381
+  tps: 1610.86648
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DoomplateBattlegear"
  value: {
-  dps: 904.94632
-  tps: 1585.59442
-  dtps: 1619.08265
+  dps: 904.06035
+  tps: 1584.69906
+  dtps: 1620.40074
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 888.2164
-  tps: 1589.73127
-  dtps: 1294.28455
+  dps: 886.76854
+  tps: 1588.15459
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonmaw-28438"
  value: {
-  dps: 893.1961
-  tps: 1539.75777
-  dtps: 1262.90409
+  dps: 892.09938
+  tps: 1538.61341
+  dtps: 1263.11632
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 892.58855
-  tps: 1589.31151
-  dtps: 1286.8966
+  dps: 891.5921
+  tps: 1588.42996
+  dtps: 1287.09913
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonstrike-28439"
  value: {
-  dps: 903.84303
-  tps: 1550.8006
-  dtps: 1264.15865
+  dps: 902.53622
+  tps: 1549.46835
+  dtps: 1264.37068
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 887.29746
-  tps: 1536.49783
-  dtps: 1282.27771
+  dps: 886.21105
+  tps: 1535.35409
+  dtps: 1282.49274
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 891.53989
-  tps: 1595.76174
-  dtps: 1294.28455
+  dps: 890.07678
+  tps: 1594.15661
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Earthstrike-21180"
  value: {
-  dps: 885.23433
-  tps: 1579.33871
-  dtps: 1294.28455
+  dps: 883.7537
+  tps: 1577.71719
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 881.90925
-  tps: 1576.37281
-  dtps: 1281.89069
+  dps: 879.64482
+  tps: 1573.60255
+  dtps: 1285.26676
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 891.25111
-  tps: 1585.35549
-  dtps: 1294.28455
+  dps: 889.75493
+  tps: 1583.71842
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 921.02341
-  tps: 1651.62698
-  dtps: 1278.88702
+  dps: 922.1013
+  tps: 1653.54875
+  dtps: 1280.70339
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 921.26171
-  tps: 1622.99859
-  dtps: 1310.99362
+  dps: 921.53764
+  tps: 1624.02882
+  dtps: 1308.07597
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 914.05257
-  tps: 1670.78022
-  dtps: 1294.28455
+  dps: 913.00457
+  tps: 1669.96603
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 910.70416
-  tps: 1629.39979
-  dtps: 1294.28455
+  dps: 909.66135
+  tps: 1628.60921
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 897.41551
-  tps: 1601.42716
-  dtps: 1227.25598
+  dps: 896.39355
+  tps: 1600.38831
+  dtps: 1227.46212
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 911.02895
-  tps: 1629.47709
-  dtps: 1294.28455
+  dps: 909.96914
+  tps: 1628.67141
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 910.24358
-  tps: 1626.42778
-  dtps: 1232.40893
+  dps: 909.71293
+  tps: 1626.3977
+  dtps: 1234.31748
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 900.02326
-  tps: 1612.46441
-  dtps: 1294.28455
+  dps: 898.56381
+  tps: 1610.86648
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeofMoam-21473"
  value: {
-  dps: 883.20069
-  tps: 1580.11104
-  dtps: 1294.28455
+  dps: 881.73999
+  tps: 1578.50995
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 909.79795
-  tps: 1631.23575
-  dtps: 1294.28455
+  dps: 908.29467
+  tps: 1629.55445
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 927.57107
-  tps: 1666.87925
-  dtps: 1323.58974
+  dps: 926.24915
+  tps: 1665.89868
+  dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelSkin"
  value: {
-  dps: 920.28305
-  tps: 1635.46286
-  dtps: 1591.51554
+  dps: 919.23926
+  tps: 1634.36875
+  dtps: 1594.09086
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelscaleArmor"
  value: {
-  dps: 891.39229
-  tps: 1569.10901
-  dtps: 1473.24399
+  dps: 890.82611
+  tps: 1568.68779
+  dtps: 1475.84708
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 868.32755
-  tps: 1552.27841
-  dtps: 1226.52683
+  dps: 868.63519
+  tps: 1553.5242
+  dtps: 1225.54009
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 864.08711
-  tps: 1544.5025
-  dtps: 1199.11718
+  dps: 862.94877
+  tps: 1543.29811
+  dtps: 1199.31803
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 887.02024
-  tps: 1581.12462
-  dtps: 1294.28455
+  dps: 885.54721
+  tps: 1579.5107
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
   hps: 4.7
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ForceReactiveDisk-18168"
  value: {
-  dps: 922.42419
-  tps: 1655.8315
-  dtps: 1453.53081
+  dps: 921.77069
+  tps: 1655.14946
+  dtps: 1453.79353
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofFortitude-33936"
  value: {
-  dps: 917.5121
-  tps: 1646.18187
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1645.37511
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofVengeance-33948"
  value: {
-  dps: 917.50494
-  tps: 1646.16826
-  dtps: 1294.28455
+  dps: 916.4514
+  tps: 1645.3615
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 898.96614
-  tps: 1610.39875
-  dtps: 1294.28455
+  dps: 897.477
+  tps: 1608.74582
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 880.16453
-  tps: 1574.17372
-  dtps: 1280.69983
+  dps: 878.70327
+  tps: 1572.56735
+  dtps: 1279.4648
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 880.16453
-  tps: 1574.13975
-  dtps: 1275.54983
+  dps: 878.70327
+  tps: 1572.53213
+  dtps: 1274.3048
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HandofJustice-11815"
  value: {
-  dps: 890.34269
-  tps: 1589.81094
-  dtps: 1293.43818
+  dps: 888.95307
+  tps: 1588.41002
+  dtps: 1295.92629
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 879.07754
-  tps: 1572.27514
-  dtps: 1305.00032
+  dps: 877.6596
+  tps: 1570.63104
+  dtps: 1303.7728
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 886.48273
-  tps: 1585.77301
-  dtps: 1294.28455
+  dps: 885.0393
+  tps: 1584.21005
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 918.40397
-  tps: 1647.75128
-  dtps: 1294.28455
+  dps: 916.88609
+  tps: 1646.04602
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 889.52186
-  tps: 1592.23156
-  dtps: 1294.28455
+  dps: 888.08702
+  tps: 1590.6796
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 887.42748
-  tps: 1582.86443
-  dtps: 1294.28455
+  dps: 886.29177
+  tps: 1581.58777
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IceGuard-2682"
  value: {
-  dps: 921.99593
-  tps: 1655.8546
-  dtps: 1312.25995
+  dps: 921.30945
+  tps: 1655.75976
+  dtps: 1315.64106
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 890.03718
-  tps: 1585.68156
-  dtps: 1283.53082
+  dps: 889.13419
+  tps: 1584.83422
+  dtps: 1291.87949
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImbuedNetherweave"
  value: {
-  dps: 913.49434
-  tps: 1644.78864
-  dtps: 1573.5504
+  dps: 912.65598
+  tps: 1643.67859
+  dtps: 1573.82623
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JomGabbar-23570"
  value: {
-  dps: 886.34813
-  tps: 1580.4525
-  dtps: 1294.28455
+  dps: 884.86382
+  tps: 1578.82731
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarArmor"
  value: {
-  dps: 909.54423
-  tps: 1632.3982
-  dtps: 1329.87036
+  dps: 908.39593
+  tps: 1630.76366
+  dtps: 1330.07443
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarBattlegear"
  value: {
-  dps: 908.26573
-  tps: 1581.26604
-  dtps: 1461.81743
+  dps: 908.38573
+  tps: 1581.99196
+  dtps: 1463.89564
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumScope-2723"
  value: {
-  dps: 921.56171
-  tps: 1653.87612
-  dtps: 1294.28455
+  dps: 920.50983
+  tps: 1653.07252
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumWard"
  value: {
-  dps: 944.62569
-  tps: 1705.76752
-  dtps: 1484.42037
+  dps: 943.17965
+  tps: 1703.79464
+  dtps: 1490.34682
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 888.51613
-  tps: 1587.08838
-  dtps: 1293.10578
+  dps: 887.46382
+  tps: 1586.00975
+  dtps: 1293.32281
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofAvengement-27484"
  value: {
-  dps: 922.95152
-  tps: 1653.42962
-  dtps: 1294.28455
+  dps: 921.4599
+  tps: 1651.77782
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 917.5121
-  tps: 1646.18187
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1645.37511
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivinePurpose-33504"
  value: {
-  dps: 939.37768
-  tps: 1687.72647
-  dtps: 1294.28455
+  dps: 938.31204
+  tps: 1686.89672
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofFervor-23203"
  value: {
-  dps: 917.5121
-  tps: 1646.18187
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1645.37511
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofHope-22401"
  value: {
-  dps: 917.5121
-  tps: 1645.42218
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1644.62013
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRepentance-29388"
  value: {
-  dps: 917.5121
-  tps: 1646.18187
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1645.37511
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRighteousPower-31033"
  value: {
-  dps: 917.5121
-  tps: 1646.18187
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1645.37511
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofWracking-28065"
  value: {
-  dps: 917.5121
-  tps: 1646.18187
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1645.37511
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27949"
  value: {
-  dps: 917.5121
-  tps: 1646.18187
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1645.37511
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27983"
  value: {
-  dps: 917.5121
-  tps: 1646.18187
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1645.37511
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerArmor"
  value: {
-  dps: 929.5124
-  tps: 1669.12532
-  dtps: 1061.24395
+  dps: 929.35641
+  tps: 1669.47703
+  dtps: 1063.24058
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1039.5731
-  tps: 1741.27521
-  dtps: 1700.06334
+  dps: 1038.51289
+  tps: 1740.28486
+  dtps: 1703.16129
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 898.78825
-  tps: 1599.20135
-  dtps: 1281.99271
+  dps: 898.53117
+  tps: 1599.55168
+  dtps: 1287.47642
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 904.58329
-  tps: 1635.6361
-  dtps: 1955.39544
+  dps: 902.60471
+  tps: 1632.30964
+  dtps: 1952.41981
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 904.72669
-  tps: 1623.58694
-  dtps: 1379.27527
+  dps: 904.21574
+  tps: 1622.98577
+  dtps: 1372.76133
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 894.05643
-  tps: 1600.19505
-  dtps: 1294.28455
+  dps: 892.588
+  tps: 1598.58374
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofFortitude-33937"
  value: {
-  dps: 917.5121
-  tps: 1646.18187
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1645.37511
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofVengeance-33949"
  value: {
-  dps: 917.50494
-  tps: 1646.16826
-  dtps: 1294.28455
+  dps: 916.4514
+  tps: 1645.3615
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 877.85714
-  tps: 1569.809
-  dtps: 1295.58137
+  dps: 876.49852
+  tps: 1568.30673
+  dtps: 1294.35324
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 865.60727
-  tps: 1548.79729
-  dtps: 1194.67222
+  dps: 863.89227
+  tps: 1546.58753
+  dtps: 1197.07385
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 889.55881
-  tps: 1592.64915
-  dtps: 1294.28455
+  dps: 888.16541
+  tps: 1591.17536
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 890.95647
-  tps: 1594.99247
-  dtps: 1294.28455
+  dps: 889.4994
+  tps: 1593.39828
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherscaleArmor"
  value: {
-  dps: 931.90544
-  tps: 1656.94519
-  dtps: 1509.65126
+  dps: 930.97933
+  tps: 1656.0524
+  dtps: 1511.94213
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherstrikeArmor"
  value: {
-  dps: 941.19839
-  tps: 1699.52105
-  dtps: 1511.76151
+  dps: 940.32808
+  tps: 1698.81245
+  dtps: 1514.05036
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherweaveVestments"
  value: {
-  dps: 943.0307
-  tps: 1708.52784
-  dtps: 2069.19023
+  dps: 941.86559
+  tps: 1706.49584
+  dtps: 2076.52996
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 886.76092
-  tps: 1580.86529
-  dtps: 1294.28455
+  dps: 885.2764
+  tps: 1579.23989
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 893.6254
-  tps: 1600.1594
-  dtps: 1294.28455
+  dps: 892.16583
+  tps: 1598.56098
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 923.51502
-  tps: 1658.65152
-  dtps: 1323.58974
+  dps: 921.51058
+  tps: 1656.44073
+  dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 923.51502
-  tps: 1658.65152
-  dtps: 1323.58974
+  dps: 921.51058
+  tps: 1656.44073
+  dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofThawing-24093"
  value: {
-  dps: 923.51502
-  tps: 1658.65152
-  dtps: 1323.58974
+  dps: 921.51058
+  tps: 1656.44073
+  dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofWithering-24095"
  value: {
-  dps: 923.51502
-  tps: 1658.65152
-  dtps: 1323.58974
+  dps: 921.51058
+  tps: 1656.44073
+  dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 923.51502
-  tps: 1658.65152
-  dtps: 1323.58974
+  dps: 921.51058
+  tps: 1656.44073
+  dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 880.34284
-  tps: 1573.84678
-  dtps: 1294.28455
+  dps: 878.88156
+  tps: 1572.25145
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalIntent"
  value: {
-  dps: 935.21538
-  tps: 1648.32809
-  dtps: 1458.1094
+  dps: 934.38287
+  tps: 1647.73561
+  dtps: 1463.58492
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalMooncloth"
  value: {
-  dps: 929.23109
-  tps: 1674.68452
-  dtps: 1606.88095
+  dps: 928.90279
+  tps: 1675.43978
+  dtps: 1608.13687
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Prismcharm-15867"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 893.29774
-  tps: 1600.90439
-  dtps: 1285.83994
+  dps: 891.83245
+  tps: 1599.29216
+  dtps: 1284.6099
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 878.38657
-  tps: 1572.87637
-  dtps: 1301.79137
+  dps: 877.09608
+  tps: 1571.22897
+  dtps: 1304.06638
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 876.42152
-  tps: 1567.27392
-  dtps: 1260.67102
+  dps: 875.29448
+  tps: 1566.14328
+  dtps: 1260.86984
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 913.08971
-  tps: 1639.64196
-  dtps: 1379.27527
+  dps: 912.57447
+  tps: 1639.03295
+  dtps: 1372.76133
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 921.56171
-  tps: 1653.87612
-  dtps: 1294.28455
+  dps: 920.50983
+  tps: 1653.07252
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 897.8816
-  tps: 1592.04162
-  dtps: 1290.34989
+  dps: 896.59873
+  tps: 1590.82721
+  dtps: 1298.69973
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RuneofForce-25994"
  value: {
-  dps: 881.82575
-  tps: 1575.93013
-  dtps: 1294.28455
+  dps: 880.35619
+  tps: 1574.31968
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SavageGuard-2681"
  value: {
-  dps: 921.99593
-  tps: 1655.8546
-  dtps: 1312.25995
+  dps: 921.30945
+  tps: 1655.75976
+  dtps: 1315.64106
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 872.8652
-  tps: 1562.89316
-  dtps: 1241.83006
+  dps: 870.64447
+  tps: 1560.78017
+  dtps: 1247.5834
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 889.17549
-  tps: 1591.59576
-  dtps: 1294.28455
+  dps: 887.70958
+  tps: 1589.98545
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 885.45184
-  tps: 1583.98318
-  dtps: 1282.29274
+  dps: 884.29185
+  tps: 1582.79641
+  dtps: 1282.50757
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 903.28438
-  tps: 1619.03328
-  dtps: 1294.28455
+  dps: 901.82392
+  tps: 1617.43212
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 894.83856
-  tps: 1602.47609
-  dtps: 1294.28455
+  dps: 893.26128
+  tps: 1600.64813
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 882.03865
-  tps: 1584.77388
-  dtps: 1552.52139
+  dps: 881.03381
+  tps: 1583.74227
+  dtps: 1552.81584
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 870.04216
-  tps: 1556.06555
-  dtps: 1220.28564
+  dps: 868.31946
+  tps: 1553.98394
+  dtps: 1218.84078
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShardofContempt-34472"
  value: {
-  dps: 910.72043
-  tps: 1611.95152
-  dtps: 1286.42927
+  dps: 909.82308
+  tps: 1611.03568
+  dtps: 1286.64496
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 882.91612
-  tps: 1579.56366
-  dtps: 1294.28455
+  dps: 881.45484
+  tps: 1577.96147
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 899.18727
-  tps: 1611.08929
-  dtps: 1294.99466
+  dps: 898.06198
+  tps: 1610.29409
+  dtps: 1293.64736
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SkullflameShield-1168"
  value: {
-  dps: 925.07693
-  tps: 1654.98052
-  dtps: 1473.80805
+  dps: 924.42195
+  tps: 1654.29692
+  dtps: 1474.07764
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 890.25264
-  tps: 1584.35702
-  dtps: 1294.28455
+  dps: 888.75945
+  tps: 1582.72294
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SoulclothEmbrace"
  value: {
-  dps: 871.28408
-  tps: 1564.27663
-  dtps: 1556.20338
+  dps: 870.25686
+  tps: 1563.20365
+  dtps: 1556.49703
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 940.86898
-  tps: 1698.74337
-  dtps: 1528.30421
+  dps: 939.33471
+  tps: 1696.52396
+  dtps: 1533.03242
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 880.16453
-  tps: 1574.26891
-  dtps: 1294.28455
+  dps: 878.70327
+  tps: 1572.66675
+  dtps: 1293.05591
   hps: 15.16667
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 923.11885
-  tps: 1656.83468
-  dtps: 1294.28455
+  dps: 922.06691
+  tps: 1656.03097
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 899.6768
-  tps: 1612.04855
-  dtps: 1294.28455
+  dps: 898.17551
+  tps: 1610.36981
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 885.22689
-  tps: 1583.97537
-  dtps: 1294.28455
+  dps: 883.74869
+  tps: 1582.34202
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 912.58766
-  tps: 1618.15918
-  dtps: 1261.67544
+  dps: 911.78366
+  tps: 1617.33523
+  dtps: 1261.8874
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 874.99909
-  tps: 1567.54055
-  dtps: 1460.21448
+  dps: 875.99233
+  tps: 1569.4867
+  dtps: 1455.14396
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 923.2431
-  tps: 1655.55751
-  dtps: 1294.28455
+  dps: 922.18686
+  tps: 1654.74955
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 921.56171
-  tps: 1653.87612
-  dtps: 1294.28455
+  dps: 920.50983
+  tps: 1653.07252
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 885.16498
-  tps: 1583.87201
-  dtps: 1294.28455
+  dps: 883.7104
+  tps: 1582.28311
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 892.04118
-  tps: 1597.05259
-  dtps: 1294.28455
+  dps: 890.5429
+  tps: 1595.38009
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 889.28996
-  tps: 1588.11133
-  dtps: 1288.19539
+  dps: 889.38435
+  tps: 1588.82109
+  dtps: 1293.68
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 894.71482
-  tps: 1602.35061
-  dtps: 1294.28455
+  dps: 893.21189
+  tps: 1600.66871
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 884.49297
-  tps: 1573.71264
-  dtps: 1294.28455
+  dps: 883.03178
+  tps: 1572.11078
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 906.48247
-  tps: 1624.84585
-  dtps: 1294.28455
+  dps: 904.9849
+  tps: 1623.17768
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 909.21064
-  tps: 1631.07509
-  dtps: 1306.38861
+  dps: 907.85906
+  tps: 1629.65023
+  dtps: 1307.10718
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 853.0013
-  tps: 1406.48853
-  dtps: 1853.62548
+  dps: 851.88064
+  tps: 1405.58808
+  dtps: 1856.79482
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThickDraenicArmor"
  value: {
-  dps: 893.13582
-  tps: 1576.44083
-  dtps: 1541.01632
+  dps: 891.78489
+  tps: 1574.36333
+  dtps: 1540.10654
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 921.56171
-  tps: 1653.87612
-  dtps: 1294.28455
+  dps: 920.50983
+  tps: 1653.07252
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 892.62578
-  tps: 1597.13312
-  dtps: 1294.28455
+  dps: 891.17417
+  tps: 1595.55749
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 914.63292
-  tps: 1640.57913
-  dtps: 1294.28455
+  dps: 913.24775
+  tps: 1639.12564
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 894.55749
-  tps: 1593.46782
-  dtps: 1287.8636
+  dps: 893.84183
+  tps: 1592.84078
+  dtps: 1286.6339
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-UnitingCharm-25633"
  value: {
-  dps: 886.76092
-  tps: 1580.86529
-  dtps: 1294.28455
+  dps: 885.2764
+  tps: 1579.23989
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 888.62883
-  tps: 1590.49922
-  dtps: 1294.28455
+  dps: 887.12811
+  tps: 1588.82209
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofFortitude-33938"
  value: {
-  dps: 917.5121
-  tps: 1646.18187
-  dtps: 1294.28455
+  dps: 916.45856
+  tps: 1645.37511
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofVengeance-33950"
  value: {
-  dps: 917.50494
-  tps: 1646.16826
-  dtps: 1294.28455
+  dps: 916.4514
+  tps: 1645.3615
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 889.03845
-  tps: 1590.53275
-  dtps: 1294.28455
+  dps: 887.58406
+  tps: 1588.94978
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WarpSlicer-30311"
  value: {
-  dps: 921.56171
-  tps: 1653.87612
-  dtps: 1294.28455
+  dps: 920.50983
+  tps: 1653.07252
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WastewalkerArmor"
  value: {
-  dps: 892.61182
-  tps: 1561.88184
-  dtps: 1680.99401
+  dps: 892.46525
+  tps: 1562.08193
+  dtps: 1688.05883
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WhitemendWisdom"
  value: {
-  dps: 911.94856
-  tps: 1641.29145
-  dtps: 1528.30421
+  dps: 910.50557
+  tps: 1639.2375
+  dtps: 1533.03242
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WindhawkArmor"
  value: {
-  dps: 943.44582
-  tps: 1704.84229
-  dtps: 1568.72218
+  dps: 942.55375
+  tps: 1704.08877
+  dtps: 1571.10698
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 922.16075
-  tps: 1656.21894
-  dtps: 1314.90897
+  dps: 921.02577
+  tps: 1655.05693
+  dtps: 1315.12989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofSpellfire"
  value: {
-  dps: 891.67295
-  tps: 1603.88719
-  dtps: 1578.32174
+  dps: 890.61412
+  tps: 1602.75951
+  dtps: 1578.61799
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 879.07754
-  tps: 1572.27514
-  dtps: 1305.00032
+  dps: 877.6596
+  tps: 1570.63104
+  dtps: 1303.7728
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 890.58738
-  tps: 1594.25858
-  dtps: 1294.28455
+  dps: 889.08797
+  tps: 1592.58396
+  dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 918.17948
-  tps: 1646.45072
-  dtps: 1257.99916
+  dps: 917.69039
+  tps: 1646.2298
+  dtps: 1260.02572
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2442.00892
-  tps: 4291.41637
-  dtps: 44358.6852
+  dps: 2439.54492
+  tps: 4288.45399
+  dtps: 44367.51326
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 978.80174
-  tps: 1729.23128
-  dtps: 1253.73335
+  dps: 978.00253
+  tps: 1728.37696
+  dtps: 1253.94289
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1106.42632
-  tps: 1937.18106
-  dtps: 1325.75557
+  dps: 1105.46833
+  tps: 1936.39282
+  dtps: 1325.97301
  }
 }
 dps_results: {
@@ -1762,25 +1762,25 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2479.04709
-  tps: 4343.54169
-  dtps: 44367.41399
+  dps: 2472.83845
+  tps: 4333.24153
+  dtps: 44391.92789
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 1000.31254
-  tps: 1762.46734
-  dtps: 1253.94098
+  dps: 999.10417
+  tps: 1761.03762
+  dtps: 1254.13171
  }
 }
 dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1135.17236
-  tps: 1980.99047
-  dtps: 1325.97528
+  dps: 1133.60845
+  tps: 1978.24298
+  dtps: 1326.17281
  }
 }
 dps_results: {
@@ -1795,7 +1795,7 @@ dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
   dps: 421.80252
-  tps: 884.81627
+  tps: 884.81838
   dtps: 2281.72218
  }
 }
@@ -1803,15 +1803,15 @@ dps_results: {
  key: "TestProtection-Settings-Human-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
   dps: 443.6182
-  tps: 924.07299
+  tps: 924.0747
   dtps: 2347.48218
  }
 }
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 978.80174
-  tps: 1729.23128
-  dtps: 1253.73335
+  dps: 978.00253
+  tps: 1728.37696
+  dtps: 1253.94289
  }
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -4,9 +4,9 @@ character_stats_results: {
   final_stats: 284
   final_stats: 238
   final_stats: 1458
-  final_stats: 312
-  final_stats: 797.1
-  final_stats: 807.1
+  final_stats: 313
+  final_stats: 796.3
+  final_stats: 806.3
   final_stats: 80
   final_stats: 0
   final_stats: 0
@@ -17,7 +17,7 @@ character_stats_results: {
   final_stats: 69
   final_stats: 0
   final_stats: 0
-  final_stats: 201
+  final_stats: 193
   final_stats: 1681.9
   final_stats: 389
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 18741.8
   final_stats: 0
   final_stats: 19097
-  final_stats: 7353
+  final_stats: 7368
   final_stats: 122.5
   final_stats: 38
   final_stats: 38
@@ -46,7 +46,7 @@ character_stats_results: {
   final_stats: 3.95122
   final_stats: 6
   final_stats: 17.34622
-  final_stats: 24.26094
+  final_stats: 24.28594
   final_stats: 31.51903
   final_stats: 0
   final_stats: 0
@@ -55,408 +55,408 @@ character_stats_results: {
 dps_results: {
  key: "TestProtection-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 889.69259
-  tps: 1586.46556
+  dps: 889.39086
+  tps: 1585.90981
   dtps: 1295.6979
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 875.22431
-  tps: 1565.92445
+  dps: 874.9241
+  tps: 1565.37182
   dtps: 1247.16781
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 920.50983
-  tps: 1653.07252
+  dps: 920.20962
+  tps: 1652.51964
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 878.70327
-  tps: 1572.66028
+  dps: 878.40306
+  tps: 1572.10678
   dtps: 1290.34519
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 875.11043
-  tps: 1564.13532
+  dps: 874.81076
+  tps: 1563.58264
   dtps: 1211.89479
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 897.477
-  tps: 1608.74582
+  dps: 897.17679
+  tps: 1608.19294
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 887.12811
-  tps: 1588.82209
+  dps: 886.8278
+  tps: 1588.26901
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 887.09504
-  tps: 1582.53797
+  dps: 886.79451
+  tps: 1581.98449
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Annihilator-12798"
  value: {
-  dps: 814.17496
-  tps: 1450.4495
+  dps: 813.8785
+  tps: 1449.90252
   dtps: 1306.41947
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 903.54173
-  tps: 1620.66553
+  dps: 903.23678
+  tps: 1620.10176
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 898.2398
-  tps: 1616.27535
+  dps: 897.94831
+  tps: 1615.72906
   dtps: 1525.93245
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 878.70327
-  tps: 1572.64938
+  dps: 878.40306
+  tps: 1572.09617
   dtps: 1290.22258
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 874.67436
-  tps: 1561.08219
+  dps: 874.37623
+  tps: 1560.53451
   dtps: 1224.89931
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 881.92315
-  tps: 1575.88664
+  dps: 881.62294
+  tps: 1575.33376
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 930.10721
-  tps: 1661.31596
+  dps: 929.80654
+  tps: 1660.76279
   dtps: 1306.70266
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 927.07202
-  tps: 1666.0823
+  dps: 926.77283
+  tps: 1665.52946
   dtps: 1315.12989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 933.02236
-  tps: 1678.11207
+  dps: 932.72307
+  tps: 1677.55729
   dtps: 1315.12989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 880.05428
-  tps: 1575.07986
+  dps: 879.75407
+  tps: 1574.52496
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BattlecastGarb"
  value: {
-  dps: 926.17712
-  tps: 1670.68234
+  dps: 925.87882
+  tps: 1670.12651
   dtps: 1533.03242
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 877.17975
-  tps: 1570.35111
+  dps: 876.88041
+  tps: 1569.7985
   dtps: 1294.86629
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 877.17975
-  tps: 1570.35111
+  dps: 876.88041
+  tps: 1569.7985
   dtps: 1294.86629
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 896.34063
-  tps: 1606.58254
+  dps: 896.04042
+  tps: 1606.02966
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 885.39885
-  tps: 1580.69486
+  dps: 885.09827
+  tps: 1580.14128
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 878.88156
-  tps: 1573.00552
+  dps: 878.58125
+  tps: 1572.45244
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 885.41139
-  tps: 1579.37487
+  dps: 885.11117
+  tps: 1578.82199
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 889.96116
-  tps: 1594.31513
+  dps: 889.66095
+  tps: 1593.76225
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 892.74331
-  tps: 1586.7068
+  dps: 892.4431
+  tps: 1586.15392
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 921.7022
-  tps: 1655.33082
+  dps: 921.40164
+  tps: 1654.77728
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 898.86142
-  tps: 1597.48051
+  dps: 898.55819
+  tps: 1596.92123
   dtps: 1284.61558
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 887.75506
-  tps: 1583.43424
+  dps: 887.45448
+  tps: 1582.88066
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 875.9922
-  tps: 1569.9288
+  dps: 875.69413
+  tps: 1569.37892
   dtps: 1305.03923
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Blinkstrike-31332"
  value: {
-  dps: 920.50983
-  tps: 1653.07252
+  dps: 920.20962
+  tps: 1652.51964
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 889.75493
-  tps: 1583.71842
+  dps: 889.45472
+  tps: 1583.16554
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 935.07959
-  tps: 1677.32308
+  dps: 934.77706
+  tps: 1676.76037
   dtps: 1340.80138
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 875.22431
-  tps: 1566.01534
+  dps: 874.9241
+  tps: 1565.46304
   dtps: 1260.33053
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofFortitude-35039"
  value: {
-  dps: 916.45856
-  tps: 1645.37511
+  dps: 916.15835
+  tps: 1644.82223
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BrutalGladiator'sLibramofVengeance-35041"
  value: {
-  dps: 916.4514
-  tps: 1645.3615
+  dps: 916.15119
+  tps: 1644.80862
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 914.79634
-  tps: 1643.49946
+  dps: 914.49774
+  tps: 1642.94971
   dtps: 1222.7848
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 918.31083
-  tps: 1631.81768
+  dps: 918.01753
+  tps: 1631.27454
   dtps: 1293.49913
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 919.86054
-  tps: 1633.74015
+  dps: 919.56743
+  tps: 1633.19515
   dtps: 1283.25059
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-BurningRage"
  value: {
-  dps: 908.78243
-  tps: 1596.77091
+  dps: 908.65796
+  tps: 1596.54014
   dtps: 1546.47627
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 929.06388
-  tps: 1670.48966
+  dps: 928.76468
+  tps: 1669.93566
   dtps: 1315.12989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 874.89292
-  tps: 1565.10376
+  dps: 874.59308
+  tps: 1564.55084
   dtps: 1240.79013
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 914.46445
-  tps: 1643.3821
+  dps: 914.16493
+  tps: 1642.82795
   dtps: 1409.54496
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CloudkeeperLegplates-14554"
  value: {
-  dps: 910.91783
-  tps: 1628.27548
+  dps: 910.61816
+  tps: 1627.72193
   dtps: 1348.40851
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 878.70327
-  tps: 1572.53213
+  dps: 878.40306
+  tps: 1571.976
   dtps: 1274.3048
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 886.671
-  tps: 1580.63448
+  dps: 886.37079
+  tps: 1580.0816
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 910.16233
-  tps: 1634.18608
+  dps: 909.8628
+  tps: 1633.63149
   dtps: 1409.54496
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeArmor"
  value: {
-  dps: 893.53801
-  tps: 1604.00457
+  dps: 893.24918
+  tps: 1603.47191
   dtps: 1290.28263
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgeBattlegear"
  value: {
-  dps: 915.18558
-  tps: 1583.31808
+  dps: 914.89475
+  tps: 1582.77516
   dtps: 1410.45316
   hps: 1.16609
  }
@@ -464,272 +464,272 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 886.09024
-  tps: 1580.05372
+  dps: 885.79003
+  tps: 1579.50084
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 875.66478
-  tps: 1566.9107
+  dps: 875.36444
+  tps: 1566.35755
   dtps: 1263.19743
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 908.27821
-  tps: 1629.50529
+  dps: 907.978
+  tps: 1628.95241
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 904.61421
-  tps: 1613.74134
+  dps: 904.314
+  tps: 1613.18846
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 875.39365
-  tps: 1567.20837
+  dps: 875.09433
+  tps: 1566.65603
   dtps: 1278.6796
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 896.05377
-  tps: 1595.76548
+  dps: 895.75123
+  tps: 1595.20818
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DirebrewHops-38288"
  value: {
-  dps: 898.56381
-  tps: 1610.86648
+  dps: 898.2636
+  tps: 1610.3136
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DoomplateBattlegear"
  value: {
-  dps: 904.06035
-  tps: 1584.69906
+  dps: 903.76596
+  tps: 1584.14316
   dtps: 1620.40074
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 886.76854
-  tps: 1588.15459
+  dps: 886.46833
+  tps: 1587.60171
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonmaw-28438"
  value: {
-  dps: 892.09938
-  tps: 1538.61341
+  dps: 891.79183
+  tps: 1538.05022
   dtps: 1263.11632
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 891.5921
-  tps: 1588.42996
+  dps: 891.28984
+  tps: 1587.86892
   dtps: 1287.09913
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Dragonstrike-28439"
  value: {
-  dps: 902.53622
-  tps: 1549.46835
+  dps: 902.22837
+  tps: 1548.90722
   dtps: 1264.37068
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 886.21105
-  tps: 1535.35409
+  dps: 885.90431
+  tps: 1534.79382
   dtps: 1282.49274
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 890.07678
-  tps: 1594.15661
+  dps: 889.77657
+  tps: 1593.60036
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Earthstrike-21180"
  value: {
-  dps: 883.7537
-  tps: 1577.71719
+  dps: 883.45349
+  tps: 1577.16431
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 879.64482
-  tps: 1573.60255
+  dps: 879.34425
+  tps: 1573.04959
   dtps: 1285.26676
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 889.75493
-  tps: 1583.71842
+  dps: 889.45472
+  tps: 1583.16554
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 922.1013
-  tps: 1653.54875
+  dps: 921.8004
+  tps: 1652.99262
   dtps: 1280.70339
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 921.53764
-  tps: 1624.02882
+  dps: 921.23745
+  tps: 1623.48835
   dtps: 1308.07597
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 913.00457
-  tps: 1669.96603
+  dps: 912.70436
+  tps: 1669.4016
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 909.66135
-  tps: 1628.60921
+  dps: 909.36114
+  tps: 1628.05633
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 896.39355
-  tps: 1600.38831
+  dps: 896.09851
+  tps: 1599.85283
   dtps: 1227.46212
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 909.96914
-  tps: 1628.67141
+  dps: 909.66892
+  tps: 1628.11853
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 909.71293
-  tps: 1626.3977
+  dps: 909.41201
+  tps: 1625.84431
   dtps: 1234.31748
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 898.56381
-  tps: 1610.86648
+  dps: 898.2636
+  tps: 1610.3136
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeofMoam-21473"
  value: {
-  dps: 881.73999
-  tps: 1578.50995
+  dps: 881.43978
+  tps: 1577.95707
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 908.29467
-  tps: 1629.55445
+  dps: 907.99446
+  tps: 1629.00157
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 926.24915
-  tps: 1665.89868
+  dps: 925.94755
+  tps: 1665.34047
   dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelSkin"
  value: {
-  dps: 919.23926
-  tps: 1634.36875
+  dps: 918.93775
+  tps: 1633.79959
   dtps: 1594.09086
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FelscaleArmor"
  value: {
-  dps: 890.82611
-  tps: 1568.68779
+  dps: 890.53575
+  tps: 1568.14826
   dtps: 1475.84708
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 868.63519
-  tps: 1553.5242
+  dps: 868.3372
+  tps: 1552.97918
   dtps: 1225.54009
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 862.94877
-  tps: 1543.29811
+  dps: 862.65282
+  tps: 1542.75805
   dtps: 1199.31803
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 885.54721
-  tps: 1579.5107
+  dps: 885.247
+  tps: 1578.95782
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
   hps: 4.7
  }
@@ -737,704 +737,704 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ForceReactiveDisk-18168"
  value: {
-  dps: 921.77069
-  tps: 1655.14946
+  dps: 921.47267
+  tps: 1654.59321
   dtps: 1453.79353
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofFortitude-33936"
  value: {
-  dps: 916.45856
-  tps: 1645.37511
+  dps: 916.15835
+  tps: 1644.82223
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gladiator'sLibramofVengeance-33948"
  value: {
-  dps: 916.4514
-  tps: 1645.3615
+  dps: 916.15119
+  tps: 1644.80862
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 897.477
-  tps: 1608.74582
+  dps: 897.17679
+  tps: 1608.19294
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 878.70327
-  tps: 1572.56735
+  dps: 878.40306
+  tps: 1572.01149
   dtps: 1279.4648
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 878.70327
-  tps: 1572.53213
+  dps: 878.40306
+  tps: 1571.976
   dtps: 1274.3048
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HandofJustice-11815"
  value: {
-  dps: 888.95307
-  tps: 1588.41002
+  dps: 888.65087
+  tps: 1587.85146
   dtps: 1295.92629
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 877.6596
-  tps: 1570.63104
+  dps: 877.36045
+  tps: 1570.07883
   dtps: 1303.7728
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 885.0393
-  tps: 1584.21005
+  dps: 884.73909
+  tps: 1583.65787
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 916.88609
-  tps: 1646.04602
+  dps: 916.58588
+  tps: 1645.49315
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 888.08702
-  tps: 1590.6796
+  dps: 887.78681
+  tps: 1590.12672
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 886.29177
-  tps: 1581.58777
+  dps: 885.99119
+  tps: 1581.03419
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IceGuard-2682"
  value: {
-  dps: 921.30945
-  tps: 1655.75976
+  dps: 921.0102
+  tps: 1655.20613
   dtps: 1315.64106
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 889.13419
-  tps: 1584.83422
+  dps: 888.83256
+  tps: 1584.27499
   dtps: 1291.87949
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ImbuedNetherweave"
  value: {
-  dps: 912.65598
-  tps: 1643.67859
+  dps: 912.36813
+  tps: 1643.1377
   dtps: 1573.82623
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JomGabbar-23570"
  value: {
-  dps: 884.86382
-  tps: 1578.82731
+  dps: 884.56361
+  tps: 1578.27443
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarArmor"
  value: {
-  dps: 908.39593
-  tps: 1630.76366
+  dps: 908.09538
+  tps: 1630.21
   dtps: 1330.07443
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-JusticarBattlegear"
  value: {
-  dps: 908.38573
-  tps: 1581.99196
+  dps: 908.09262
+  tps: 1581.44427
   dtps: 1463.89564
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumScope-2723"
  value: {
-  dps: 920.50983
-  tps: 1653.07252
+  dps: 920.20962
+  tps: 1652.51964
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KhoriumWard"
  value: {
-  dps: 943.17965
-  tps: 1703.79464
+  dps: 942.87839
+  tps: 1703.22825
   dtps: 1490.34682
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 887.46382
-  tps: 1586.00975
+  dps: 887.16188
+  tps: 1585.45356
   dtps: 1293.32281
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofAvengement-27484"
  value: {
-  dps: 921.4599
-  tps: 1651.77782
+  dps: 921.15932
+  tps: 1651.22424
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 916.45856
-  tps: 1645.37511
+  dps: 916.15835
+  tps: 1644.82223
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofDivinePurpose-33504"
  value: {
-  dps: 938.31204
-  tps: 1686.89672
+  dps: 938.01183
+  tps: 1686.34384
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofFervor-23203"
  value: {
-  dps: 916.45856
-  tps: 1645.37511
+  dps: 916.15835
+  tps: 1644.82223
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofHope-22401"
  value: {
-  dps: 916.45856
-  tps: 1644.62013
+  dps: 916.15835
+  tps: 1644.06781
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRepentance-29388"
  value: {
-  dps: 916.45856
-  tps: 1645.37511
+  dps: 916.15835
+  tps: 1644.82223
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofRighteousPower-31033"
  value: {
-  dps: 916.45856
-  tps: 1645.37511
+  dps: 916.15835
+  tps: 1644.82223
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofWracking-28065"
  value: {
-  dps: 916.45856
-  tps: 1645.37511
+  dps: 916.15835
+  tps: 1644.82223
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27949"
  value: {
-  dps: 916.45856
-  tps: 1645.37511
+  dps: 916.15835
+  tps: 1644.82223
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LibramofZeal-27983"
  value: {
-  dps: 916.45856
-  tps: 1645.37511
+  dps: 916.15835
+  tps: 1644.82223
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerArmor"
  value: {
-  dps: 929.35641
-  tps: 1669.47703
+  dps: 929.06211
+  tps: 1668.94474
   dtps: 1063.24058
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1038.51289
-  tps: 1740.28486
+  dps: 1038.20299
+  tps: 1739.69532
   dtps: 1703.16129
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 898.53117
-  tps: 1599.55168
+  dps: 898.22779
+  tps: 1598.99004
   dtps: 1287.47642
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 902.60471
-  tps: 1632.30964
+  dps: 902.30777
+  tps: 1631.75035
   dtps: 1952.41981
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 904.21574
-  tps: 1622.98577
+  dps: 903.93149
+  tps: 1622.46115
   dtps: 1372.76133
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 892.588
-  tps: 1598.58374
+  dps: 892.28779
+  tps: 1598.03005
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofFortitude-33937"
  value: {
-  dps: 916.45856
-  tps: 1645.37511
+  dps: 916.15835
+  tps: 1644.82223
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MercilessGladiator'sLibramofVengeance-33949"
  value: {
-  dps: 916.4514
-  tps: 1645.3615
+  dps: 916.15119
+  tps: 1644.80862
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 876.49852
-  tps: 1568.30673
+  dps: 876.19923
+  tps: 1567.75548
   dtps: 1294.35324
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 863.89227
-  tps: 1546.58753
+  dps: 863.59494
+  tps: 1546.04616
   dtps: 1197.07385
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 888.16541
-  tps: 1591.17536
+  dps: 887.86086
+  tps: 1590.61236
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 889.4994
-  tps: 1593.39828
+  dps: 889.19919
+  tps: 1592.8454
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherscaleArmor"
  value: {
-  dps: 930.97933
-  tps: 1656.0524
+  dps: 930.68587
+  tps: 1655.50047
   dtps: 1511.94213
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherstrikeArmor"
  value: {
-  dps: 940.32808
-  tps: 1698.81245
+  dps: 940.03618
+  tps: 1698.26377
   dtps: 1514.05036
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-NetherweaveVestments"
  value: {
-  dps: 941.86559
-  tps: 1706.49584
+  dps: 941.57605
+  tps: 1705.94565
   dtps: 2076.52996
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 885.2764
-  tps: 1579.23989
+  dps: 884.97619
+  tps: 1578.68701
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 892.16583
-  tps: 1598.56098
+  dps: 891.86562
+  tps: 1598.0081
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 921.51058
-  tps: 1656.44073
+  dps: 921.21218
+  tps: 1655.88906
   dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 921.51058
-  tps: 1656.44073
+  dps: 921.21218
+  tps: 1655.88906
   dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofThawing-24093"
  value: {
-  dps: 921.51058
-  tps: 1656.44073
+  dps: 921.21218
+  tps: 1655.88906
   dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantofWithering-24095"
  value: {
-  dps: 921.51058
-  tps: 1656.44073
+  dps: 921.21218
+  tps: 1655.88906
   dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 921.51058
-  tps: 1656.44073
+  dps: 921.21218
+  tps: 1655.88906
   dtps: 1326.8412
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 878.88156
-  tps: 1572.25145
+  dps: 878.58125
+  tps: 1571.69745
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalIntent"
  value: {
-  dps: 934.38287
-  tps: 1647.73561
+  dps: 934.09299
+  tps: 1647.19542
   dtps: 1463.58492
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrimalMooncloth"
  value: {
-  dps: 928.90279
-  tps: 1675.43978
+  dps: 928.64729
+  tps: 1674.97159
   dtps: 1608.13687
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Prismcharm-15867"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 891.83245
-  tps: 1599.29216
+  dps: 891.53214
+  tps: 1598.73807
   dtps: 1284.6099
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 877.09608
-  tps: 1571.22897
+  dps: 876.79592
+  tps: 1570.67759
   dtps: 1304.06638
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 875.29448
-  tps: 1566.14328
+  dps: 874.9944
+  tps: 1565.58992
   dtps: 1260.86984
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 912.57447
-  tps: 1639.03295
+  dps: 912.32052
+  tps: 1638.56242
   dtps: 1372.76133
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 920.50983
-  tps: 1653.07252
+  dps: 920.20962
+  tps: 1652.51964
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 896.59873
-  tps: 1590.82721
+  dps: 896.29765
+  tps: 1590.27145
   dtps: 1298.69973
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-RuneofForce-25994"
  value: {
-  dps: 880.35619
-  tps: 1574.31968
+  dps: 880.05598
+  tps: 1573.7668
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SavageGuard-2681"
  value: {
-  dps: 921.30945
-  tps: 1655.75976
+  dps: 921.0102
+  tps: 1655.20613
   dtps: 1315.64106
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 870.64447
-  tps: 1560.78017
+  dps: 870.34434
+  tps: 1560.23192
   dtps: 1247.5834
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 887.70958
-  tps: 1589.98545
+  dps: 887.40937
+  tps: 1589.43257
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 884.29185
-  tps: 1582.79641
+  dps: 883.98956
+  tps: 1582.23976
   dtps: 1282.50757
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 901.82392
-  tps: 1617.43212
+  dps: 901.51782
+  tps: 1616.86612
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 893.26128
-  tps: 1600.64813
+  dps: 892.96096
+  tps: 1600.09506
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 881.03381
-  tps: 1583.74227
+  dps: 880.74615
+  tps: 1583.20433
   dtps: 1552.81584
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 868.31946
-  tps: 1553.98394
+  dps: 868.02145
+  tps: 1553.43836
   dtps: 1218.84078
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShardofContempt-34472"
  value: {
-  dps: 909.82308
-  tps: 1611.03568
+  dps: 909.51673
+  tps: 1610.46925
   dtps: 1286.64496
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 881.45484
-  tps: 1577.96147
+  dps: 881.15453
+  tps: 1577.4084
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 898.06198
-  tps: 1610.29409
+  dps: 897.76314
+  tps: 1609.7425
   dtps: 1293.64736
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SkullflameShield-1168"
  value: {
-  dps: 924.42195
-  tps: 1654.29692
+  dps: 924.11476
+  tps: 1653.73132
   dtps: 1474.07764
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 888.75945
-  tps: 1582.72294
+  dps: 888.45924
+  tps: 1582.17006
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SoulclothEmbrace"
  value: {
-  dps: 870.25686
-  tps: 1563.20365
+  dps: 870.00215
+  tps: 1562.72678
   dtps: 1556.49703
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 939.33471
-  tps: 1696.52396
+  dps: 939.0291
+  tps: 1695.95239
   dtps: 1533.03242
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 878.70327
-  tps: 1572.66675
+  dps: 878.40306
+  tps: 1572.11387
   dtps: 1293.05591
   hps: 15.16667
  }
@@ -1442,296 +1442,296 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 922.06691
-  tps: 1656.03097
+  dps: 921.76633
+  tps: 1655.47739
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 898.17551
-  tps: 1610.36981
+  dps: 897.87027
+  tps: 1609.80548
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 883.74869
-  tps: 1582.34202
+  dps: 883.44848
+  tps: 1581.78914
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 911.78366
-  tps: 1617.33523
+  dps: 911.47356
+  tps: 1616.76127
   dtps: 1261.8874
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 875.99233
-  tps: 1569.4867
+  dps: 875.87936
+  tps: 1569.28486
   dtps: 1455.14396
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 922.18686
-  tps: 1654.74955
+  dps: 921.88665
+  tps: 1654.19667
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 920.50983
-  tps: 1653.07252
+  dps: 920.20962
+  tps: 1652.51964
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 883.7104
-  tps: 1582.28311
+  dps: 883.41019
+  tps: 1581.73023
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 890.5429
-  tps: 1595.38009
+  dps: 890.24269
+  tps: 1594.82721
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 889.38435
-  tps: 1588.82109
+  dps: 889.08181
+  tps: 1588.26143
   dtps: 1293.68
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 893.21189
-  tps: 1600.66871
+  dps: 892.90771
+  tps: 1600.10644
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 883.03178
-  tps: 1572.11078
+  dps: 882.73199
+  tps: 1571.5591
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 904.9849
-  tps: 1623.17768
+  dps: 904.68469
+  tps: 1622.6248
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 907.85906
-  tps: 1629.65023
+  dps: 907.55522
+  tps: 1629.08805
   dtps: 1307.10718
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 851.88064
-  tps: 1405.58808
+  dps: 851.58584
+  tps: 1405.04857
   dtps: 1856.79482
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-ThickDraenicArmor"
  value: {
-  dps: 891.78489
-  tps: 1574.36333
+  dps: 891.49254
+  tps: 1573.81575
   dtps: 1540.10654
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 920.50983
-  tps: 1653.07252
+  dps: 920.20962
+  tps: 1652.51964
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 891.17417
-  tps: 1595.55749
+  dps: 890.87396
+  tps: 1595.0025
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 913.24775
-  tps: 1639.12564
+  dps: 912.94754
+  tps: 1638.57276
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 893.84183
-  tps: 1592.84078
+  dps: 893.5397
+  tps: 1592.28054
   dtps: 1286.6339
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-UnitingCharm-25633"
  value: {
-  dps: 885.2764
-  tps: 1579.23989
+  dps: 884.97619
+  tps: 1578.68701
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 887.12811
-  tps: 1588.82209
+  dps: 886.8278
+  tps: 1588.26901
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofFortitude-33938"
  value: {
-  dps: 916.45856
-  tps: 1645.37511
+  dps: 916.15835
+  tps: 1644.82223
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VengefulGladiator'sLibramofVengeance-33950"
  value: {
-  dps: 916.4514
-  tps: 1645.3615
+  dps: 916.15119
+  tps: 1644.80862
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 887.58406
-  tps: 1588.94978
+  dps: 887.28385
+  tps: 1588.39554
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WarpSlicer-30311"
  value: {
-  dps: 920.50983
-  tps: 1653.07252
+  dps: 920.20962
+  tps: 1652.51964
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WastewalkerArmor"
  value: {
-  dps: 892.46525
-  tps: 1562.08193
+  dps: 892.17205
+  tps: 1561.52919
   dtps: 1688.05883
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WhitemendWisdom"
  value: {
-  dps: 910.50557
-  tps: 1639.2375
+  dps: 910.20747
+  tps: 1638.67815
   dtps: 1533.03242
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WindhawkArmor"
  value: {
-  dps: 942.55375
-  tps: 1704.08877
+  dps: 942.29834
+  tps: 1703.60778
   dtps: 1571.10698
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 921.02577
-  tps: 1655.05693
+  dps: 920.72658
+  tps: 1654.50342
   dtps: 1315.12989
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-WrathofSpellfire"
  value: {
-  dps: 890.61412
-  tps: 1602.75951
+  dps: 890.34809
+  tps: 1602.26387
   dtps: 1578.61799
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 877.6596
-  tps: 1570.63104
+  dps: 877.36045
+  tps: 1570.07883
   dtps: 1303.7728
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 889.08797
-  tps: 1592.58396
+  dps: 888.78766
+  tps: 1592.03088
   dtps: 1293.05591
  }
 }
 dps_results: {
  key: "TestProtection-Average-Default"
  value: {
-  dps: 917.69039
-  tps: 1646.2298
+  dps: 917.40888
+  tps: 1645.71274
   dtps: 1260.02572
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 2439.54492
-  tps: 4288.45399
+  dps: 2439.0157
+  tps: 4287.43383
   dtps: 44367.51326
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 978.00253
-  tps: 1728.37696
+  dps: 977.6878
+  tps: 1727.79813
   dtps: 1253.94289
  }
 }
 dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 1105.46833
-  tps: 1936.39282
+  dps: 1105.1196
+  tps: 1935.7608
   dtps: 1325.97301
  }
 }
@@ -1747,7 +1747,7 @@ dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
   dps: 419.32687
-  tps: 880.89485
+  tps: 880.91632
   dtps: 2281.36763
  }
 }
@@ -1755,7 +1755,7 @@ dps_results: {
  key: "TestProtection-Settings-BloodElf-p2-Protection-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
   dps: 442.21601
-  tps: 922.10635
+  tps: 922.12304
   dtps: 2347.11751
  }
 }
@@ -1810,8 +1810,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 978.00253
-  tps: 1728.37696
+  dps: 977.6878
+  tps: 1727.79813
   dtps: 1253.94289
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -1678,39 +1678,39 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Default-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2470.95076
-  tps: 2510.69188
+  dps: 2470.80797
+  tps: 2510.59193
   dtps: 12.8974
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Default-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1950.61517
-  tps: 1535.81666
+  dps: 1950.471
+  tps: 1535.71574
   dtps: 14.64644
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2357.9648
-  tps: 1870.43097
+  dps: 2357.78395
+  tps: 1870.30437
   dtps: 30.31153
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Default-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 534.85666
-  tps: 502.14917
+  dps: 532.34094
+  tps: 499.9276
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Default-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 534.85666
-  tps: 418.869
+  dps: 532.34094
+  tps: 416.64743
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -4,9 +4,9 @@ character_stats_results: {
   final_stats: 878
   final_stats: 491
   final_stats: 688
-  final_stats: 251
-  final_stats: 236.7
-  final_stats: 223.7
+  final_stats: 253
+  final_stats: 236
+  final_stats: 223
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,7 +17,7 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 207
+  final_stats: 200
   final_stats: 3540.9
   final_stats: 891
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 9644
   final_stats: 0
   final_stats: 11247
-  final_stats: 6438
+  final_stats: 6468
   final_stats: 122.5
   final_stats: 38
   final_stats: 38
@@ -46,7 +46,7 @@ character_stats_results: {
   final_stats: 6.80488
   final_stats: 6
   final_stats: 42.53242
-  final_stats: 24.78472
+  final_stats: 24.83472
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -55,368 +55,368 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1885.26951
-  tps: 1486.4381
+  dps: 1885.16966
+  tps: 1486.38567
   dtps: 14.52037
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1915.73822
-  tps: 1509.74295
+  dps: 1915.63781
+  tps: 1509.68842
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 1833.95533
-  tps: 1446.26937
+  dps: 1833.85721
+  tps: 1446.21293
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 1829.75594
-  tps: 1443.34289
+  dps: 1829.65783
+  tps: 1443.28645
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 1852.42422
-  tps: 1461.56902
+  dps: 1852.32514
+  tps: 1461.5119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 1832.40288
-  tps: 1445.18265
+  dps: 1832.30476
+  tps: 1445.12621
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1724.99765
-  tps: 1361.1007
+  dps: 1724.88517
+  tps: 1361.03025
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1843.06139
-  tps: 1453.97826
+  dps: 1842.9623
+  tps: 1453.92114
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1842.81269
-  tps: 1452.37792
+  dps: 1842.71445
+  tps: 1452.32139
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1934.40168
-  tps: 1523.3927
+  dps: 1934.30312
+  tps: 1523.3387
   dtps: 14.34631
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 1889.44203
-  tps: 1488.53811
+  dps: 1889.34393
+  tps: 1488.47532
   dtps: 14.70989
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1891.12366
-  tps: 1489.84129
+  dps: 1891.02557
+  tps: 1489.77863
   dtps: 14.70989
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 1827.3411
-  tps: 1441.63941
+  dps: 1827.24298
+  tps: 1441.58297
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BattlecastGarb"
  value: {
-  dps: 1703.6379
-  tps: 1344.50027
+  dps: 1703.54405
+  tps: 1344.44057
   dtps: 14.65778
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 1827.92655
-  tps: 1440.85184
+  dps: 1827.82785
+  tps: 1440.795
   dtps: 14.40392
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 1827.92655
-  tps: 1440.85184
+  dps: 1827.82785
+  tps: 1440.795
   dtps: 14.40392
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1833.44562
-  tps: 1445.91258
+  dps: 1833.34751
+  tps: 1445.85614
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1853.07489
-  tps: 1461.94422
+  dps: 1852.97524
+  tps: 1461.88671
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1826.85793
-  tps: 1441.31937
+  dps: 1826.75982
+  tps: 1441.26293
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1852.75258
-  tps: 1461.50045
+  dps: 1852.65447
+  tps: 1461.44401
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1831.06284
-  tps: 1444.24463
+  dps: 1830.96473
+  tps: 1444.18819
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1883.65956
-  tps: 1485.57425
+  dps: 1883.56144
+  tps: 1485.51781
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1915.73822
-  tps: 1509.74295
+  dps: 1915.63781
+  tps: 1509.68842
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1915.00195
-  tps: 1509.8425
+  dps: 1914.90735
+  tps: 1509.79403
   dtps: 14.74805
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1856.50114
-  tps: 1464.61319
+  dps: 1856.40189
+  tps: 1464.55595
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1880.96986
-  tps: 1482.71234
+  dps: 1880.86985
+  tps: 1482.65808
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BrutalGladiator'sLibramofFortitude-35039"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BrutalGladiator'sLibramofVengeance-35041"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 1903.5697
-  tps: 1499.73752
+  dps: 1903.45495
+  tps: 1499.66607
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 1908.78343
-  tps: 1503.91468
+  dps: 1908.66868
+  tps: 1503.84323
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningRage"
  value: {
-  dps: 1797.98795
-  tps: 1416.78209
+  dps: 1797.87657
+  tps: 1416.71412
   dtps: 13.79028
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1880.13327
-  tps: 1482.29949
+  dps: 1880.03326
+  tps: 1482.23549
   dtps: 14.90221
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1800.43201
-  tps: 1419.88027
+  dps: 1800.32038
+  tps: 1419.8098
   dtps: 14.34177
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CloudkeeperLegplates-14554"
  value: {
-  dps: 1848.23778
-  tps: 1457.36136
+  dps: 1848.14097
+  tps: 1457.30859
   dtps: 14.41524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1859.06176
-  tps: 1466.40232
+  dps: 1858.96364
+  tps: 1466.34588
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1800.43898
-  tps: 1420.14003
+  dps: 1800.3413
+  tps: 1420.07953
   dtps: 14.68478
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CrystalforgeArmor"
  value: {
-  dps: 1485.50952
-  tps: 1173.14201
+  dps: 1485.40633
+  tps: 1173.07524
   dtps: 14.69308
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CrystalforgeBattlegear"
  value: {
-  dps: 1765.68731
-  tps: 1392.96649
+  dps: 1765.57878
+  tps: 1392.8954
   dtps: 14.73865
   hps: 1.277
  }
@@ -424,960 +424,960 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1845.21863
-  tps: 1455.2224
+  dps: 1845.12052
+  tps: 1455.16596
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1838.03148
-  tps: 1449.12267
+  dps: 1837.93336
+  tps: 1449.06623
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1862.3366
-  tps: 1469.01652
+  dps: 1862.23849
+  tps: 1468.96008
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1838.22649
-  tps: 1450.58424
+  dps: 1838.12795
+  tps: 1450.5275
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Despair-28573"
  value: {
-  dps: 1958.2462
-  tps: 1542.8778
+  dps: 1958.1458
+  tps: 1542.82326
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Devastation-30316"
  value: {
-  dps: 1992.69363
-  tps: 1570.00126
+  dps: 1992.59229
+  tps: 1569.94608
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DirebrewHops-38288"
  value: {
-  dps: 1834.12752
-  tps: 1446.3899
+  dps: 1834.0294
+  tps: 1446.33346
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DoomplateBattlegear"
  value: {
-  dps: 1668.01839
-  tps: 1316.16392
+  dps: 1667.91139
+  tps: 1316.09902
   dtps: 14.05926
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 1829.5223
-  tps: 1443.16625
+  dps: 1829.42419
+  tps: 1443.10981
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 1831.05653
-  tps: 1444.24021
+  dps: 1830.95842
+  tps: 1444.18377
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Earthstrike-21180"
  value: {
-  dps: 1848.37916
-  tps: 1458.06144
+  dps: 1848.28104
+  tps: 1458.005
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1871.53062
-  tps: 1476.12106
+  dps: 1871.4325
+  tps: 1476.06462
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantBoots-Boar'sSpeed-2940"
  value: {
-  dps: 1907.60038
-  tps: 1503.51638
+  dps: 1907.50016
+  tps: 1503.46198
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 1912.41001
-  tps: 1507.19936
+  dps: 1912.30971
+  tps: 1507.1449
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 1907.60038
-  tps: 1473.92648
+  dps: 1907.50016
+  tps: 1473.87348
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1903.59308
-  tps: 1529.80093
+  dps: 1903.49268
+  tps: 1529.745
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1898.88323
-  tps: 1496.61387
+  dps: 1898.78546
+  tps: 1496.55867
   dtps: 13.85942
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 1887.50069
-  tps: 1489.95337
+  dps: 1887.40303
+  tps: 1489.89976
   dtps: 13.6916
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 1909.17355
-  tps: 1502.28709
+  dps: 1909.07578
+  tps: 1502.23265
   dtps: 14.47476
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1834.12752
-  tps: 1446.3899
+  dps: 1834.0294
+  tps: 1446.33346
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1834.42677
-  tps: 1446.59938
+  dps: 1834.32865
+  tps: 1446.54294
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeofMoam-21473"
  value: {
-  dps: 1828.36711
-  tps: 1442.35762
+  dps: 1828.269
+  tps: 1442.30118
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 1838.02381
-  tps: 1449.11731
+  dps: 1837.9257
+  tps: 1449.06087
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1877.13291
-  tps: 1480.04466
+  dps: 1877.0329
+  tps: 1479.9904
   dtps: 14.99327
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelSkin"
  value: {
-  dps: 1761.25458
-  tps: 1388.96283
+  dps: 1761.15738
+  tps: 1388.91079
   dtps: 14.63719
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelscaleArmor"
  value: {
-  dps: 1745.29205
-  tps: 1375.75534
+  dps: 1745.18046
+  tps: 1375.68623
   dtps: 14.63719
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1852.7117
-  tps: 1461.47232
+  dps: 1852.61359
+  tps: 1461.41588
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sLibramofFortitude-33936"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sLibramofVengeance-33948"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 1833.95533
-  tps: 1446.26937
+  dps: 1833.85721
+  tps: 1446.21293
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HandofJustice-11815"
  value: {
-  dps: 1888.17853
-  tps: 1487.08017
+  dps: 1888.07961
+  tps: 1487.02318
   dtps: 14.35053
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 1834.07535
-  tps: 1446.31225
+  dps: 1833.97823
+  tps: 1446.25651
   dtps: 14.68094
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 1826.85793
-  tps: 1441.26587
+  dps: 1826.75982
+  tps: 1441.21143
   dtps: 13.54198
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 1829.32801
-  tps: 1442.89874
+  dps: 1829.2299
+  tps: 1442.84006
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1841.2925
-  tps: 1451.40539
+  dps: 1841.19438
+  tps: 1451.34895
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 1830.51615
-  tps: 1443.86195
+  dps: 1830.41804
+  tps: 1443.80551
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1860.4926
-  tps: 1467.78868
+  dps: 1860.39313
+  tps: 1467.73129
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IceGuard-2682"
  value: {
-  dps: 1900.27217
-  tps: 1497.47799
+  dps: 1900.17223
+  tps: 1497.42378
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1837.80223
-  tps: 1448.9622
+  dps: 1837.70412
+  tps: 1448.90576
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1838.03148
-  tps: 1449.12267
+  dps: 1837.93336
+  tps: 1449.06623
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1695.01252
-  tps: 1336.75195
+  dps: 1694.90455
+  tps: 1336.68125
   dtps: 14.77883
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JomGabbar-23570"
  value: {
-  dps: 1853.72124
-  tps: 1462.15027
+  dps: 1853.62313
+  tps: 1462.09383
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JusticarArmor"
  value: {
-  dps: 1516.82643
-  tps: 1205.07782
+  dps: 1516.72324
+  tps: 1205.01149
   dtps: 14.69308
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JusticarBattlegear"
  value: {
-  dps: 1730.88906
-  tps: 1365.87763
+  dps: 1730.78055
+  tps: 1365.80717
   dtps: 14.77886
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1915.73822
-  tps: 1509.74295
+  dps: 1915.63781
+  tps: 1509.68842
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KhoriumWard"
  value: {
-  dps: 1716.11369
-  tps: 1353.50836
+  dps: 1716.01922
+  tps: 1353.44273
   dtps: 14.77883
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1876.55715
-  tps: 1478.54493
+  dps: 1876.45765
+  tps: 1478.49128
   dtps: 14.51358
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofDivinePurpose-33504"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofFervor-23203"
  value: {
-  dps: 1909.31544
-  tps: 1504.00672
+  dps: 1909.21512
+  tps: 1503.95224
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofHope-22401"
  value: {
-  dps: 1904.5858
-  tps: 1499.69789
+  dps: 1904.48547
+  tps: 1499.63795
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofRepentance-29388"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofRighteousPower-31033"
  value: {
-  dps: 1912.9116
-  tps: 1506.52403
+  dps: 1912.81128
+  tps: 1506.46955
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofWracking-28065"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofZeal-27949"
  value: {
-  dps: 1911.32196
-  tps: 1505.41128
+  dps: 1911.22163
+  tps: 1505.3568
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofZeal-27983"
  value: {
-  dps: 1911.32196
-  tps: 1505.41128
+  dps: 1911.22163
+  tps: 1505.3568
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramoftheEternalRest-27917"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerArmor"
  value: {
-  dps: 1353.38982
-  tps: 1070.04602
+  dps: 1353.28967
+  tps: 1069.98091
   dtps: 14.69308
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1971.52014
-  tps: 1559.16802
+  dps: 1971.41134
+  tps: 1559.09386
   dtps: 13.70441
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1981.57364
-  tps: 1561.33193
+  dps: 1981.47254
+  tps: 1561.27691
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 1826.85793
-  tps: 1441.23924
+  dps: 1826.75982
+  tps: 1441.18556
   dtps: 12.80638
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1860.9151
-  tps: 1467.31787
+  dps: 1860.81698
+  tps: 1467.26143
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1482.76033
-  tps: 1171.21565
+  dps: 1482.65714
+  tps: 1171.14992
   dtps: 15.445
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 1841.45361
-  tps: 1451.54437
+  dps: 1841.33931
+  tps: 1451.4721
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1832.04399
-  tps: 1444.93143
+  dps: 1831.94587
+  tps: 1444.87499
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MercilessGladiator'sLibramofFortitude-33937"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MercilessGladiator'sLibramofVengeance-33949"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1836.06705
-  tps: 1447.16389
+  dps: 1835.96975
+  tps: 1447.10802
   dtps: 14.10268
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1832.1883
-  tps: 1445.03245
+  dps: 1832.09018
+  tps: 1444.97601
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherscaleArmor"
  value: {
-  dps: 1826.36339
-  tps: 1440.04587
+  dps: 1826.24901
+  tps: 1439.97119
   dtps: 14.90221
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1745.46865
-  tps: 1376.349
+  dps: 1745.35616
+  tps: 1376.27563
   dtps: 14.90221
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherweaveVestments"
  value: {
-  dps: 1531.67215
-  tps: 1208.05565
+  dps: 1531.56588
+  tps: 1207.99026
   dtps: 14.63719
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 1852.89897
-  tps: 1461.62844
+  dps: 1852.80085
+  tps: 1461.572
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 1831.77982
-  tps: 1444.74651
+  dps: 1831.6817
+  tps: 1444.69007
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1877.13291
-  tps: 1479.98022
+  dps: 1877.0329
+  tps: 1479.92596
   dtps: 13.40632
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1877.13291
-  tps: 1480.02648
+  dps: 1877.0329
+  tps: 1479.97222
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1877.13291
-  tps: 1480.02648
+  dps: 1877.0329
+  tps: 1479.97222
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1877.13291
-  tps: 1480.02648
+  dps: 1877.0329
+  tps: 1479.97222
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1877.13291
-  tps: 1480.02648
+  dps: 1877.0329
+  tps: 1479.97222
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1826.85793
-  tps: 1441.5503
+  dps: 1826.75982
+  tps: 1441.48962
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrimalIntent"
  value: {
-  dps: 1869.77698
-  tps: 1473.66324
+  dps: 1869.6626
+  tps: 1473.59205
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrimalMooncloth"
  value: {
-  dps: 1720.61957
-  tps: 1356.63559
+  dps: 1720.52139
+  tps: 1356.57519
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Prismcharm-15867"
  value: {
-  dps: 1826.85793
-  tps: 1441.26984
+  dps: 1826.75982
+  tps: 1441.2154
   dtps: 13.6214
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1832.04399
-  tps: 1444.93143
+  dps: 1831.94587
+  tps: 1444.87499
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 1820.78416
-  tps: 1436.68611
+  dps: 1820.68618
+  tps: 1436.62977
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1842.56195
-  tps: 1452.44172
+  dps: 1842.46194
+  tps: 1452.38771
   dtps: 14.90221
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1838.32261
-  tps: 1453.1028
+  dps: 1838.22502
+  tps: 1453.04673
   dtps: 14.44896
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofForce-25994"
  value: {
-  dps: 1833.6715
-  tps: 1446.6251
+  dps: 1833.57338
+  tps: 1446.56866
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGuard-2681"
  value: {
-  dps: 1900.27217
-  tps: 1497.47799
+  dps: 1900.17223
+  tps: 1497.42378
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1813.24063
-  tps: 1430.68914
+  dps: 1813.14252
+  tps: 1430.6327
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 1830.22186
-  tps: 1443.65594
+  dps: 1830.12374
+  tps: 1443.5995
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 1863.21687
-  tps: 1466.81664
+  dps: 1863.11706
+  tps: 1466.76425
   dtps: 14.34202
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1830.51572
-  tps: 1443.85656
+  dps: 1830.41761
+  tps: 1443.80012
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1834.78994
-  tps: 1446.87178
+  dps: 1834.69183
+  tps: 1446.81534
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1703.39224
-  tps: 1344.57988
+  dps: 1703.28019
+  tps: 1344.51744
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1926.74501
-  tps: 1522.88054
+  dps: 1926.64636
+  tps: 1522.82373
   dtps: 14.36645
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1826.85793
-  tps: 1441.31937
+  dps: 1826.75982
+  tps: 1441.26293
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1835.87815
-  tps: 1448.35385
+  dps: 1835.78166
+  tps: 1448.29855
   dtps: 14.29983
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1867.55764
-  tps: 1473.02369
+  dps: 1867.45953
+  tps: 1472.96725
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1698.19289
-  tps: 1340.60549
+  dps: 1698.09754
+  tps: 1340.54624
   dtps: 14.34631
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1704.04014
-  tps: 1344.50401
+  dps: 1703.94628
+  tps: 1344.44631
   dtps: 14.65778
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
   hps: 14.44444
  }
@@ -1385,287 +1385,287 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1915.73822
-  tps: 1509.74295
+  dps: 1915.63781
+  tps: 1509.68842
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 1829.88257
-  tps: 1443.41335
+  dps: 1829.78446
+  tps: 1443.35691
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 1828.61481
-  tps: 1442.53101
+  dps: 1828.5167
+  tps: 1442.47457
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 1912.70978
-  tps: 1511.88487
+  dps: 1912.61045
+  tps: 1511.82758
   dtps: 14.36645
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1680.51036
-  tps: 1326.3436
+  dps: 1680.40239
+  tps: 1326.27653
   dtps: 14.41524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1879.50152
-  tps: 1481.87364
+  dps: 1879.40341
+  tps: 1481.82071
   dtps: 14.34177
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 1828.78059
-  tps: 1442.64705
+  dps: 1828.68248
+  tps: 1442.59061
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 1831.14888
-  tps: 1444.29976
+  dps: 1831.05076
+  tps: 1444.24332
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 1834.37326
-  tps: 1447.17338
+  dps: 1834.27514
+  tps: 1447.11694
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 1828.8442
-  tps: 1442.68649
+  dps: 1828.74609
+  tps: 1442.63005
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1826.85793
-  tps: 1441.30119
+  dps: 1826.75982
+  tps: 1441.24475
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1836.7809
-  tps: 1448.24727
+  dps: 1836.68279
+  tps: 1448.19083
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1826.7709
-  tps: 1437.91958
+  dps: 1826.67446
+  tps: 1437.86432
   dtps: 14.24679
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThickDraenicArmor"
  value: {
-  dps: 1714.00048
-  tps: 1351.67874
+  dps: 1713.88949
+  tps: 1351.61005
   dtps: 14.63719
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 1831.31793
-  tps: 1444.17057
+  dps: 1831.21982
+  tps: 1444.11026
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 1837.86536
-  tps: 1449.00639
+  dps: 1837.76725
+  tps: 1448.94995
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1869.15449
-  tps: 1474.65234
+  dps: 1869.05485
+  tps: 1474.59483
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnitingCharm-25633"
  value: {
-  dps: 1852.89897
-  tps: 1461.62844
+  dps: 1852.80085
+  tps: 1461.572
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 1829.75594
-  tps: 1443.34289
+  dps: 1829.65783
+  tps: 1443.28645
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VengefulGladiator'sLibramofFortitude-33938"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VengefulGladiator'sLibramofVengeance-33950"
  value: {
-  dps: 1904.5858
-  tps: 1500.69596
+  dps: 1904.48547
+  tps: 1500.64149
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 1830.03399
-  tps: 1443.34993
+  dps: 1829.93588
+  tps: 1443.29125
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WastewalkerArmor"
  value: {
-  dps: 1653.48548
-  tps: 1304.24878
+  dps: 1653.37615
+  tps: 1304.18225
   dtps: 14.05926
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WhitemendWisdom"
  value: {
-  dps: 1698.14067
-  tps: 1340.2582
+  dps: 1698.04681
+  tps: 1340.19788
   dtps: 14.65778
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WindhawkArmor"
  value: {
-  dps: 1746.32636
-  tps: 1377.21244
+  dps: 1746.22794
+  tps: 1377.14904
   dtps: 14.90221
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1956.22201
-  tps: 1541.29995
+  dps: 1956.12161
+  tps: 1541.24541
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 1886.35903
-  tps: 1486.29679
+  dps: 1886.26094
+  tps: 1486.24312
   dtps: 14.34631
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathofSpellfire"
  value: {
-  dps: 1724.44704
-  tps: 1360.16147
+  dps: 1724.34543
+  tps: 1360.09784
   dtps: 14.70989
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 1834.07535
-  tps: 1446.31225
+  dps: 1833.97823
+  tps: 1446.25651
   dtps: 14.68094
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1830.51572
-  tps: 1443.87474
+  dps: 1830.41761
+  tps: 1443.8183
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 1938.50271
-  tps: 1528.43225
-  dtps: 14.81808
+  dps: 1938.42042
+  tps: 1528.3945
+  dtps: 14.82297
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Default-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2439.8786
-  tps: 2488.75813
+  dps: 2439.77883
+  tps: 2489.0233
   dtps: 12.75792
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Default-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1915.73822
-  tps: 1509.74295
+  dps: 1915.63781
+  tps: 1509.68842
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2319.75753
-  tps: 1840.72372
+  dps: 2319.63227
+  tps: 1840.66154
   dtps: 30.31153
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Default-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 520.71706
-  tps: 492.63214
+  dps: 519.75626
+  tps: 490.62895
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Default-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 520.71706
-  tps: 408.29642
+  dps: 519.75626
+  tps: 407.0469
  }
 }
 dps_results: {
@@ -1723,8 +1723,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1620.46409
-  tps: 1271.14472
+  dps: 1620.37466
+  tps: 1271.09912
   dtps: 14.41651
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestRetribution-CharacterStats-Default"
  value: {
-  final_stats: 880.638
-  final_stats: 493.295
-  final_stats: 690.36
-  final_stats: 252.89
-  final_stats: 236.889
-  final_stats: 223.889
+  final_stats: 878
+  final_stats: 491
+  final_stats: 688
+  final_stats: 251
+  final_stats: 236.7
+  final_stats: 223.7
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 208.89
-  final_stats: 3547.2536
+  final_stats: 207
+  final_stats: 3540.9
   final_stats: 891
   final_stats: 0
   final_stats: 60
@@ -29,24 +29,24 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 373.38641
+  final_stats: 371.64927
   final_stats: 0
   final_stats: 0
-  final_stats: 9648.99
+  final_stats: 9644
   final_stats: 0
-  final_stats: 11270.6
-  final_stats: 6466.35
-  final_stats: 122.7
-  final_stats: 38.75
-  final_stats: 38.75
-  final_stats: 38.75
-  final_stats: 38.75
+  final_stats: 11247
+  final_stats: 6438
+  final_stats: 122.5
+  final_stats: 38
+  final_stats: 38
+  final_stats: 38
+  final_stats: 38
   final_stats: 75
   final_stats: 0
   final_stats: 6.80488
   final_stats: 6
-  final_stats: 42.62422
-  final_stats: 24.83197
+  final_stats: 42.53242
+  final_stats: 24.78472
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -55,368 +55,368 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1888.0001
-  tps: 1488.75169
+  dps: 1885.26951
+  tps: 1486.4381
   dtps: 14.52037
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1918.17376
-  tps: 1511.6183
+  dps: 1915.73822
+  tps: 1509.74295
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 1836.83619
-  tps: 1448.6056
+  dps: 1833.95533
+  tps: 1446.26937
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 1832.63681
-  tps: 1445.67912
+  dps: 1829.75594
+  tps: 1443.34289
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 1855.09076
-  tps: 1463.5979
+  dps: 1852.42422
+  tps: 1461.56902
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 1835.28374
-  tps: 1447.51888
+  dps: 1832.40288
+  tps: 1445.18265
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1728.07135
-  tps: 1363.52968
+  dps: 1724.99765
+  tps: 1361.1007
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1846.43472
-  tps: 1456.6608
+  dps: 1843.06139
+  tps: 1453.97826
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1845.71161
-  tps: 1454.72668
+  dps: 1842.81269
+  tps: 1452.37792
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1937.0636
-  tps: 1525.48644
+  dps: 1934.40168
+  tps: 1523.3927
   dtps: 14.34631
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 1892.91925
-  tps: 1491.19194
+  dps: 1889.44203
+  tps: 1488.53811
   dtps: 14.70989
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1894.60088
-  tps: 1492.49526
+  dps: 1891.12366
+  tps: 1489.84129
   dtps: 14.70989
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 1830.22196
-  tps: 1443.97564
+  dps: 1827.3411
+  tps: 1441.63941
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BattlecastGarb"
  value: {
-  dps: 1706.43042
-  tps: 1346.65868
+  dps: 1703.6379
+  tps: 1344.50027
   dtps: 14.65778
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 1830.82803
-  tps: 1443.20711
+  dps: 1827.92655
+  tps: 1440.85184
   dtps: 14.40392
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 1830.82803
-  tps: 1443.20711
+  dps: 1827.92655
+  tps: 1440.85184
   dtps: 14.40392
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1836.32649
-  tps: 1448.24881
+  dps: 1833.44562
+  tps: 1445.91258
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1856.73145
-  tps: 1464.77817
+  dps: 1853.07489
+  tps: 1461.94422
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1829.7388
-  tps: 1443.6556
+  dps: 1826.85793
+  tps: 1441.31937
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1855.64819
-  tps: 1463.84938
+  dps: 1852.75258
+  tps: 1461.50045
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1833.94371
-  tps: 1446.58086
+  dps: 1831.06284
+  tps: 1444.24463
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1886.55701
-  tps: 1487.92477
+  dps: 1883.65956
+  tps: 1485.57425
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1918.17376
-  tps: 1511.6183
+  dps: 1915.73822
+  tps: 1509.74295
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1917.42884
-  tps: 1511.77958
+  dps: 1915.00195
+  tps: 1509.8425
   dtps: 14.74805
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1859.85799
-  tps: 1467.24421
+  dps: 1856.50114
+  tps: 1464.61319
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1883.94887
-  tps: 1484.9735
+  dps: 1880.96986
+  tps: 1482.71234
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BrutalGladiator'sLibramofFortitude-35039"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BrutalGladiator'sLibramofVengeance-35041"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 1906.14755
-  tps: 1501.7162
+  dps: 1903.5697
+  tps: 1499.73752
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 1911.88712
-  tps: 1506.42176
+  dps: 1908.78343
+  tps: 1503.91468
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningRage"
  value: {
-  dps: 1800.61824
-  tps: 1418.89489
+  dps: 1797.98795
+  tps: 1416.78209
   dtps: 13.79028
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1883.10937
-  tps: 1484.5533
+  dps: 1880.13327
+  tps: 1482.29949
   dtps: 14.90221
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1804.36502
-  tps: 1422.98209
+  dps: 1800.43201
+  tps: 1419.88027
   dtps: 14.34177
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CloudkeeperLegplates-14554"
  value: {
-  dps: 1851.3981
-  tps: 1459.85922
+  dps: 1848.23778
+  tps: 1457.36136
   dtps: 14.41524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1861.95221
-  tps: 1468.7468
+  dps: 1859.06176
+  tps: 1466.40232
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1804.37565
-  tps: 1423.24642
+  dps: 1800.43898
+  tps: 1420.14003
   dtps: 14.68478
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CrystalforgeArmor"
  value: {
-  dps: 1488.27798
-  tps: 1175.25851
+  dps: 1485.50952
+  tps: 1173.14201
   dtps: 14.69308
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CrystalforgeBattlegear"
  value: {
-  dps: 1768.6702
-  tps: 1395.26007
+  dps: 1765.68731
+  tps: 1392.96649
   dtps: 14.73865
   hps: 1.277
  }
@@ -424,960 +424,960 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1848.10161
-  tps: 1457.5601
+  dps: 1845.21863
+  tps: 1455.2224
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1840.91234
-  tps: 1451.4589
+  dps: 1838.03148
+  tps: 1449.12267
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1865.23959
-  tps: 1471.37181
+  dps: 1862.3366
+  tps: 1469.01652
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1842.56106
-  tps: 1453.94062
+  dps: 1838.22649
+  tps: 1450.58424
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Despair-28573"
  value: {
-  dps: 1960.63848
-  tps: 1544.71857
+  dps: 1958.2462
+  tps: 1542.8778
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Devastation-30316"
  value: {
-  dps: 1996.98961
-  tps: 1573.18351
+  dps: 1992.69363
+  tps: 1570.00126
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DirebrewHops-38288"
  value: {
-  dps: 1837.00838
-  tps: 1448.72613
+  dps: 1834.12752
+  tps: 1446.3899
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DoomplateBattlegear"
  value: {
-  dps: 1671.1196
-  tps: 1318.49669
+  dps: 1668.01839
+  tps: 1316.16392
   dtps: 14.05926
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 1832.40317
-  tps: 1445.50248
+  dps: 1829.5223
+  tps: 1443.16625
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 1833.9374
-  tps: 1446.57644
+  dps: 1831.05653
+  tps: 1444.24021
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Earthstrike-21180"
  value: {
-  dps: 1851.26002
-  tps: 1460.39767
+  dps: 1848.37916
+  tps: 1458.06144
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1874.42475
-  tps: 1478.46872
+  dps: 1871.53062
+  tps: 1476.12106
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantBoots-Boar'sSpeed-2940"
  value: {
-  dps: 1911.1162
-  tps: 1506.25975
+  dps: 1907.60038
+  tps: 1503.51638
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 1914.86797
-  tps: 1509.09016
+  dps: 1912.41001
+  tps: 1507.19936
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 1911.1162
-  tps: 1476.61526
+  dps: 1907.60038
+  tps: 1473.92648
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1905.92432
-  tps: 1531.63084
+  dps: 1903.59308
+  tps: 1529.80093
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1900.94897
-  tps: 1498.28122
+  dps: 1898.88323
+  tps: 1496.61387
   dtps: 13.85942
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 1889.67593
-  tps: 1491.70751
+  dps: 1887.50069
+  tps: 1489.95337
   dtps: 13.6916
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 1911.38293
-  tps: 1504.06375
+  dps: 1909.17355
+  tps: 1502.28709
   dtps: 14.47476
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1837.00838
-  tps: 1448.72613
+  dps: 1834.12752
+  tps: 1446.3899
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1837.30764
-  tps: 1448.93561
+  dps: 1834.42677
+  tps: 1446.59938
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeofMoam-21473"
  value: {
-  dps: 1831.24798
-  tps: 1444.69385
+  dps: 1828.36711
+  tps: 1442.35762
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 1840.90468
-  tps: 1451.45354
+  dps: 1838.02381
+  tps: 1449.11731
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1880.10902
-  tps: 1482.30378
+  dps: 1877.13291
+  tps: 1480.04466
   dtps: 14.99327
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelSkin"
  value: {
-  dps: 1765.67612
-  tps: 1392.31171
+  dps: 1761.25458
+  tps: 1388.96283
   dtps: 14.63719
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelscaleArmor"
  value: {
-  dps: 1748.22073
-  tps: 1378.0299
+  dps: 1745.29205
+  tps: 1375.75534
   dtps: 14.63719
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1855.60252
-  tps: 1463.81712
+  dps: 1852.7117
+  tps: 1461.47232
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sLibramofFortitude-33936"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sLibramofVengeance-33948"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 1836.83619
-  tps: 1448.6056
+  dps: 1833.95533
+  tps: 1446.26937
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HandofJustice-11815"
  value: {
-  dps: 1890.15471
-  tps: 1488.62669
+  dps: 1888.17853
+  tps: 1487.08017
   dtps: 14.35053
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 1836.9847
-  tps: 1448.67469
+  dps: 1834.07535
+  tps: 1446.31225
   dtps: 14.68094
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 1829.7388
-  tps: 1443.60458
+  dps: 1826.85793
+  tps: 1441.26587
   dtps: 13.54198
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 1832.20888
-  tps: 1445.23235
+  dps: 1829.32801
+  tps: 1442.89874
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1844.17336
-  tps: 1453.74162
+  dps: 1841.2925
+  tps: 1451.40539
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 1833.39702
-  tps: 1446.19818
+  dps: 1830.51615
+  tps: 1443.86195
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1863.59109
-  tps: 1470.18683
+  dps: 1860.4926
+  tps: 1467.78868
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IceGuard-2682"
  value: {
-  dps: 1904.45854
-  tps: 1500.64167
+  dps: 1900.27217
+  tps: 1497.47799
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1840.69594
-  tps: 1451.30742
+  dps: 1837.80223
+  tps: 1448.9622
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1840.91234
-  tps: 1451.4589
+  dps: 1838.03148
+  tps: 1449.12267
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1698.30303
-  tps: 1339.44712
+  dps: 1695.01252
+  tps: 1336.75195
   dtps: 14.77883
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JomGabbar-23570"
  value: {
-  dps: 1856.60211
-  tps: 1464.4865
+  dps: 1853.72124
+  tps: 1462.15027
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JusticarArmor"
  value: {
-  dps: 1519.65311
-  tps: 1207.25563
+  dps: 1516.82643
+  tps: 1205.07782
   dtps: 14.69308
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JusticarBattlegear"
  value: {
-  dps: 1733.61583
-  tps: 1367.94079
+  dps: 1730.88906
+  tps: 1365.87763
   dtps: 14.77886
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1918.17376
-  tps: 1511.6183
+  dps: 1915.73822
+  tps: 1509.74295
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KhoriumWard"
  value: {
-  dps: 1717.95123
-  tps: 1354.93344
+  dps: 1716.11369
+  tps: 1353.50836
   dtps: 14.77883
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1879.92452
-  tps: 1481.14241
+  dps: 1876.55715
+  tps: 1478.54493
   dtps: 14.51358
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofDivineJudgement-33503"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofDivinePurpose-33504"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofFervor-23203"
  value: {
-  dps: 1911.77393
-  tps: 1505.90498
+  dps: 1909.31544
+  tps: 1504.00672
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofHope-22401"
  value: {
-  dps: 1907.04429
-  tps: 1501.58928
+  dps: 1904.5858
+  tps: 1499.69789
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofRepentance-29388"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofRighteousPower-31033"
  value: {
-  dps: 1915.37073
-  tps: 1508.42274
+  dps: 1912.9116
+  tps: 1506.52403
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofWracking-28065"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofZeal-27949"
  value: {
-  dps: 1913.78045
-  tps: 1507.30954
+  dps: 1911.32196
+  tps: 1505.41128
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramofZeal-27983"
  value: {
-  dps: 1913.78045
-  tps: 1507.30954
+  dps: 1911.32196
+  tps: 1505.41128
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LibramoftheEternalRest-27917"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerArmor"
  value: {
-  dps: 1355.20278
-  tps: 1071.49394
+  dps: 1353.38982
+  tps: 1070.04602
   dtps: 14.69308
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightbringerBattlegear"
  value: {
-  dps: 1975.71389
-  tps: 1562.41744
+  dps: 1971.52014
+  tps: 1559.16802
   dtps: 13.70441
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1984.76199
-  tps: 1563.82587
+  dps: 1981.57364
+  tps: 1561.33193
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 1829.7388
-  tps: 1443.5773
-  dtps: 12.77325
+  dps: 1826.85793
+  tps: 1441.23924
+  dtps: 12.80638
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1863.82877
-  tps: 1469.67956
+  dps: 1860.9151
+  tps: 1467.31787
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1485.52883
-  tps: 1173.33586
+  dps: 1482.76033
+  tps: 1171.21565
   dtps: 15.445
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 1843.9883
-  tps: 1453.53883
+  dps: 1841.45361
+  tps: 1451.54437
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1834.92485
-  tps: 1447.26766
+  dps: 1832.04399
+  tps: 1444.93143
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MercilessGladiator'sLibramofFortitude-33937"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MercilessGladiator'sLibramofVengeance-33949"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1838.9773
-  tps: 1449.65599
+  dps: 1836.06705
+  tps: 1447.16389
   dtps: 14.10268
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1835.06916
-  tps: 1447.36868
+  dps: 1832.1883
+  tps: 1445.03245
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherscaleArmor"
  value: {
-  dps: 1830.36794
-  tps: 1443.10657
+  dps: 1826.36339
+  tps: 1440.04587
   dtps: 14.90221
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1748.51439
-  tps: 1378.65605
+  dps: 1745.46865
+  tps: 1376.349
   dtps: 14.90221
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NetherweaveVestments"
  value: {
-  dps: 1533.32098
-  tps: 1209.34752
+  dps: 1531.67215
+  tps: 1208.05565
   dtps: 14.63719
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 1855.78868
-  tps: 1463.97229
+  dps: 1852.89897
+  tps: 1461.62844
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 1834.66068
-  tps: 1447.08274
+  dps: 1831.77982
+  tps: 1444.74651
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1880.10902
-  tps: 1482.23935
+  dps: 1877.13291
+  tps: 1479.98022
   dtps: 13.40632
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1880.10902
-  tps: 1482.2856
+  dps: 1877.13291
+  tps: 1480.02648
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1880.10902
-  tps: 1482.2856
+  dps: 1877.13291
+  tps: 1480.02648
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1880.10902
-  tps: 1482.2856
+  dps: 1877.13291
+  tps: 1480.02648
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1880.10902
-  tps: 1482.2856
+  dps: 1877.13291
+  tps: 1480.02648
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1829.7388
-  tps: 1443.88131
+  dps: 1826.85793
+  tps: 1441.5503
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrimalIntent"
  value: {
-  dps: 1873.88154
-  tps: 1476.8167
+  dps: 1869.77698
+  tps: 1473.66324
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrimalMooncloth"
  value: {
-  dps: 1723.76005
-  tps: 1359.06298
+  dps: 1720.61957
+  tps: 1356.63559
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Prismcharm-15867"
  value: {
-  dps: 1829.7388
-  tps: 1443.60855
+  dps: 1826.85793
+  tps: 1441.26984
   dtps: 13.6214
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1834.92485
-  tps: 1447.26766
+  dps: 1832.04399
+  tps: 1444.93143
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 1822.66678
-  tps: 1438.16204
+  dps: 1820.78416
+  tps: 1436.68611
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1845.10235
-  tps: 1454.44644
+  dps: 1842.56195
+  tps: 1452.44172
   dtps: 14.90221
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1841.20508
-  tps: 1455.44075
+  dps: 1838.32261
+  tps: 1453.1028
   dtps: 14.44896
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofForce-25994"
  value: {
-  dps: 1836.55236
-  tps: 1448.96133
+  dps: 1833.6715
+  tps: 1446.6251
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SavageGuard-2681"
  value: {
-  dps: 1904.45854
-  tps: 1500.64167
+  dps: 1900.27217
+  tps: 1497.47799
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1816.1215
-  tps: 1433.02537
+  dps: 1813.24063
+  tps: 1430.68914
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 1833.10273
-  tps: 1445.99217
+  dps: 1830.22186
+  tps: 1443.65594
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 1866.06926
-  tps: 1469.10763
+  dps: 1863.21687
+  tps: 1466.81664
   dtps: 14.34202
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1833.39659
-  tps: 1446.19279
+  dps: 1830.51572
+  tps: 1443.85656
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1837.65996
-  tps: 1449.20041
+  dps: 1834.78994
+  tps: 1446.87178
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1705.649
-  tps: 1346.46662
+  dps: 1703.39224
+  tps: 1344.57988
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1929.93387
-  tps: 1525.38218
+  dps: 1926.74501
+  tps: 1522.88054
   dtps: 14.36645
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1829.7388
-  tps: 1443.6556
+  dps: 1826.85793
+  tps: 1441.31937
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1838.76115
-  tps: 1450.69266
+  dps: 1835.87815
+  tps: 1448.35385
   dtps: 14.29983
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1870.45031
-  tps: 1475.37008
+  dps: 1867.55764
+  tps: 1473.02369
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1702.01506
-  tps: 1343.53695
+  dps: 1698.19289
+  tps: 1340.60549
   dtps: 14.34631
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1706.83265
-  tps: 1346.6702
+  dps: 1704.04014
+  tps: 1344.50401
   dtps: 14.65778
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
   hps: 14.44444
  }
@@ -1385,272 +1385,272 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1918.17376
-  tps: 1511.6183
+  dps: 1915.73822
+  tps: 1509.74295
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 1832.76344
-  tps: 1445.74958
+  dps: 1829.88257
+  tps: 1443.41335
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 1831.49568
-  tps: 1444.86724
+  dps: 1828.61481
+  tps: 1442.53101
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 1915.03397
-  tps: 1513.77871
+  dps: 1912.70978
+  tps: 1511.88487
   dtps: 14.36645
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1683.80086
-  tps: 1329.04097
+  dps: 1680.51036
+  tps: 1326.3436
   dtps: 14.41524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1882.90233
-  tps: 1484.52783
+  dps: 1879.50152
+  tps: 1481.87364
   dtps: 14.34177
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 1831.66146
-  tps: 1444.98328
+  dps: 1828.78059
+  tps: 1442.64705
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 1834.02974
-  tps: 1446.63599
+  dps: 1831.14888
+  tps: 1444.29976
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 1837.26016
-  tps: 1449.51565
+  dps: 1834.37326
+  tps: 1447.17338
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 1831.72507
-  tps: 1445.02272
+  dps: 1828.8442
+  tps: 1442.68649
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1829.7388
-  tps: 1443.63742
+  dps: 1826.85793
+  tps: 1441.30119
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1839.66177
-  tps: 1450.5835
+  dps: 1836.7809
+  tps: 1448.24727
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1829.42782
-  tps: 1440.16073
+  dps: 1826.7709
+  tps: 1437.91958
   dtps: 14.24679
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ThickDraenicArmor"
  value: {
-  dps: 1717.28503
-  tps: 1354.27325
+  dps: 1714.00048
+  tps: 1351.67874
   dtps: 14.63719
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 1834.1988
-  tps: 1446.50227
+  dps: 1831.31793
+  tps: 1444.17057
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TomeofFieryRedemption-30447"
  value: {
-  dps: 1840.74623
-  tps: 1451.34262
+  dps: 1837.86536
+  tps: 1449.00639
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1871.098
-  tps: 1476.17607
+  dps: 1869.15449
+  tps: 1474.65234
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnitingCharm-25633"
  value: {
-  dps: 1855.78868
-  tps: 1463.97229
+  dps: 1852.89897
+  tps: 1461.62844
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 1832.63681
-  tps: 1445.67912
+  dps: 1829.75594
+  tps: 1443.34289
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VengefulGladiator'sLibramofFortitude-33938"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VengefulGladiator'sLibramofVengeance-33950"
  value: {
-  dps: 1907.04429
-  tps: 1502.59423
+  dps: 1904.5858
+  tps: 1500.69596
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 1832.91486
-  tps: 1445.68354
+  dps: 1830.03399
+  tps: 1443.34993
   dtps: 14.34107
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WastewalkerArmor"
  value: {
-  dps: 1655.99402
-  tps: 1306.30385
+  dps: 1653.48548
+  tps: 1304.24878
   dtps: 14.05926
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WhitemendWisdom"
  value: {
-  dps: 1700.93318
-  tps: 1342.41611
+  dps: 1698.14067
+  tps: 1340.2582
   dtps: 14.65778
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WindhawkArmor"
  value: {
-  dps: 1749.38132
-  tps: 1379.52721
+  dps: 1746.32636
+  tps: 1377.21244
   dtps: 14.90221
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1959.00522
-  tps: 1543.44548
+  dps: 1956.22201
+  tps: 1541.29995
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 1889.83625
-  tps: 1488.95749
+  dps: 1886.35903
+  tps: 1486.29679
   dtps: 14.34631
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WrathofSpellfire"
  value: {
-  dps: 1727.42385
-  tps: 1362.47083
+  dps: 1724.44704
+  tps: 1360.16147
   dtps: 14.70989
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 1836.9847
-  tps: 1448.67469
+  dps: 1834.07535
+  tps: 1446.31225
   dtps: 14.68094
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1833.39659
-  tps: 1446.21097
+  dps: 1830.51572
+  tps: 1443.87474
   dtps: 14.70466
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 1941.84829
-  tps: 1531.03374
-  dtps: 14.79713
+  dps: 1938.50271
+  tps: 1528.43225
+  dtps: 14.81808
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Default-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2442.31479
-  tps: 2490.9192
+  dps: 2439.8786
+  tps: 2488.75813
   dtps: 12.75792
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Default-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1918.17376
-  tps: 1511.6183
+  dps: 1915.73822
+  tps: 1509.74295
   dtps: 14.53862
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p1-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2323.46547
-  tps: 1843.52666
+  dps: 2319.75753
+  tps: 1840.72372
   dtps: 30.31153
  }
 }
@@ -1678,53 +1678,53 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Default-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2475.28218
-  tps: 2514.66541
+  dps: 2470.95076
+  tps: 2510.69188
   dtps: 12.8974
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Default-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1954.16338
-  tps: 1538.80365
+  dps: 1950.61517
+  tps: 1535.81666
   dtps: 14.64644
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2362.95453
-  tps: 1874.97545
+  dps: 2357.9648
+  tps: 1870.43097
   dtps: 30.31153
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Default-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 534.93792
-  tps: 502.21269
+  dps: 534.85666
+  tps: 502.14917
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Default-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 534.93792
-  tps: 418.93253
+  dps: 534.85666
+  tps: 418.869
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-p1-Default-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 721.90159
-  tps: 569.00996
+  dps: 721.79629
+  tps: 568.927
  }
 }
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1623.48978
-  tps: 1273.53784
+  dps: 1620.46409
+  tps: 1271.14472
   dtps: 14.41651
  }
 }

--- a/sim/priest/TestShadowPriest.results
+++ b/sim/priest/TestShadowPriest.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestShadowPriest-CharacterStats-Default"
  value: {
-  final_stats: 180.18
-  final_stats: 176.495
-  final_stats: 580.36
-  final_stats: 346.39
-  final_stats: 899.049
-  final_stats: 886.049
+  final_stats: 178
+  final_stats: 174
+  final_stats: 578
+  final_stats: 345
+  final_stats: 898.9
+  final_stats: 885.9
   final_stats: 0
   final_stats: 0
   final_stats: 233
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 132
   final_stats: 0
   final_stats: 0
-  final_stats: 270.49
-  final_stats: 848.65
+  final_stats: 269
+  final_stats: 848.1
   final_stats: 389
   final_stats: 0
   final_stats: 0
@@ -32,21 +32,21 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 27
-  final_stats: 3049.39
+  final_stats: 3044
   final_stats: 0
-  final_stats: 10184.6
-  final_stats: 7535.85
-  final_stats: 122.7
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
+  final_stats: 10161
+  final_stats: 7515
+  final_stats: 122.5
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
   final_stats: 70
   final_stats: 0
   final_stats: 0
   final_stats: 9.18293
   final_stats: 10.35722
-  final_stats: 21.54647
+  final_stats: 21.52909
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -55,1164 +55,1164 @@ character_stats_results: {
 dps_results: {
  key: "TestShadowPriest-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AbsolutionRegalia"
  value: {
-  dps: 1717.83811
-  tps: 1255.72795
+  dps: 1717.68008
+  tps: 1255.6826
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 1737.93099
-  tps: 1275.16667
+  dps: 1737.8077
+  tps: 1275.136
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 1719.89646
-  tps: 1262.15997
+  dps: 1719.77303
+  tps: 1262.12648
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 1731.28091
-  tps: 1270.50161
+  dps: 1731.15762
+  tps: 1270.47169
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1611.24446
-  tps: 1184.54464
+  dps: 1611.04116
+  tps: 1184.46693
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1537.55425
-  tps: 1130.87815
+  dps: 1537.44082
+  tps: 1130.85695
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
-  dps: 1747.17622
-  tps: 1281.48463
+  dps: 1747.05292
+  tps: 1281.45528
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AvatarRegalia"
  value: {
-  dps: 1642.42043
-  tps: 1203.52228
+  dps: 1642.2769
+  tps: 1203.47228
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1731.22906
-  tps: 1270.44875
+  dps: 1731.10577
+  tps: 1270.41921
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 1751.80051
-  tps: 1284.57121
+  dps: 1751.28783
+  tps: 1284.23836
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1767.34623
-  tps: 1296.23305
+  dps: 1767.22269
+  tps: 1296.19196
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 1704.83974
-  tps: 1251.01095
+  dps: 1704.71645
+  tps: 1250.98435
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BattlecastGarb"
  value: {
-  dps: 1666.38219
-  tps: 1223.96452
+  dps: 1665.89049
+  tps: 1223.67366
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 1736.4165
-  tps: 1275.29772
+  dps: 1736.29128
+  tps: 1275.26213
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 1736.4165
-  tps: 1275.29772
+  dps: 1736.29128
+  tps: 1275.26213
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1734.10487
-  tps: 1272.29933
+  dps: 1733.98158
+  tps: 1272.26827
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1708.12961
-  tps: 1253.75838
+  dps: 1708.00603
+  tps: 1253.72856
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1722.62398
-  tps: 1264.10284
+  dps: 1722.50069
+  tps: 1264.07104
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1734.23238
-  tps: 1272.64702
+  dps: 1734.1091
+  tps: 1272.61376
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1748.78807
-  tps: 1282.97059
+  dps: 1748.66477
+  tps: 1282.93294
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1705.17164
-  tps: 1251.24257
+  dps: 1705.06868
+  tps: 1251.2242
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1690.95949
-  tps: 1240.59062
+  dps: 1690.75257
+  tps: 1240.48753
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1752.5182
-  tps: 1285.46611
+  dps: 1752.39491
+  tps: 1285.43003
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1712.89116
-  tps: 1257.15438
+  dps: 1712.76734
+  tps: 1257.12243
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DirebrewHops-38288"
  value: {
-  dps: 1738.41589
-  tps: 1275.50681
+  dps: 1738.2926
+  tps: 1275.47552
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 1718.25922
-  tps: 1261.08591
+  dps: 1718.13593
+  tps: 1261.05337
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1612.62469
-  tps: 1185.81756
+  dps: 1612.50149
+  tps: 1185.797
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1612.62469
-  tps: 1185.81756
+  dps: 1612.50149
+  tps: 1185.797
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1612.62469
-  tps: 1185.81756
+  dps: 1612.50149
+  tps: 1185.797
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 1722.93541
-  tps: 1263.55583
+  dps: 1722.81212
+  tps: 1263.51243
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Earthstrike-21180"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1744.73599
-  tps: 1305.18116
+  dps: 1744.6127
+  tps: 1305.14547
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1721.77421
-  tps: 1263.69453
+  dps: 1721.65092
+  tps: 1263.66182
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1738.41589
-  tps: 1275.50681
+  dps: 1738.2926
+  tps: 1275.47552
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1741.56482
-  tps: 1277.61202
+  dps: 1741.44153
+  tps: 1277.57474
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EyeofMoam-21473"
  value: {
-  dps: 1709.03635
-  tps: 1254.40954
+  dps: 1708.91306
+  tps: 1254.3762
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 1757.12133
-  tps: 1289.10013
+  dps: 1756.99804
+  tps: 1289.06286
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1737.85106
-  tps: 1275.22574
+  dps: 1737.72761
+  tps: 1275.19235
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1534.4919
-  tps: 1128.7004
+  dps: 1534.37865
+  tps: 1128.67934
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-FrostscytheofLordAhune-278953"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 1737.93099
-  tps: 1275.16667
+  dps: 1737.8077
+  tps: 1275.136
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 1703.38546
-  tps: 1250.34789
+  dps: 1703.26212
+  tps: 1250.31704
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HandofJustice-11815"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 1703.75967
-  tps: 1250.61357
+  dps: 1703.63631
+  tps: 1250.58271
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 1707.00909
-  tps: 1252.58459
+  dps: 1706.88547
+  tps: 1252.55424
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Heartrazor-29962"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 1712.02518
-  tps: 1255.95606
+  dps: 1711.90189
+  tps: 1255.91942
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1774.69321
-  tps: 1301.59127
+  dps: 1774.56991
+  tps: 1301.5625
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 1716.67253
-  tps: 1259.85783
+  dps: 1716.54924
+  tps: 1259.82529
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-IceGuard-2682"
  value: {
-  dps: 1743.3853
-  tps: 1279.12841
+  dps: 1743.262
+  tps: 1279.09534
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1650.79531
-  tps: 1211.40987
+  dps: 1650.67202
+  tps: 1211.37421
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-IncarnateRegalia"
  value: {
-  dps: 1613.04995
-  tps: 1179.52378
+  dps: 1612.60184
+  tps: 1179.25235
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-InfinityBlade-30312"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-JomGabbar-23570"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1558.62296
-  tps: 1147.03717
+  dps: 1558.47254
+  tps: 1146.99351
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 1723.15784
-  tps: 1264.13723
+  dps: 1723.01445
+  tps: 1264.08789
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1727.35141
-  tps: 1266.38121
+  dps: 1727.22811
+  tps: 1266.34555
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1729.32698
-  tps: 1270.09368
+  dps: 1729.20251
+  tps: 1270.06423
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1726.6024
-  tps: 1266.98763
+  dps: 1726.47911
+  tps: 1266.9571
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-NetherweaveVestments"
  value: {
-  dps: 1582.86787
-  tps: 1164.96947
+  dps: 1582.74474
+  tps: 1164.94189
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 1726.81402
-  tps: 1267.18639
+  dps: 1726.69072
+  tps: 1267.15575
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1734.23238
-  tps: 1272.64702
+  dps: 1734.1091
+  tps: 1272.61376
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1734.23238
-  tps: 1272.64702
+  dps: 1734.1091
+  tps: 1272.61376
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1734.23238
-  tps: 1272.64702
+  dps: 1734.1091
+  tps: 1272.61376
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1734.23238
-  tps: 1272.64702
+  dps: 1734.1091
+  tps: 1272.61376
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1734.23238
-  tps: 1272.64702
+  dps: 1734.1091
+  tps: 1272.61376
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1704.08162
-  tps: 1249.6456
+  dps: 1703.95824
+  tps: 1249.60566
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PrimalMooncloth"
  value: {
-  dps: 1673.98558
-  tps: 1226.84999
+  dps: 1673.86236
+  tps: 1226.80436
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Prismcharm-15867"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1741.99972
-  tps: 1277.72602
+  dps: 1741.51426
+  tps: 1277.42348
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-RuneofForce-25994"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SavageGuard-2681"
  value: {
-  dps: 1743.3853
-  tps: 1279.12841
+  dps: 1743.262
+  tps: 1279.09534
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 1718.5719
-  tps: 1261.20787
+  dps: 1718.44861
+  tps: 1261.17532
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 1729.32698
-  tps: 1270.09368
+  dps: 1729.20251
+  tps: 1270.06423
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1720.70839
-  tps: 1262.73822
+  dps: 1720.58509
+  tps: 1262.7095
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1724.32397
-  tps: 1265.28839
+  dps: 1724.20039
+  tps: 1265.25522
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1719.16522
-  tps: 1262.02288
+  dps: 1719.04202
+  tps: 1261.99507
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1718.42903
-  tps: 1261.07798
+  dps: 1718.30551
+  tps: 1261.0507
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1784.11928
-  tps: 1309.28834
+  dps: 1783.99361
+  tps: 1309.2549
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1592.9353
-  tps: 1171.10005
+  dps: 1592.81208
+  tps: 1171.06718
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1681.25343
-  tps: 1234.75571
+  dps: 1681.13014
+  tps: 1234.72865
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 1717.65092
-  tps: 1260.55585
+  dps: 1717.52763
+  tps: 1260.52497
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 1711.23067
-  tps: 1256.02533
+  dps: 1711.10738
+  tps: 1255.9893
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 1712.49261
-  tps: 1256.91202
+  dps: 1712.36932
+  tps: 1256.87862
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 1723.76585
-  tps: 1264.92096
+  dps: 1723.64256
+  tps: 1264.89182
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 1712.63668
-  tps: 1256.97165
+  dps: 1712.51338
+  tps: 1256.93911
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1721.0652
-  tps: 1252.70034
+  dps: 1720.94175
+  tps: 1252.66599
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1751.88794
-  tps: 1285.17924
+  dps: 1751.76464
+  tps: 1285.14495
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1760.46114
-  tps: 1291.66395
+  dps: 1760.33628
+  tps: 1291.63415
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 1725.2204
-  tps: 1265.07797
+  dps: 1725.0971
+  tps: 1265.04112
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-UnitingCharm-25633"
  value: {
-  dps: 1702.36359
-  tps: 1249.62236
+  dps: 1702.2403
+  tps: 1249.59154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 1721.36552
-  tps: 1263.203
+  dps: 1720.87072
+  tps: 1262.90901
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 1718.64041
-  tps: 1260.62542
+  dps: 1718.51711
+  tps: 1260.59048
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-WhitemendWisdom"
  value: {
-  dps: 1637.79511
-  tps: 1202.32884
+  dps: 1637.6725
+  tps: 1202.29468
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 1751.58935
-  tps: 1285.01405
+  dps: 1751.46606
+  tps: 1284.97834
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-WrathofSpellfire"
  value: {
-  dps: 1630.18394
-  tps: 1198.28158
+  dps: 1629.97178
+  tps: 1198.19568
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 1707.00909
-  tps: 1252.58459
+  dps: 1706.88547
+  tps: 1252.55424
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1725.74923
-  tps: 1266.33607
+  dps: 1725.62568
+  tps: 1266.30167
  }
 }
 dps_results: {
  key: "TestShadowPriest-Average-Default"
  value: {
-  dps: 1753.74654
-  tps: 1286.96034
+  dps: 1753.57682
+  tps: 1286.88592
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1773.15341
-  tps: 1765.01996
+  dps: 1773.00433
+  tps: 1765.70936
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1773.15341
-  tps: 1299.65717
+  dps: 1773.00433
+  tps: 1299.60399
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1982.84659
-  tps: 1395.68911
+  dps: 1982.6314
+  tps: 1395.59682
  }
 }
 dps_results: {
@@ -1239,22 +1239,22 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1774.3887
-  tps: 1638.74543
+  dps: 1774.236
+  tps: 1638.85169
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1774.3887
-  tps: 1290.01793
+  dps: 1774.236
+  tps: 1289.9357
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1971.17219
-  tps: 1384.18982
+  dps: 1970.95764
+  tps: 1384.10561
  }
 }
 dps_results: {
@@ -1281,22 +1281,22 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1738.34981
-  tps: 1745.18023
+  dps: 1738.24114
+  tps: 1745.67719
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1738.34981
-  tps: 1274.53319
+  dps: 1738.24114
+  tps: 1274.49838
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1944.91662
-  tps: 1368.03897
+  dps: 1944.74514
+  tps: 1367.97259
  }
 }
 dps_results: {
@@ -1323,22 +1323,22 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1739.55465
-  tps: 1610.58422
+  dps: 1739.44238
+  tps: 1610.55185
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1739.55465
-  tps: 1264.48371
+  dps: 1739.44238
+  tps: 1264.4225
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1933.39089
-  tps: 1356.80884
+  dps: 1933.21985
+  tps: 1356.7464
  }
 }
 dps_results: {
@@ -1365,22 +1365,22 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1793.66517
-  tps: 1793.08847
+  dps: 1793.56868
+  tps: 1793.63365
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1793.66517
-  tps: 1315.19276
+  dps: 1793.56868
+  tps: 1315.1689
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2028.73515
-  tps: 1429.97993
+  dps: 2028.57472
+  tps: 1429.93834
  }
 }
 dps_results: {
@@ -1407,22 +1407,22 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1798.84276
-  tps: 1681.46217
+  dps: 1798.74234
+  tps: 1681.59102
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1798.84276
-  tps: 1308.8313
+  dps: 1798.74234
+  tps: 1308.78657
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2045.72981
-  tps: 1440.82258
+  dps: 2045.56897
+  tps: 1440.77445
  }
 }
 dps_results: {
@@ -1449,22 +1449,22 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1758.24292
-  tps: 1775.60412
+  dps: 1758.11962
+  tps: 1776.27424
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1758.24292
-  tps: 1289.7558
+  dps: 1758.11962
+  tps: 1289.71963
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1990.15525
-  tps: 1402.3646
+  dps: 1989.96553
+  tps: 1402.30097
  }
 }
 dps_results: {
@@ -1491,22 +1491,22 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1763.61027
-  tps: 1649.57495
+  dps: 1763.48299
+  tps: 1649.35219
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1763.61027
-  tps: 1282.83502
+  dps: 1763.48299
+  tps: 1282.75414
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2007.04436
-  tps: 1412.94539
+  dps: 2006.85389
+  tps: 1412.8774
  }
 }
 dps_results: {
@@ -1533,22 +1533,22 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1809.42477
-  tps: 1811.2273
+  dps: 1809.30078
+  tps: 1811.73289
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1809.42477
-  tps: 1327.26062
+  dps: 1809.30078
+  tps: 1327.21561
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2080.63702
-  tps: 1469.59545
+  dps: 2080.44604
+  tps: 1469.52829
  }
 }
 dps_results: {
@@ -1575,22 +1575,22 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1783.55882
-  tps: 1651.54474
+  dps: 1783.43228
+  tps: 1651.63231
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1783.55882
-  tps: 1296.83141
+  dps: 1783.43228
+  tps: 1296.76645
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2014.87132
-  tps: 1415.26997
+  dps: 2014.68263
+  tps: 1415.20091
  }
 }
 dps_results: {
@@ -1617,22 +1617,22 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1773.76823
-  tps: 1790.46069
+  dps: 1773.61735
+  tps: 1791.3278
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1773.76823
-  tps: 1301.49462
+  dps: 1773.61735
+  tps: 1301.44906
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2041.17641
-  tps: 1441.37627
+  dps: 2040.95569
+  tps: 1441.29956
  }
 }
 dps_results: {
@@ -1659,22 +1659,22 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1748.2326
-  tps: 1620.48593
+  dps: 1748.07951
+  tps: 1620.31155
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1748.2326
-  tps: 1270.80999
+  dps: 1748.07951
+  tps: 1270.71358
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1975.80625
-  tps: 1386.9916
+  dps: 1975.58848
+  tps: 1386.89493
  }
 }
 dps_results: {
@@ -1701,7 +1701,7 @@ dps_results: {
 dps_results: {
  key: "TestShadowPriest-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1752.37207
-  tps: 1289.29356
+  dps: 1752.25226
+  tps: 1289.25784
  }
 }

--- a/sim/priest/TestShadowPriest.results
+++ b/sim/priest/TestShadowPriest.results
@@ -3,10 +3,10 @@ character_stats_results: {
  value: {
   final_stats: 178
   final_stats: 174
-  final_stats: 578
+  final_stats: 579
   final_stats: 345
-  final_stats: 898.9
-  final_stats: 885.9
+  final_stats: 897.3
+  final_stats: 884.3
   final_stats: 0
   final_stats: 0
   final_stats: 233
@@ -17,7 +17,7 @@ character_stats_results: {
   final_stats: 132
   final_stats: 0
   final_stats: 0
-  final_stats: 269
+  final_stats: 253
   final_stats: 848.1
   final_stats: 389
   final_stats: 0
@@ -34,7 +34,7 @@ character_stats_results: {
   final_stats: 27
   final_stats: 3044
   final_stats: 0
-  final_stats: 10161
+  final_stats: 10171
   final_stats: 7515
   final_stats: 122.5
   final_stats: 33
@@ -55,1653 +55,1653 @@ character_stats_results: {
 dps_results: {
  key: "TestShadowPriest-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AbsolutionRegalia"
  value: {
-  dps: 1717.68008
-  tps: 1255.6826
+  dps: 1716.53218
+  tps: 1255.14327
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 1737.8077
-  tps: 1275.136
+  dps: 1736.72714
+  tps: 1274.6163
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 1719.77303
-  tps: 1262.12648
+  dps: 1718.69095
+  tps: 1261.59451
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 1731.15762
-  tps: 1270.47169
+  dps: 1730.07707
+  tps: 1269.94066
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1611.04116
-  tps: 1184.46693
+  dps: 1609.96124
+  tps: 1183.96394
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1537.44082
-  tps: 1130.85695
+  dps: 1536.46618
+  tps: 1130.4355
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AshtongueTalismanofAcumen-32490"
  value: {
-  dps: 1747.05292
-  tps: 1281.45528
+  dps: 1745.97237
+  tps: 1280.93869
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-AvatarRegalia"
  value: {
-  dps: 1642.2769
-  tps: 1203.47228
+  dps: 1641.19654
+  tps: 1202.94027
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1731.10577
-  tps: 1270.41921
+  dps: 1730.02521
+  tps: 1269.88901
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 1751.28783
-  tps: 1284.23836
+  dps: 1750.20708
+  tps: 1283.67107
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1767.22269
-  tps: 1296.19196
+  dps: 1766.13944
+  tps: 1295.65503
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 1704.71645
-  tps: 1250.98435
+  dps: 1703.6359
+  tps: 1250.45838
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BattlecastGarb"
  value: {
-  dps: 1665.89049
-  tps: 1223.67366
+  dps: 1664.81757
+  tps: 1223.17719
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 1736.29128
-  tps: 1275.26213
+  dps: 1735.1886
+  tps: 1274.71883
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 1736.29128
-  tps: 1275.26213
+  dps: 1735.1886
+  tps: 1274.71883
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1733.98158
-  tps: 1272.26827
+  dps: 1732.90102
+  tps: 1271.74937
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1708.00603
-  tps: 1253.72856
+  dps: 1706.92239
+  tps: 1253.20181
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1722.50069
-  tps: 1264.07104
+  dps: 1721.42014
+  tps: 1263.54218
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1734.1091
-  tps: 1272.61376
+  dps: 1733.02874
+  tps: 1272.07759
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1748.66477
-  tps: 1282.93294
+  dps: 1747.58422
+  tps: 1282.40666
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1705.06868
-  tps: 1251.2242
+  dps: 1703.92163
+  tps: 1250.67073
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1690.75257
-  tps: 1240.48753
+  dps: 1689.67265
+  tps: 1239.9387
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1752.39491
-  tps: 1285.43003
+  dps: 1751.31435
+  tps: 1284.88796
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1712.76734
-  tps: 1257.12243
+  dps: 1711.68115
+  tps: 1256.5905
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DirebrewHops-38288"
  value: {
-  dps: 1738.2926
-  tps: 1275.47552
+  dps: 1737.21205
+  tps: 1274.95643
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 1718.13593
-  tps: 1261.05337
+  dps: 1717.05538
+  tps: 1260.52517
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1612.50149
-  tps: 1185.797
+  dps: 1611.42191
+  tps: 1185.30325
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1612.50149
-  tps: 1185.797
+  dps: 1611.42191
+  tps: 1185.30325
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1612.50149
-  tps: 1185.797
+  dps: 1611.42191
+  tps: 1185.30325
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 1722.81212
-  tps: 1263.51243
+  dps: 1721.73157
+  tps: 1262.92678
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Earthstrike-21180"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1744.6127
-  tps: 1305.14547
+  dps: 1743.53214
+  tps: 1304.615
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1721.65092
-  tps: 1263.66182
+  dps: 1720.57037
+  tps: 1263.13145
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1738.2926
-  tps: 1275.47552
+  dps: 1737.21205
+  tps: 1274.95643
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1741.44153
-  tps: 1277.57474
+  dps: 1740.36097
+  tps: 1277.05154
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EyeofMoam-21473"
  value: {
-  dps: 1708.91306
-  tps: 1254.3762
+  dps: 1707.83251
+  tps: 1253.85415
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 1756.99804
-  tps: 1289.06286
+  dps: 1755.91749
+  tps: 1288.54096
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1737.72761
-  tps: 1275.19235
+  dps: 1736.64534
+  tps: 1274.65483
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1534.37865
-  tps: 1128.67934
+  dps: 1533.406
+  tps: 1128.25194
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-FrostscytheofLordAhune-278953"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 1737.8077
-  tps: 1275.136
+  dps: 1736.72714
+  tps: 1274.6163
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 1703.26212
-  tps: 1250.31704
+  dps: 1702.18103
+  tps: 1249.81092
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HandofJustice-11815"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 1703.63631
-  tps: 1250.58271
+  dps: 1702.55502
+  tps: 1250.07645
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 1706.88547
-  tps: 1252.55424
+  dps: 1705.80114
+  tps: 1252.04034
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Heartrazor-29962"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 1711.90189
-  tps: 1255.91942
+  dps: 1710.82134
+  tps: 1255.37453
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1774.56991
-  tps: 1301.5625
+  dps: 1773.48936
+  tps: 1301.01745
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 1716.54924
-  tps: 1259.82529
+  dps: 1715.46869
+  tps: 1259.29565
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-IceGuard-2682"
  value: {
-  dps: 1743.262
-  tps: 1279.09534
+  dps: 1742.18145
+  tps: 1278.58008
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1650.67202
-  tps: 1211.37421
+  dps: 1649.59146
+  tps: 1210.85022
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-IncarnateRegalia"
  value: {
-  dps: 1612.60184
-  tps: 1179.25235
+  dps: 1611.43657
+  tps: 1178.66558
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-InfinityBlade-30312"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-JomGabbar-23570"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1558.47254
-  tps: 1146.99351
+  dps: 1557.39106
+  tps: 1146.50462
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 1723.01445
-  tps: 1264.08789
+  dps: 1721.9203
+  tps: 1263.56609
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1727.22811
-  tps: 1266.34555
+  dps: 1726.14756
+  tps: 1265.81556
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1729.20251
-  tps: 1270.06423
+  dps: 1728.10462
+  tps: 1269.55535
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1726.47911
-  tps: 1266.9571
+  dps: 1725.39856
+  tps: 1266.44451
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-NetherweaveVestments"
  value: {
-  dps: 1582.74474
-  tps: 1164.94189
+  dps: 1581.66594
+  tps: 1164.43627
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 1726.69072
-  tps: 1267.15575
+  dps: 1725.61017
+  tps: 1266.62505
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1734.1091
-  tps: 1272.61376
+  dps: 1733.02874
+  tps: 1272.07759
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1734.1091
-  tps: 1272.61376
+  dps: 1733.02874
+  tps: 1272.07759
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1734.1091
-  tps: 1272.61376
+  dps: 1733.02874
+  tps: 1272.07759
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1734.1091
-  tps: 1272.61376
+  dps: 1733.02874
+  tps: 1272.07759
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1734.1091
-  tps: 1272.61376
+  dps: 1733.02874
+  tps: 1272.07759
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1703.95824
-  tps: 1249.60566
+  dps: 1702.87675
+  tps: 1249.04273
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PrimalMooncloth"
  value: {
-  dps: 1673.86236
-  tps: 1226.80436
+  dps: 1672.78259
+  tps: 1226.24653
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Prismcharm-15867"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1741.51426
-  tps: 1277.42348
+  dps: 1740.36477
+  tps: 1276.84526
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-RuneofForce-25994"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SavageGuard-2681"
  value: {
-  dps: 1743.262
-  tps: 1279.09534
+  dps: 1742.18145
+  tps: 1278.58008
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 1718.44861
-  tps: 1261.17532
+  dps: 1717.36806
+  tps: 1260.6483
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 1729.20251
-  tps: 1270.06423
+  dps: 1728.10462
+  tps: 1269.55535
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1720.58509
-  tps: 1262.7095
+  dps: 1719.50454
+  tps: 1262.18111
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1724.20039
-  tps: 1265.25522
+  dps: 1723.11675
+  tps: 1264.72613
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1719.04202
-  tps: 1261.99507
+  dps: 1717.96244
+  tps: 1261.48816
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1718.30551
-  tps: 1261.0507
+  dps: 1717.22245
+  tps: 1260.52942
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1783.99361
-  tps: 1309.2549
+  dps: 1782.88674
+  tps: 1308.71055
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1592.81208
-  tps: 1171.06718
+  dps: 1591.73231
+  tps: 1170.55824
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1681.13014
-  tps: 1234.72865
+  dps: 1680.04958
+  tps: 1234.21445
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 1717.52763
-  tps: 1260.52497
+  dps: 1716.44707
+  tps: 1259.99465
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 1711.10738
-  tps: 1255.9893
+  dps: 1710.02683
+  tps: 1255.47408
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 1712.36932
-  tps: 1256.87862
+  dps: 1711.28876
+  tps: 1256.3591
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 1723.64256
-  tps: 1264.89182
+  dps: 1722.56201
+  tps: 1264.37092
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 1712.51338
-  tps: 1256.93911
+  dps: 1711.43283
+  tps: 1256.41248
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1720.94175
-  tps: 1252.66599
+  dps: 1719.85898
+  tps: 1252.1301
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1751.76464
-  tps: 1285.14495
+  dps: 1750.68409
+  tps: 1284.62059
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1760.33628
-  tps: 1291.63415
+  dps: 1759.23966
+  tps: 1291.10038
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 1725.0971
-  tps: 1265.04112
+  dps: 1724.01655
+  tps: 1264.52119
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-UnitingCharm-25633"
  value: {
-  dps: 1702.2403
-  tps: 1249.59154
+  dps: 1701.15974
+  tps: 1249.0858
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 1720.87072
-  tps: 1262.90901
+  dps: 1719.78806
+  tps: 1262.3917
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 1718.51711
-  tps: 1260.59048
+  dps: 1717.43656
+  tps: 1260.0475
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-WhitemendWisdom"
  value: {
-  dps: 1637.6725
-  tps: 1202.29468
+  dps: 1636.59997
+  tps: 1201.77585
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 1751.46606
-  tps: 1284.97834
+  dps: 1750.3855
+  tps: 1284.454
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-WrathofSpellfire"
  value: {
-  dps: 1629.97178
-  tps: 1198.19568
+  dps: 1628.88624
+  tps: 1197.68111
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 1706.88547
-  tps: 1252.55424
+  dps: 1705.80114
+  tps: 1252.04034
  }
 }
 dps_results: {
  key: "TestShadowPriest-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1725.62568
-  tps: 1266.30167
+  dps: 1724.54244
+  tps: 1265.78536
  }
 }
 dps_results: {
  key: "TestShadowPriest-Average-Default"
  value: {
-  dps: 1753.57682
-  tps: 1286.88592
+  dps: 1752.49836
+  tps: 1286.33568
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1773.00433
-  tps: 1765.70936
+  dps: 1771.93275
+  tps: 1769.80148
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1773.00433
-  tps: 1299.60399
+  dps: 1771.93275
+  tps: 1299.0666
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1982.6314
-  tps: 1395.59682
+  dps: 1981.47242
+  tps: 1394.87324
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 720.72001
-  tps: 778.19954
+  dps: 711.86382
+  tps: 769.66996
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 720.72001
-  tps: 535.00274
+  dps: 711.86382
+  tps: 528.45056
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 1033.04461
-  tps: 753.84173
+  tps: 753.89335
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1774.236
-  tps: 1638.85169
+  dps: 1773.1642
+  tps: 1639.55106
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1774.236
-  tps: 1289.9357
+  dps: 1773.1642
+  tps: 1289.22951
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1970.95764
-  tps: 1384.10561
+  dps: 1969.80411
+  tps: 1383.41334
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-test-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 567.62357
-  tps: 503.45507
+  dps: 561.47241
+  tps: 499.22583
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-test-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 567.62357
-  tps: 414.61764
+  dps: 561.47241
+  tps: 410.11113
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-p1-Shadow-test-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 1022.76531
-  tps: 743.97545
+  tps: 744.01922
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1738.24114
-  tps: 1745.67719
+  dps: 1737.10571
+  tps: 1749.12746
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1738.24114
-  tps: 1274.49838
+  dps: 1737.10571
+  tps: 1273.8847
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1944.74514
-  tps: 1367.97259
+  dps: 1943.51716
+  tps: 1367.21341
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 623.6325
-  tps: 708.12844
+  dps: 617.62092
+  tps: 700.65454
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 623.6325
-  tps: 463.67076
+  dps: 617.62092
+  tps: 459.1874
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 1009.91943
-  tps: 737.27028
+  tps: 737.31419
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1739.44238
-  tps: 1610.55185
+  dps: 1738.30672
+  tps: 1610.79098
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1739.44238
-  tps: 1264.4225
+  dps: 1738.30672
+  tps: 1263.64916
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1933.21985
-  tps: 1356.7464
+  dps: 1931.99767
+  tps: 1355.98546
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-test-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 483.18213
-  tps: 442.34089
+  dps: 476.21422
+  tps: 437.48216
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-test-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 483.18213
-  tps: 352.70047
+  dps: 476.21422
+  tps: 347.59219
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Dwarf-pre_raid-Shadow-test-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 999.0792
-  tps: 727.00801
+  tps: 727.04742
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1793.56868
-  tps: 1793.63365
+  dps: 1792.41731
+  tps: 1798.16015
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1793.56868
-  tps: 1315.1689
+  dps: 1792.41731
+  tps: 1314.59795
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2028.57472
-  tps: 1429.93834
+  dps: 2027.31651
+  tps: 1429.228
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 723.10079
-  tps: 779.59409
+  dps: 713.85298
+  tps: 770.28917
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 723.10079
-  tps: 536.74507
+  dps: 713.85298
+  tps: 529.8947
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 1084.899
-  tps: 793.25906
+  tps: 793.3146
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1798.74234
-  tps: 1681.59102
+  dps: 1797.58836
+  tps: 1682.47583
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1798.74234
-  tps: 1308.78657
+  dps: 1797.58836
+  tps: 1308.03282
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2045.56897
-  tps: 1440.77445
+  dps: 2044.29675
+  tps: 1440.013
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-test-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 564.92469
-  tps: 516.52321
+  dps: 559.04834
+  tps: 512.51638
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-test-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 564.92469
-  tps: 413.30108
+  dps: 559.04834
+  tps: 408.99758
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-p1-Shadow-test-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 1090.58004
-  tps: 795.82064
+  tps: 795.86748
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1758.11962
-  tps: 1776.27424
+  dps: 1757.03907
+  tps: 1780.60707
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1758.11962
-  tps: 1289.71963
+  dps: 1757.03907
+  tps: 1289.18805
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1989.96553
-  tps: 1402.30097
+  dps: 1988.78471
+  tps: 1401.60913
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 622.66484
-  tps: 704.41288
+  dps: 618.6538
+  tps: 703.92607
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 622.66484
-  tps: 462.89576
+  dps: 618.6538
+  tps: 459.99989
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 1060.99785
-  tps: 776.15257
+  tps: 776.20014
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1763.48299
-  tps: 1649.35219
+  dps: 1762.39988
+  tps: 1648.97407
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1763.48299
-  tps: 1282.75414
+  dps: 1762.39988
+  tps: 1281.98627
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2006.85389
-  tps: 1412.8774
+  dps: 2005.65974
+  tps: 1412.15592
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-test-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 487.16603
-  tps: 460.44188
+  dps: 479.82091
+  tps: 455.31329
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-test-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 487.16603
-  tps: 356.30301
+  dps: 479.82091
+  tps: 350.91785
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Troll-pre_raid-Shadow-test-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 1065.84382
-  tps: 778.10313
+  tps: 778.14365
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1809.30078
-  tps: 1811.73289
+  dps: 1808.21083
+  tps: 1815.30185
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1809.30078
-  tps: 1327.21561
+  dps: 1808.21083
+  tps: 1326.63923
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2080.44604
-  tps: 1469.52829
+  dps: 2079.23953
+  tps: 1468.79227
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 741.29641
-  tps: 794.32879
+  dps: 730.81886
+  tps: 785.99456
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 741.29641
-  tps: 550.14773
+  dps: 730.81886
+  tps: 542.4333
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 1113.01712
-  tps: 814.30936
+  tps: 814.35544
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1783.43228
-  tps: 1651.63231
+  dps: 1782.35554
+  tps: 1652.44539
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1783.43228
-  tps: 1296.76645
+  dps: 1782.35554
+  tps: 1296.06254
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2014.68263
-  tps: 1415.20091
+  dps: 2013.50285
+  tps: 1414.48329
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-test-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 570.16213
-  tps: 512.5447
+  dps: 563.67471
+  tps: 508.02439
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-test-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 570.16213
-  tps: 416.79769
+  dps: 563.67471
+  tps: 412.04184
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-p1-Shadow-test-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 1055.17353
-  tps: 768.73811
+  tps: 768.77531
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1773.61735
-  tps: 1791.3278
+  dps: 1772.53049
+  tps: 1795.81271
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1773.61735
-  tps: 1301.44906
+  dps: 1772.53049
+  tps: 1300.92063
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2040.95569
-  tps: 1441.29956
+  dps: 2039.7527
+  tps: 1440.57847
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 632.78025
-  tps: 708.56241
+  dps: 628.30106
+  tps: 704.87376
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 632.78025
-  tps: 470.26086
+  dps: 628.30106
+  tps: 466.96024
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 1088.37337
-  tps: 796.66198
+  tps: 796.70524
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-test-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1748.07951
-  tps: 1620.31155
+  dps: 1747.0059
+  tps: 1620.18247
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-test-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1748.07951
-  tps: 1270.71358
+  dps: 1747.0059
+  tps: 1269.96475
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-test-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1975.58848
-  tps: 1386.89493
+  dps: 1974.41223
+  tps: 1386.15853
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-test-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 485.62876
-  tps: 451.29074
+  dps: 479.86345
+  tps: 447.28171
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-test-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 485.62876
-  tps: 354.81
+  dps: 479.86345
+  tps: 350.58392
  }
 }
 dps_results: {
  key: "TestShadowPriest-Settings-Undead-pre_raid-Shadow-test-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 1031.12582
-  tps: 751.49605
+  tps: 751.53032
  }
 }
 dps_results: {
  key: "TestShadowPriest-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1752.25226
-  tps: 1289.25784
+  dps: 1751.17303
+  tps: 1288.73715
  }
 }

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestRogue-CharacterStats-Default"
  value: {
-  final_stats: 240.68
-  final_stats: 622.0929
-  final_stats: 581.8384
-  final_stats: 114.29
-  final_stats: 234.5009
-  final_stats: 221.5009
+  final_stats: 238
+  final_stats: 620
+  final_stats: 580
+  final_stats: 113
+  final_stats: 234.3
+  final_stats: 221.3
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 185.009
-  final_stats: 2996.70019
+  final_stats: 183
+  final_stats: 2990.9
   final_stats: 1359
   final_stats: 0
   final_stats: 316
@@ -32,20 +32,20 @@ character_stats_results: {
   final_stats: 56.76924
   final_stats: 0
   final_stats: 0
-  final_stats: 4715.5858
+  final_stats: 4711
   final_stats: 0
-  final_stats: 10512.384
+  final_stats: 10494
   final_stats: 0
-  final_stats: 122.7
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
+  final_stats: 122.5
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
   final_stats: 70
   final_stats: 5
   final_stats: 26.03902
   final_stats: 4
-  final_stats: 32.45941
+  final_stats: 32.40709
   final_stats: 12.17422
   final_stats: 0
   final_stats: 0
@@ -55,1422 +55,1422 @@ character_stats_results: {
 dps_results: {
  key: "TestRogue-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 1840.02259
-  tps: 1306.41604
+  dps: 1837.3347
+  tps: 1304.50764
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 1815.84541
-  tps: 1289.25024
+  dps: 1812.57133
+  tps: 1286.92564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1649.16578
-  tps: 1170.90771
+  dps: 1646.84453
+  tps: 1169.25962
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-AssassinationArmor"
  value: {
-  dps: 1607.45517
-  tps: 1141.29317
+  dps: 1605.35051
+  tps: 1139.79886
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1845.29782
-  tps: 1310.16145
+  dps: 1842.34545
+  tps: 1308.06527
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1843.69959
-  tps: 1309.02671
+  dps: 1840.35218
+  tps: 1306.65005
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1893.92068
-  tps: 1344.68369
+  dps: 1891.16436
+  tps: 1342.7267
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 1837.84538
-  tps: 1304.87022
+  dps: 1835.1445
+  tps: 1302.95259
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1837.84538
-  tps: 1304.87022
+  dps: 1835.1445
+  tps: 1302.95259
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BattlecastGarb"
  value: {
-  dps: 1620.90253
-  tps: 1150.84079
+  dps: 1618.60315
+  tps: 1149.20823
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1838.86917
-  tps: 1305.59711
+  dps: 1836.62934
+  tps: 1304.00683
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1845.5315
-  tps: 1310.32736
+  dps: 1842.23364
+  tps: 1307.98589
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1880.10581
-  tps: 1334.87513
+  dps: 1876.76134
+  tps: 1332.50055
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1912.55694
-  tps: 1357.91543
+  dps: 1910.06194
+  tps: 1356.14398
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1843.21839
-  tps: 1308.68506
+  dps: 1841.10729
+  tps: 1307.18618
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 1626.99942
-  tps: 1155.16959
+  dps: 1624.83973
+  tps: 1153.63621
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1839.91588
-  tps: 1306.34027
+  dps: 1837.62072
+  tps: 1304.71071
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1717.67255
-  tps: 1219.54751
+  dps: 1714.95243
+  tps: 1217.61623
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1852.24586
-  tps: 1315.09456
+  dps: 1848.93207
+  tps: 1312.74177
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1717.67255
-  tps: 1219.54751
+  dps: 1714.95243
+  tps: 1217.61623
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1850.87615
-  tps: 1314.12206
+  dps: 1847.56711
+  tps: 1311.77265
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1859.48976
-  tps: 1320.23773
+  dps: 1856.18362
+  tps: 1317.89037
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1834.19188
-  tps: 1302.27623
+  dps: 1831.98429
+  tps: 1300.70885
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Deathmantle"
  value: {
-  dps: 1763.14062
-  tps: 1251.82984
+  dps: 1760.57743
+  tps: 1250.00997
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DirebrewHops-38288"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DonSantos'FamousHuntingRifle-31323"
  value: {
-  dps: 1847.54475
-  tps: 1311.75677
+  dps: 1845.41236
+  tps: 1310.24277
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1828.83123
-  tps: 1298.47018
+  dps: 1826.15241
+  tps: 1296.56821
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1919.01122
-  tps: 1362.49797
+  dps: 1916.49423
+  tps: 1360.7109
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1849.78967
-  tps: 1313.35066
+  dps: 1847.72162
+  tps: 1311.88235
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1815.9676
-  tps: 1289.337
+  dps: 1813.15847
+  tps: 1287.34251
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Earthstrike-21180"
  value: {
-  dps: 1839.74071
-  tps: 1306.21591
+  dps: 1836.43268
+  tps: 1303.8672
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnchantBoots-Boar'sSpeed-2940"
  value: {
-  dps: 1859.43536
-  tps: 1320.1991
+  dps: 1857.28518
+  tps: 1318.67248
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 1855.70983
-  tps: 1291.2029
+  dps: 1853.57633
+  tps: 1289.71841
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1853.28242
-  tps: 1342.14713
+  dps: 1850.93508
+  tps: 1340.44719
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1802.60158
-  tps: 1279.84712
+  dps: 1799.70071
+  tps: 1277.78751
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 1799.55334
-  tps: 1277.68287
+  dps: 1796.65382
+  tps: 1275.62422
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 1840.90724
-  tps: 1307.04414
+  dps: 1837.9157
+  tps: 1304.92015
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeofMoam-21473"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1840.00206
-  tps: 1306.40146
+  dps: 1837.7069
+  tps: 1304.7719
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FelSkin"
  value: {
-  dps: 1743.25385
-  tps: 1237.71024
+  dps: 1740.90307
+  tps: 1236.04118
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1844.97153
-  tps: 1309.92979
+  dps: 1841.66526
+  tps: 1307.58234
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Gladiator'sVestments"
  value: {
-  dps: 1767.88861
-  tps: 1255.20092
+  dps: 1765.97244
+  tps: 1253.84044
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HandofJustice-11815"
  value: {
-  dps: 1861.08783
-  tps: 1321.37236
+  dps: 1858.09657
+  tps: 1319.24857
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Heartrazor-29962"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1854.21447
-  tps: 1316.49228
+  dps: 1851.95662
+  tps: 1314.8892
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IceGuard-2682"
  value: {
-  dps: 1853.71769
-  tps: 1316.13956
+  dps: 1850.39861
+  tps: 1313.78301
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1831.42083
-  tps: 1300.30879
+  dps: 1828.10503
+  tps: 1297.95457
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1601.16271
-  tps: 1136.82552
+  dps: 1599.1543
+  tps: 1135.39956
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-InfinityBlade-30312"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-JomGabbar-23570"
  value: {
-  dps: 1845.90547
-  tps: 1310.59288
+  dps: 1842.58668
+  tps: 1308.23655
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1851.34759
-  tps: 1314.45679
+  dps: 1849.22347
+  tps: 1312.94867
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1865.83832
-  tps: 1324.74521
+  dps: 1862.49896
+  tps: 1322.37426
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1392.76327
-  tps: 988.86192
+  dps: 1390.65784
+  tps: 987.36707
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 1764.86774
-  tps: 1253.0561
+  dps: 1761.77769
+  tps: 1250.86216
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 1815.84541
-  tps: 1289.25024
+  dps: 1812.57133
+  tps: 1286.92564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Netherblade"
  value: {
-  dps: 1723.65068
-  tps: 1223.79198
+  dps: 1721.40718
+  tps: 1222.1991
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-NetherweaveVestments"
  value: {
-  dps: 1433.65122
-  tps: 1017.89236
+  dps: 1431.37238
+  tps: 1016.27439
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 1845.66659
-  tps: 1310.42328
+  dps: 1842.35958
+  tps: 1308.0753
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1839.91588
-  tps: 1306.34027
+  dps: 1837.62072
+  tps: 1304.71071
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1839.91588
-  tps: 1306.34027
+  dps: 1837.62072
+  tps: 1304.71071
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1839.91588
-  tps: 1306.34027
+  dps: 1837.62072
+  tps: 1304.71071
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1839.91588
-  tps: 1306.34027
+  dps: 1837.62072
+  tps: 1304.71071
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1839.91588
-  tps: 1306.34027
+  dps: 1837.62072
+  tps: 1304.71071
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrimalIntent"
  value: {
-  dps: 1835.56952
-  tps: 1303.25436
+  dps: 1833.15579
+  tps: 1301.54061
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrimalMooncloth"
  value: {
-  dps: 1620.01132
-  tps: 1150.20803
+  dps: 1617.21919
+  tps: 1148.22562
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Prismcharm-15867"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 1808.9578
-  tps: 1284.36004
+  dps: 1805.72002
+  tps: 1282.06122
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1764.86774
-  tps: 1253.0561
+  dps: 1761.77769
+  tps: 1250.86216
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1835.16732
-  tps: 1302.9688
+  dps: 1831.89649
+  tps: 1300.64651
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-RuneofForce-25994"
  value: {
-  dps: 1823.56135
-  tps: 1294.72856
+  dps: 1820.27515
+  tps: 1292.39536
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SavageGuard-2681"
  value: {
-  dps: 1853.71769
-  tps: 1316.13956
+  dps: 1850.39861
+  tps: 1313.78301
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1799.76518
-  tps: 1277.83328
+  dps: 1796.50774
+  tps: 1275.52049
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 1847.0483
-  tps: 1311.40429
+  dps: 1844.04685
+  tps: 1309.27326
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1815.84541
-  tps: 1289.25024
+  dps: 1812.57133
+  tps: 1286.92564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1622.83833
-  tps: 1152.21521
+  dps: 1620.2518
+  tps: 1150.37877
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1868.37589
-  tps: 1326.54688
+  dps: 1865.51434
+  tps: 1324.51518
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sArmor"
  value: {
-  dps: 2023.55268
-  tps: 1436.7224
+  dps: 2020.83835
+  tps: 1434.79523
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1861.85561
-  tps: 1321.91748
+  dps: 1858.53098
+  tps: 1319.557
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1612.82945
-  tps: 1145.10891
+  dps: 1610.29628
+  tps: 1143.31036
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1621.05765
-  tps: 1150.95093
+  dps: 1618.75828
+  tps: 1149.31838
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1815.31827
-  tps: 1288.87597
+  dps: 1812.25166
+  tps: 1286.69868
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 1815.84541
-  tps: 1289.25024
+  dps: 1812.57133
+  tps: 1286.92564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 1830.16975
-  tps: 1299.42052
+  dps: 1827.32448
+  tps: 1297.40038
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1601.16271
-  tps: 1136.82552
+  dps: 1599.1543
+  tps: 1135.39956
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1836.4648
-  tps: 1303.89001
+  dps: 1834.37214
+  tps: 1302.40422
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 1824.42581
-  tps: 1295.34233
+  dps: 1821.1376
+  tps: 1293.0077
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 1815.84541
-  tps: 1289.25024
+  dps: 1812.57133
+  tps: 1286.92564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheBladefist-29348"
  value: {
-  dps: 1749.10288
-  tps: 1241.86304
+  dps: 1746.2615
+  tps: 1239.84566
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1815.84541
-  tps: 1289.25024
+  dps: 1812.57133
+  tps: 1286.92564
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2018.04695
-  tps: 1432.81333
+  dps: 2014.87198
+  tps: 1430.55911
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-ThickDraenicArmor"
  value: {
-  dps: 1674.06609
-  tps: 1188.58693
+  dps: 1671.71737
+  tps: 1186.91934
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1861.75726
-  tps: 1321.84766
+  dps: 1859.59149
+  tps: 1320.30996
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-UnitingCharm-25633"
  value: {
-  dps: 1845.66659
-  tps: 1310.42328
+  dps: 1842.35958
+  tps: 1308.0753
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Warp-SpringCoil-30450"
  value: {
-  dps: 1862.48086
-  tps: 1322.36141
+  dps: 1859.11779
+  tps: 1319.97363
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WastewalkerArmor"
  value: {
-  dps: 1652.04024
-  tps: 1172.94857
+  dps: 1648.5735
+  tps: 1170.48719
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WhitemendWisdom"
  value: {
-  dps: 1620.90253
-  tps: 1150.84079
+  dps: 1618.60315
+  tps: 1149.20823
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WindhawkArmor"
  value: {
-  dps: 1654.20396
-  tps: 1174.48481
+  dps: 1651.77421
+  tps: 1172.75969
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 1837.84538
-  tps: 1304.87022
+  dps: 1835.1445
+  tps: 1302.95259
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-WrathofSpellfire"
  value: {
-  dps: 1627.07266
-  tps: 1155.22159
+  dps: 1624.57902
+  tps: 1153.4511
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1815.74544
-  tps: 1289.17926
+  dps: 1812.47135
+  tps: 1286.85466
  }
 }
 dps_results: {
  key: "TestRogue-Average-Default"
  value: {
-  dps: 1872.88235
-  tps: 1329.74647
+  dps: 1870.25682
+  tps: 1327.88234
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-p1-Rogue-swords-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2417.61855
-  tps: 1716.50917
+  dps: 2414.19804
+  tps: 1714.08061
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-p1-Rogue-swords-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2019.03702
-  tps: 1433.51629
+  dps: 2016.25362
+  tps: 1431.54007
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-p1-Rogue-swords-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2278.00217
-  tps: 1617.38154
+  dps: 2274.41034
+  tps: 1614.83134
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-p1-Rogue-swords-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 808.85301
-  tps: 574.28564
+  dps: 808.71996
+  tps: 574.19117
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-p1-Rogue-swords-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 670.12026
-  tps: 475.78538
+  dps: 670.00116
+  tps: 475.70082
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-p1-Rogue-swords-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 700.06904
-  tps: 497.04902
+  dps: 699.99828
+  tps: 496.99878
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-preraid-Rogue-swords-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2244.34541
-  tps: 1593.48524
+  dps: 2240.3751
+  tps: 1590.66632
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-preraid-Rogue-swords-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1866.37677
-  tps: 1325.1275
+  dps: 1863.04758
+  tps: 1322.76378
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-preraid-Rogue-swords-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2114.1555
-  tps: 1501.05041
+  dps: 2109.21043
+  tps: 1497.5394
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-preraid-Rogue-swords-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 728.51554
-  tps: 517.24603
+  dps: 728.31398
+  tps: 517.10292
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-preraid-Rogue-swords-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 599.92773
-  tps: 425.94869
+  dps: 599.7521
+  tps: 425.82399
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Human-preraid-Rogue-swords-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 624.4005
-  tps: 443.32436
+  dps: 624.11792
+  tps: 443.12373
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-p1-Rogue-swords-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2423.52007
-  tps: 1720.69925
+  dps: 2421.25523
+  tps: 1719.09121
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-p1-Rogue-swords-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2011.58709
-  tps: 1428.22683
+  dps: 2009.6702
+  tps: 1426.86584
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-p1-Rogue-swords-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2282.64244
-  tps: 1620.67613
+  dps: 2280.16138
+  tps: 1618.91458
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-p1-Rogue-swords-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 819.25473
-  tps: 581.67086
+  dps: 819.18265
+  tps: 581.61968
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-p1-Rogue-swords-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 671.12405
-  tps: 476.49807
+  dps: 671.06324
+  tps: 476.4549
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-p1-Rogue-swords-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 704.90341
-  tps: 500.48142
+  dps: 704.84668
+  tps: 500.44114
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-preraid-Rogue-swords-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2263.01792
-  tps: 1606.74272
+  dps: 2260.33531
+  tps: 1604.83807
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-preraid-Rogue-swords-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1862.30663
-  tps: 1322.23771
+  dps: 1860.21789
+  tps: 1320.7547
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-preraid-Rogue-swords-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2122.53534
-  tps: 1507.00009
+  dps: 2119.34715
+  tps: 1504.73648
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-preraid-Rogue-swords-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 738.91032
-  tps: 524.62633
+  dps: 738.63161
+  tps: 524.42844
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-preraid-Rogue-swords-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 603.25881
-  tps: 428.31375
+  dps: 603.0481
+  tps: 428.16415
  }
 }
 dps_results: {
  key: "TestRogue-Settings-Orc-preraid-Rogue-swords-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 635.92618
-  tps: 451.50759
+  dps: 635.66152
+  tps: 451.31968
  }
 }
 dps_results: {
  key: "TestRogue-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1702.63491
-  tps: 1208.87078
+  dps: 1700.32344
+  tps: 1207.22965
  }
 }

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -5,8 +5,8 @@ character_stats_results: {
   final_stats: 620
   final_stats: 580
   final_stats: 113
-  final_stats: 233.7
-  final_stats: 220.7
+  final_stats: 234.3
+  final_stats: 221.3
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,7 +17,7 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 177
+  final_stats: 183
   final_stats: 2990.9
   final_stats: 1359
   final_stats: 0

--- a/sim/rogue/TestRogue.results
+++ b/sim/rogue/TestRogue.results
@@ -5,8 +5,8 @@ character_stats_results: {
   final_stats: 620
   final_stats: 580
   final_stats: 113
-  final_stats: 234.3
-  final_stats: 221.3
+  final_stats: 233.7
+  final_stats: 220.7
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,7 +17,7 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 183
+  final_stats: 177
   final_stats: 2990.9
   final_stats: 1359
   final_stats: 0

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestElemental-CharacterStats-Default"
  value: {
-  final_stats: 249.48
-  final_stats: 197.395
-  final_stats: 693.66
-  final_stats: 515.79
-  final_stats: 1188.549
-  final_stats: 1175.549
+  final_stats: 247
+  final_stats: 195
+  final_stats: 691
+  final_stats: 514
+  final_stats: 1188.4
+  final_stats: 1175.4
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 403
   final_stats: 0
   final_stats: 0
-  final_stats: 215.49
-  final_stats: 1529.506
+  final_stats: 214
+  final_stats: 1523.5
   final_stats: 389
   final_stats: 0
   final_stats: 0
@@ -29,24 +29,24 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 115
-  final_stats: 149.41285
+  final_stats: 147.60002
   final_stats: 0
   final_stats: 0
-  final_stats: 10254.19
+  final_stats: 10249
   final_stats: 0
-  final_stats: 11085.6
-  final_stats: 10414.85
-  final_stats: 184.6474
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
+  final_stats: 11059
+  final_stats: 10388
+  final_stats: 184.34
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
   final_stats: 70
   final_stats: 0
   final_stats: 3
   final_stats: 12.25
-  final_stats: 16.74502
-  final_stats: 39.90273
+  final_stats: 16.64922
+  final_stats: 39.88036
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -55,1374 +55,1374 @@ character_stats_results: {
 dps_results: {
  key: "TestElemental-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 1739.54449
-  tps: 1417.62754
+  dps: 1737.27418
+  tps: 1415.27439
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 1724.70774
-  tps: 1404.8433
+  dps: 1723.62931
+  tps: 1403.91231
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 1700.00538
-  tps: 1385.98604
+  dps: 1695.52003
+  tps: 1381.45178
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Annihilator-12798"
  value: {
-  dps: 1563.58802
-  tps: 1216.15312
+  dps: 1563.1283
+  tps: 1215.58569
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 1730.10041
-  tps: 1409.97111
+  dps: 1727.87645
+  tps: 1407.65647
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1558.98721
-  tps: 1216.27305
+  dps: 1558.81659
+  tps: 1215.44994
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1722.50171
-  tps: 1342.31373
+  dps: 1721.40105
+  tps: 1341.26218
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 1761.10775
-  tps: 1374.29032
+  dps: 1760.70179
+  tps: 1373.98581
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1794.03949
-  tps: 1397.49624
+  dps: 1793.46365
+  tps: 1397.44484
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 1703.06518
-  tps: 1388.35471
+  dps: 1700.75743
+  tps: 1385.98523
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BattlecastGarb"
  value: {
-  dps: 1603.74114
-  tps: 1254.5462
+  dps: 1603.64138
+  tps: 1254.47448
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 1721.4977
-  tps: 1401.13475
+  dps: 1721.14799
+  tps: 1401.13293
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 1721.4977
-  tps: 1401.13475
+  dps: 1721.14799
+  tps: 1401.13293
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1737.68422
-  tps: 1416.23026
+  dps: 1735.35488
+  tps: 1413.83295
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1725.66583
-  tps: 1408.08241
+  dps: 1723.16627
+  tps: 1405.30245
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1724.1509
-  tps: 1405.34461
+  dps: 1721.83515
+  tps: 1402.96237
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1700.00538
-  tps: 1385.98604
+  dps: 1695.52003
+  tps: 1381.45178
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1731.26457
-  tps: 1350.51814
+  dps: 1731.14715
+  tps: 1350.40579
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 1733.54506
-  tps: 1351.71519
+  dps: 1732.54986
+  tps: 1349.97728
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CataclysmHarness"
  value: {
-  dps: 1325.74716
-  tps: 1037.73377
+  dps: 1324.14212
+  tps: 1036.49299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CataclysmRegalia"
  value: {
-  dps: 1586.17215
-  tps: 1241.92952
+  dps: 1585.02237
+  tps: 1240.56651
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1754.12803
-  tps: 1369.05143
+  dps: 1754.54617
+  tps: 1369.63194
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1660.51779
-  tps: 1295.17427
+  dps: 1659.65863
+  tps: 1294.6208
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CommunalTotemofLightning-186071"
  value: {
-  dps: 1744.63497
-  tps: 1359.10907
+  dps: 1745.27188
+  tps: 1359.88476
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1654.92132
-  tps: 1292.05274
+  dps: 1653.81104
+  tps: 1290.83803
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CycloneHarness"
  value: {
-  dps: 1327.26041
-  tps: 1039.22198
+  dps: 1326.93268
+  tps: 1039.70624
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CycloneRegalia"
  value: {
-  dps: 1519.7742
-  tps: 1187.42149
+  dps: 1517.57966
+  tps: 1185.20665
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1762.18812
-  tps: 1435.79259
+  dps: 1759.92494
+  tps: 1433.4369
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1760.69512
-  tps: 1434.78617
+  dps: 1758.33941
+  tps: 1432.35962
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1711.78694
-  tps: 1395.32695
+  dps: 1709.13342
+  tps: 1392.32301
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Devastation-30316"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DirebrewHops-38288"
  value: {
-  dps: 1741.91983
-  tps: 1419.43358
+  dps: 1739.49515
+  tps: 1416.95741
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 1715.76973
-  tps: 1398.521
+  dps: 1713.44457
+  tps: 1396.15358
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1563.58802
-  tps: 1216.15312
+  dps: 1563.1283
+  tps: 1215.58569
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1563.58802
-  tps: 1216.15312
+  dps: 1563.1283
+  tps: 1215.58569
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1563.58802
-  tps: 1216.15312
+  dps: 1563.1283
+  tps: 1215.58569
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 1724.23598
-  tps: 1405.34516
+  dps: 1721.88977
+  tps: 1402.93812
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Earthstrike-21180"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1764.62859
-  tps: 1402.3412
+  dps: 1765.27824
+  tps: 1403.14573
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1748.6337
-  tps: 1362.32127
+  dps: 1749.27315
+  tps: 1363.09951
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 1748.6337
-  tps: 1362.32127
+  dps: 1749.27315
+  tps: 1363.09951
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 1748.6337
-  tps: 1362.32127
+  dps: 1749.27315
+  tps: 1363.09951
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 1748.6337
-  tps: 1362.32127
+  dps: 1749.27315
+  tps: 1363.09951
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1741.91983
-  tps: 1419.43358
+  dps: 1739.49515
+  tps: 1416.95741
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1750.92999
-  tps: 1427.03863
+  dps: 1748.59506
+  tps: 1424.63512
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeofMoam-21473"
  value: {
-  dps: 1707.51802
-  tps: 1391.96637
+  dps: 1705.22623
+  tps: 1389.61072
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 1762.34303
-  tps: 1435.71542
+  dps: 1760.03436
+  tps: 1433.32633
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1755.0968
-  tps: 1368.97538
+  dps: 1753.25607
+  tps: 1367.66821
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FelSkin"
  value: {
-  dps: 1519.03542
-  tps: 1184.49792
+  dps: 1517.88571
+  tps: 1183.98611
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FelscaleArmor"
  value: {
-  dps: 1362.31821
-  tps: 1059.78997
+  dps: 1356.78812
+  tps: 1055.70382
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForceReactiveDisk-18168"
  value: {
-  dps: 1733.54506
-  tps: 1351.71519
+  dps: 1732.54986
+  tps: 1349.97728
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostscytheofLordAhune-278953"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 1739.54449
-  tps: 1417.62754
+  dps: 1737.27418
+  tps: 1415.27439
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 1711.54137
-  tps: 1393.89422
+  dps: 1711.72059
+  tps: 1394.84978
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HandofJustice-11815"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 1714.37299
-  tps: 1396.37233
+  dps: 1714.552
+  tps: 1397.3277
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 1703.01502
-  tps: 1385.48115
+  dps: 1702.3259
+  tps: 1384.86487
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartrazor-29962"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 1712.22528
-  tps: 1396.07012
+  dps: 1711.6938
+  tps: 1395.66414
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1780.15238
-  tps: 1450.18897
+  dps: 1777.90396
+  tps: 1447.83817
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 1717.22773
-  tps: 1399.59379
+  dps: 1714.93594
+  tps: 1397.23814
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IceGuard-2682"
  value: {
-  dps: 1760.69381
-  tps: 1370.96999
+  dps: 1761.34255
+  tps: 1371.75759
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1623.62906
-  tps: 1264.29663
+  dps: 1621.63277
+  tps: 1263.21327
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InfinityBlade-30312"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JomGabbar-23570"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1469.80611
-  tps: 1147.20089
+  dps: 1469.52968
+  tps: 1147.22129
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 1709.01986
-  tps: 1332.77441
+  dps: 1708.87967
+  tps: 1332.65068
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1728.68052
-  tps: 1409.03256
+  dps: 1728.00796
+  tps: 1408.43066
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1737.2523
-  tps: 1415.03611
+  dps: 1736.15277
+  tps: 1413.67135
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1724.44784
-  tps: 1405.54328
+  dps: 1722.15605
+  tps: 1403.18763
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NetherscaleArmor"
  value: {
-  dps: 1589.82559
-  tps: 1240.75352
+  dps: 1590.79094
+  tps: 1242.28339
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1717.18858
-  tps: 1339.00098
+  dps: 1714.03786
+  tps: 1335.22907
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NetherweaveVestments"
  value: {
-  dps: 1339.59135
-  tps: 1046.38764
+  dps: 1339.41386
+  tps: 1047.82135
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 1728.4832
-  tps: 1408.68329
+  dps: 1726.09776
+  tps: 1406.24306
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1731.26457
-  tps: 1350.51814
+  dps: 1731.14715
+  tps: 1350.40579
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1731.26457
-  tps: 1350.51814
+  dps: 1731.14715
+  tps: 1350.40579
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1731.26457
-  tps: 1350.51814
+  dps: 1731.14715
+  tps: 1350.40579
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1731.26457
-  tps: 1350.51814
+  dps: 1731.14715
+  tps: 1350.40579
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1731.26457
-  tps: 1350.51814
+  dps: 1731.14715
+  tps: 1350.40579
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1710.34015
-  tps: 1397.34736
+  dps: 1709.34243
+  tps: 1395.65934
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PrimalIntent"
  value: {
-  dps: 1523.08235
-  tps: 1189.81779
+  dps: 1519.25484
+  tps: 1187.14551
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PrimalMooncloth"
  value: {
-  dps: 1643.89635
-  tps: 1281.63904
+  dps: 1643.78102
+  tps: 1281.53255
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Prismcharm-15867"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1749.879
-  tps: 1423.3112
+  dps: 1749.63759
+  tps: 1423.5001
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1744.10804
-  tps: 1359.49707
+  dps: 1743.12538
+  tps: 1358.431
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofForce-25994"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SavageGuard-2681"
  value: {
-  dps: 1760.69381
-  tps: 1370.96999
+  dps: 1761.34255
+  tps: 1371.75759
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 1719.37444
-  tps: 1401.50262
+  dps: 1717.06347
+  tps: 1399.1257
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 1737.2523
-  tps: 1415.03611
+  dps: 1736.15277
+  tps: 1413.67135
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1718.86984
-  tps: 1401.07141
+  dps: 1714.3973
+  tps: 1396.52158
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1765.9175
-  tps: 1440.24527
+  dps: 1763.34077
+  tps: 1437.41865
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1557.8136
-  tps: 1216.72104
+  dps: 1554.96806
+  tps: 1214.38494
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1748.08025
-  tps: 1425.06801
+  dps: 1746.00121
+  tps: 1422.61107
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1775.1415
-  tps: 1445.49597
+  dps: 1774.45034
+  tps: 1444.8779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkullflameShield-1168"
  value: {
-  dps: 1733.54506
-  tps: 1351.71519
+  dps: 1732.54986
+  tps: 1349.97728
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
-  dps: 1773.22409
-  tps: 1381.24619
+  dps: 1771.97775
+  tps: 1380.77442
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterHarness"
  value: {
-  dps: 1198.79749
-  tps: 935.87722
+  dps: 1197.34996
+  tps: 935.10544
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterRegalia"
  value: {
-  dps: 1819.60917
-  tps: 1416.60317
+  dps: 1820.02468
+  tps: 1417.25092
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1539.62948
-  tps: 1203.967
+  dps: 1539.41069
+  tps: 1203.59926
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1628.72822
-  tps: 1270.66701
+  dps: 1628.92049
+  tps: 1270.24358
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 1715.72577
-  tps: 1398.55718
+  dps: 1711.25109
+  tps: 1394.00994
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 1709.44017
-  tps: 1393.43251
+  dps: 1707.17681
+  tps: 1391.09405
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1477.77464
-  tps: 1153.36715
+  dps: 1474.7622
+  tps: 1150.72052
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1718.23617
-  tps: 1341.07945
+  dps: 1718.94018
+  tps: 1342.06067
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 1710.6117
-  tps: 1394.40435
+  dps: 1708.31388
+  tps: 1392.03888
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 1722.01392
-  tps: 1403.58564
+  dps: 1717.54351
+  tps: 1399.03321
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 1700.00538
-  tps: 1385.98604
+  dps: 1695.52003
+  tps: 1381.45178
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 1710.56948
-  tps: 1394.43385
+  dps: 1706.0913
+  tps: 1389.89086
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheBladefist-29348"
  value: {
-  dps: 1563.58802
-  tps: 1216.15312
+  dps: 1563.1283
+  tps: 1215.58569
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1755.33405
-  tps: 1430.30326
+  dps: 1753.06311
+  tps: 1427.94409
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1785.40929
-  tps: 1452.91578
+  dps: 1782.88031
+  tps: 1449.04587
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThickDraenicArmor"
  value: {
-  dps: 1362.31821
-  tps: 1059.78997
+  dps: 1356.78812
+  tps: 1055.70382
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 1454.56946
-  tps: 1135.57522
+  dps: 1454.42942
+  tps: 1135.44873
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 1725.96221
-  tps: 1407.52805
+  dps: 1725.29486
+  tps: 1406.94808
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofAncestralGuidance-32330"
  value: {
-  dps: 1804.61582
-  tps: 1407.29213
+  dps: 1805.29098
+  tps: 1408.10598
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofImpact-27947"
  value: {
-  dps: 1736.63753
-  tps: 1352.68466
+  dps: 1737.26933
+  tps: 1353.45526
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofImpact-27984"
  value: {
-  dps: 1736.63753
-  tps: 1352.68466
+  dps: 1737.26933
+  tps: 1353.45526
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofLightning-28066"
  value: {
-  dps: 1740.39729
-  tps: 1354.48361
+  dps: 1740.05411
+  tps: 1354.11086
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheAstralWinds-27815"
  value: {
-  dps: 1736.63753
-  tps: 1352.68466
+  dps: 1737.26933
+  tps: 1353.45526
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheStorm-23199"
  value: {
-  dps: 1763.0291
-  tps: 1373.8852
+  dps: 1763.67773
+  tps: 1374.6726
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnitingCharm-25633"
  value: {
-  dps: 1700.26858
-  tps: 1386.13465
+  dps: 1697.97679
+  tps: 1383.779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 1729.66247
-  tps: 1408.9668
+  dps: 1727.42785
+  tps: 1407.01607
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 1719.08185
-  tps: 1401.51634
+  dps: 1718.39301
+  tps: 1400.90006
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WastewalkerArmor"
  value: {
-  dps: 1150.1198
-  tps: 894.31493
+  dps: 1150.53134
+  tps: 894.83915
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WhitemendWisdom"
  value: {
-  dps: 1573.76729
-  tps: 1228.98081
+  dps: 1573.65523
+  tps: 1228.87982
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WindhawkArmor"
  value: {
-  dps: 1709.44831
-  tps: 1331.59928
+  dps: 1709.33073
+  tps: 1331.49097
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 1747.76692
-  tps: 1362.70914
+  dps: 1746.66627
+  tps: 1361.65759
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WrathofSpellfire"
  value: {
-  dps: 1621.3933
-  tps: 1257.92804
+  dps: 1619.69196
+  tps: 1256.42175
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 1703.01502
-  tps: 1385.48115
+  dps: 1702.3259
+  tps: 1384.86487
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1739.02905
-  tps: 1417.83383
+  dps: 1736.18109
+  tps: 1414.7183
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 1793.05227
-  tps: 1406.48194
+  dps: 1792.72797
+  tps: 1406.14836
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Draenei-p1_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2272.19516
-  tps: 2147.27692
+  dps: 2272.04024
+  tps: 2146.91551
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Draenei-p1_a-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1774.66121
-  tps: 1389.80621
+  dps: 1774.68082
+  tps: 1389.73509
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Draenei-p1_a-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2085.02352
-  tps: 1662.87929
+  dps: 2084.87785
+  tps: 1662.72517
  }
 }
 dps_results: {
@@ -1449,22 +1449,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Draenei-p2-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2324.92599
-  tps: 2184.39069
+  dps: 2324.81931
+  tps: 2184.00769
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Draenei-p2-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1823.10205
-  tps: 1428.45822
+  dps: 1821.73424
+  tps: 1427.55234
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Draenei-p2-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2136.56302
-  tps: 1703.93821
+  dps: 2136.46292
+  tps: 1703.81211
  }
 }
 dps_results: {
@@ -1491,22 +1491,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Draenei-p3-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2705.21347
-  tps: 2512.29191
+  dps: 2704.90712
+  tps: 2511.79465
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Draenei-p3-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2281.02604
-  tps: 1784.89249
+  dps: 2280.43514
+  tps: 1784.66519
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Draenei-p3-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2650.12158
-  tps: 2076.78438
+  dps: 2649.97097
+  tps: 2076.60738
  }
 }
 dps_results: {
@@ -1533,22 +1533,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Draenei-p4-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2662.93545
-  tps: 2557.90257
+  dps: 2662.42805
+  tps: 2557.55415
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Draenei-p4-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2290.77999
-  tps: 1861.43682
+  dps: 2287.46794
+  tps: 1858.65574
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Draenei-p4-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2697.47848
-  tps: 2187.06077
+  dps: 2696.22952
+  tps: 2186.91445
  }
 }
 dps_results: {
@@ -1575,22 +1575,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Draenei-p5-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3076.14688
-  tps: 2924.57838
+  dps: 3075.29052
+  tps: 2923.60101
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Draenei-p5-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2723.64079
-  tps: 2207.00748
+  dps: 2719.59618
+  tps: 2205.135
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Draenei-p5-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3239.33273
-  tps: 2614.35793
+  dps: 3239.12983
+  tps: 2614.16087
  }
 }
 dps_results: {
@@ -1617,22 +1617,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p1_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2298.36871
-  tps: 2168.51962
+  dps: 2295.10838
+  tps: 2165.30209
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1_a-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1791.1279
-  tps: 1404.11256
+  dps: 1790.89889
+  tps: 1403.6885
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1_a-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2119.74689
-  tps: 1692.16098
+  dps: 2119.6012
+  tps: 1691.98578
  }
 }
 dps_results: {
@@ -1659,22 +1659,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p2-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2340.50014
-  tps: 2197.4684
+  dps: 2340.11368
+  tps: 2197.14561
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p2-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1839.31928
-  tps: 1441.73664
+  dps: 1839.23253
+  tps: 1441.65463
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p2-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2171.74308
-  tps: 1733.30312
+  dps: 2171.64295
+  tps: 1733.18596
  }
 }
 dps_results: {
@@ -1701,22 +1701,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p3-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2733.96311
-  tps: 2534.47389
+  dps: 2729.62466
+  tps: 2530.37392
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p3-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2306.81146
-  tps: 1805.50081
+  dps: 2306.73855
+  tps: 1805.42198
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p3-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2696.63071
-  tps: 2112.74845
+  dps: 2696.48009
+  tps: 2112.58045
  }
 }
 dps_results: {
@@ -1743,22 +1743,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p4-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2688.47994
-  tps: 2577.73711
+  dps: 2688.34148
+  tps: 2577.24872
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2311.4095
-  tps: 1877.63203
+  dps: 2311.28809
+  tps: 1877.51551
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2737.70725
-  tps: 2219.4002
+  dps: 2737.56498
+  tps: 2219.2341
  }
 }
 dps_results: {
@@ -1785,22 +1785,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p5-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3105.46304
-  tps: 2945.99238
+  dps: 3104.74338
+  tps: 2944.99562
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p5-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2750.33201
-  tps: 2230.18387
+  dps: 2745.78301
+  tps: 2227.05503
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p5-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3289.10286
-  tps: 2653.15896
+  dps: 3288.89996
+  tps: 2652.9409
  }
 }
 dps_results: {
@@ -1827,22 +1827,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p1_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2215.9281
-  tps: 2094.45716
+  dps: 2215.21719
+  tps: 2093.48469
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1_a-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1_a-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2079.96715
-  tps: 1640.28596
+  dps: 2079.82979
+  tps: 1640.1217
  }
 }
 dps_results: {
@@ -1869,22 +1869,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p2-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2266.7435
-  tps: 2128.90703
+  dps: 2265.97825
+  tps: 2128.73887
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p2-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1830.15201
-  tps: 1425.14273
+  dps: 1830.07246
+  tps: 1425.06794
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p2-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2130.7719
-  tps: 1676.227
+  dps: 2130.68048
+  tps: 1676.12086
  }
 }
 dps_results: {
@@ -1911,22 +1911,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p3-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2715.20004
-  tps: 2524.98039
+  dps: 2711.84615
+  tps: 2520.76841
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p3-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2285.88423
-  tps: 1788.05292
+  dps: 2285.2657
+  tps: 1788.08871
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p3-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2721.47528
-  tps: 2133.4212
+  dps: 2721.33133
+  tps: 2133.26155
  }
 }
 dps_results: {
@@ -1953,22 +1953,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p4-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2673.03014
-  tps: 2566.63191
+  dps: 2672.57519
+  tps: 2565.88339
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2298.77261
-  tps: 1867.97837
+  dps: 2298.58718
+  tps: 1867.63374
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2769.47175
-  tps: 2241.61413
+  dps: 2769.33687
+  tps: 2241.45304
  }
 }
 dps_results: {
@@ -1995,22 +1995,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p5-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3082.62689
-  tps: 2927.57705
+  dps: 3079.26588
+  tps: 2924.11978
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p5-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2736.48608
-  tps: 2222.39067
+  dps: 2729.51371
+  tps: 2216.64934
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p5-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3310.38177
-  tps: 2673.70223
+  dps: 3310.18789
+  tps: 2673.49422
  }
 }
 dps_results: {
@@ -2037,7 +2037,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1780.62348
-  tps: 1388.0189
+  dps: 1781.28334
+  tps: 1388.81749
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 247
   final_stats: 195
-  final_stats: 691
+  final_stats: 693
   final_stats: 514
   final_stats: 1188.4
   final_stats: 1175.4
@@ -34,7 +34,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 10249
   final_stats: 0
-  final_stats: 11059
+  final_stats: 11079
   final_stats: 10388
   final_stats: 184.34
   final_stats: 33
@@ -1617,36 +1617,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p1_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2295.10838
-  tps: 2165.30209
+  dps: 2295.20577
+  tps: 2165.37967
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1_a-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1790.89889
-  tps: 1403.6885
+  dps: 1790.97807
+  tps: 1403.75248
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1_a-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2119.6012
-  tps: 1691.98578
+  dps: 2119.69283
+  tps: 1692.06031
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1_a-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 917.18313
-  tps: 703.05703
+  dps: 917.38821
+  tps: 703.05713
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1_a-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 792.73002
-  tps: 615.37039
+  dps: 793.39829
+  tps: 615.56674
  }
 }
 dps_results: {
@@ -1659,36 +1659,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p2-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2340.11368
-  tps: 2197.14561
+  dps: 2340.21124
+  tps: 2197.2234
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p2-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1839.23253
-  tps: 1441.65463
+  dps: 1839.31212
+  tps: 1441.71895
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p2-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2171.64295
-  tps: 1733.18596
+  dps: 2171.73481
+  tps: 1733.26069
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p2-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 933.94144
-  tps: 717.21662
+  dps: 933.75973
+  tps: 717.20893
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p2-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 804.39495
-  tps: 625.19604
+  dps: 805.24406
+  tps: 625.81707
  }
 }
 dps_results: {
@@ -1701,22 +1701,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p3-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2729.62466
-  tps: 2530.37392
+  dps: 2729.73216
+  tps: 2530.45964
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p3-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2306.73855
-  tps: 1805.42198
+  dps: 2306.83161
+  tps: 1805.49689
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p3-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2696.48009
-  tps: 2112.58045
+  dps: 2696.58845
+  tps: 2112.667
  }
 }
 dps_results: {
@@ -1729,8 +1729,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p3-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1045.51108
-  tps: 803.25648
+  dps: 1045.48803
+  tps: 803.23615
  }
 }
 dps_results: {
@@ -1743,36 +1743,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p4-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2688.34148
-  tps: 2577.24872
+  dps: 2688.44881
+  tps: 2577.33429
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2311.28809
-  tps: 1877.51551
+  dps: 2311.3822
+  tps: 1877.59118
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2737.56498
-  tps: 2219.2341
+  dps: 2737.67527
+  tps: 2219.32207
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1147.34255
-  tps: 913.20394
+  dps: 1148.6046
+  tps: 914.26988
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1053.45847
-  tps: 848.02429
+  dps: 1053.54436
+  tps: 848.10004
  }
 }
 dps_results: {
@@ -1785,29 +1785,29 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p5-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3104.74338
-  tps: 2944.99562
+  dps: 3104.86341
+  tps: 2945.09143
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p5-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2745.78301
-  tps: 2227.05503
+  dps: 2745.8908
+  tps: 2227.14166
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p5-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3288.89996
-  tps: 2652.9409
+  dps: 3289.02757
+  tps: 2653.04238
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p5-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1207.50517
-  tps: 967.30917
+  dps: 1207.42927
+  tps: 967.24223
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 470
   final_stats: 381
-  final_stats: 730
+  final_stats: 731
   final_stats: 278
   final_stats: 236.7
   final_stats: 1043.09
@@ -34,7 +34,7 @@ character_stats_results: {
   final_stats: 20
   final_stats: 6280
   final_stats: 0
-  final_stats: 11449
+  final_stats: 11459
   final_stats: 7190.4
   final_stats: 143.5
   final_stats: 33
@@ -1638,36 +1638,36 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4197.20857
-  tps: 2492.24973
+  dps: 4197.3043
+  tps: 2492.25898
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2007.24794
-  tps: 1776.30934
+  dps: 2007.27513
+  tps: 1776.31888
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2189.05327
-  tps: 1913.92562
+  dps: 2189.08677
+  tps: 1913.9355
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1936.42867
-  tps: 1266.4051
+  dps: 1946.67927
+  tps: 1270.61558
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 860.64418
-  tps: 732.45925
+  dps: 860.51947
+  tps: 731.43059
  }
 }
 dps_results: {
@@ -1680,36 +1680,36 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4156.1386
-  tps: 2450.58202
+  dps: 4156.23442
+  tps: 2450.59127
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1965.99211
-  tps: 1733.93368
+  dps: 1966.01943
+  tps: 1733.94325
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2150.84765
-  tps: 1874.83499
+  dps: 2150.88125
+  tps: 1874.84487
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1929.81909
-  tps: 1254.5619
+  dps: 1928.76136
+  tps: 1249.39183
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 849.9229
-  tps: 721.1315
+  dps: 848.68274
+  tps: 719.59454
  }
 }
 dps_results: {
@@ -1722,36 +1722,36 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4481.04733
-  tps: 2968.36097
+  dps: 4481.15155
+  tps: 2968.37294
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2045.25961
-  tps: 1832.81086
+  dps: 2045.28909
+  tps: 1832.82285
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2207.56002
-  tps: 1947.759
+  dps: 2207.5939
+  tps: 1947.77049
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1980.62725
-  tps: 1294.10165
+  dps: 1978.89364
+  tps: 1293.60933
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 839.81353
-  tps: 719.09627
+  dps: 840.62218
+  tps: 720.98662
  }
 }
 dps_results: {
@@ -1764,36 +1764,36 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4463.65901
-  tps: 2969.07599
+  dps: 4463.7632
+  tps: 2969.0879
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2032.67486
-  tps: 1819.01922
+  dps: 2032.70453
+  tps: 1819.03122
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2202.96118
-  tps: 1937.28959
+  dps: 2202.99569
+  tps: 1937.30108
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1966.14175
-  tps: 1282.42812
+  dps: 1961.9965
+  tps: 1279.23016
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 835.21148
-  tps: 715.25028
+  dps: 835.5568
+  tps: 716.98364
  }
 }
 dps_results: {
@@ -1806,36 +1806,36 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4197.20857
-  tps: 2492.24973
+  dps: 4197.3043
+  tps: 2492.25898
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2007.24794
-  tps: 1776.30934
+  dps: 2007.27513
+  tps: 1776.31888
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2189.05327
-  tps: 1913.92562
+  dps: 2189.08677
+  tps: 1913.9355
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1936.42867
-  tps: 1266.4051
+  dps: 1946.67927
+  tps: 1270.61558
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 860.64418
-  tps: 732.45925
+  dps: 860.51947
+  tps: 731.43059
  }
 }
 dps_results: {
@@ -1848,36 +1848,36 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4156.1386
-  tps: 2450.58202
+  dps: 4156.23442
+  tps: 2450.59127
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1965.99211
-  tps: 1733.93368
+  dps: 1966.01943
+  tps: 1733.94325
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2150.84765
-  tps: 1874.83499
+  dps: 2150.88125
+  tps: 1874.84487
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1929.81909
-  tps: 1254.5619
+  dps: 1928.76136
+  tps: 1249.39183
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 849.9229
-  tps: 721.1315
+  dps: 848.68274
+  tps: 719.59454
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestEnhancement-CharacterStats-Default"
  value: {
-  final_stats: 472.78
-  final_stats: 383.295
-  final_stats: 732.16
-  final_stats: 279.29
-  final_stats: 236.889
-  final_stats: 1045.2788
+  final_stats: 470
+  final_stats: 381
+  final_stats: 730
+  final_stats: 278
+  final_stats: 236.7
+  final_stats: 1043.09
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 208.89
-  final_stats: 2737.966
+  final_stats: 207
+  final_stats: 2731.3
   final_stats: 1041
   final_stats: 0
   final_stats: 142
@@ -29,24 +29,24 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 290.12486
+  final_stats: 288.38772
   final_stats: 0
   final_stats: 20
-  final_stats: 6284.99
+  final_stats: 6280
   final_stats: 0
-  final_stats: 11470.6
-  final_stats: 7210.7175
-  final_stats: 143.7
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
+  final_stats: 11449
+  final_stats: 7190.4
+  final_stats: 143.5
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
   final_stats: 70
   final_stats: 0
   final_stats: 18.00488
   final_stats: 6
-  final_stats: 32.47021
-  final_stats: 17.86634
+  final_stats: 32.37841
+  final_stats: 17.85022
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -55,2094 +55,2094 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1937.0768
-  tps: 1742.4326
+  dps: 1929.62544
+  tps: 1736.63882
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 1917.33318
-  tps: 1701.71581
+  dps: 1912.25014
+  tps: 1696.99187
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 1913.97321
-  tps: 1700.32013
+  dps: 1908.89335
+  tps: 1695.59601
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 1914.80706
-  tps: 1718.88549
+  dps: 1912.5704
+  tps: 1716.70287
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Annihilator-12798"
  value: {
-  dps: 1681.50858
-  tps: 1490.35024
+  dps: 1679.84708
+  tps: 1488.74914
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 1927.76376
-  tps: 1705.63361
+  dps: 1922.66406
+  tps: 1700.90762
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1774.17023
-  tps: 1577.85407
+  dps: 1771.96702
+  tps: 1576.8643
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1913.60442
-  tps: 1718.97425
+  dps: 1909.25192
+  tps: 1714.93796
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1912.09282
-  tps: 1717.06538
+  dps: 1907.08583
+  tps: 1712.37182
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1952.69085
-  tps: 1756.29338
+  dps: 1950.31226
+  tps: 1753.66743
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 1910.50882
-  tps: 1710.66004
+  dps: 1907.00468
+  tps: 1707.14077
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1915.15542
-  tps: 1713.33391
+  dps: 1911.65154
+  tps: 1709.82114
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 1891.84162
-  tps: 1696.73975
+  dps: 1886.80486
+  tps: 1692.01642
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BattlecastGarb"
  value: {
-  dps: 1794.33585
-  tps: 1585.4859
+  dps: 1792.31704
+  tps: 1583.52124
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 1890.4042
-  tps: 1695.82587
+  dps: 1888.84205
+  tps: 1694.63371
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 1890.4042
-  tps: 1695.82587
+  dps: 1888.84205
+  tps: 1694.63371
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1903.72249
-  tps: 1700.84076
+  dps: 1898.66922
+  tps: 1696.11743
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1908.62426
-  tps: 1714.43938
+  dps: 1906.56171
+  tps: 1712.43125
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1893.76793
-  tps: 1698.04919
+  dps: 1888.72988
+  tps: 1693.32486
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1921.01523
-  tps: 1725.58635
+  dps: 1915.92341
+  tps: 1720.80796
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1899.26374
-  tps: 1699.22292
+  dps: 1894.21645
+  tps: 1694.49959
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1957.44214
-  tps: 1761.34478
+  dps: 1952.48792
+  tps: 1756.70399
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1985.48863
-  tps: 1792.0115
+  dps: 1982.92616
+  tps: 1788.60366
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1918.70541
-  tps: 1722.83987
+  dps: 1916.77468
+  tps: 1720.96316
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1921.7327
-  tps: 1726.06833
+  dps: 1919.48643
+  tps: 1723.87333
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CataclysmHarness"
  value: {
-  dps: 1903.58299
-  tps: 1707.85734
+  dps: 1900.56607
+  tps: 1704.90549
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CataclysmRegalia"
  value: {
-  dps: 1679.72965
-  tps: 1440.5322
+  dps: 1677.2566
+  tps: 1438.16037
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1912.9898
-  tps: 1713.64968
+  dps: 1910.33536
+  tps: 1711.05042
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1843.65621
-  tps: 1648.4848
+  dps: 1841.19852
+  tps: 1646.07754
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CommunalTotemofLightning-186071"
  value: {
-  dps: 1933.45364
-  tps: 1737.58744
+  dps: 1928.51128
+  tps: 1732.9585
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1928.82851
-  tps: 1733.19663
+  dps: 1923.83624
+  tps: 1728.51778
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1842.74281
-  tps: 1647.52626
+  dps: 1840.27701
+  tps: 1645.12139
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1920.5847
-  tps: 1725.38855
+  dps: 1915.55886
+  tps: 1720.67613
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CycloneHarness"
  value: {
-  dps: 1812.0497
-  tps: 1618.74591
+  dps: 1806.73471
+  tps: 1613.26325
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CycloneRegalia"
  value: {
-  dps: 1662.97259
-  tps: 1433.04852
+  dps: 1660.53738
+  tps: 1430.67971
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1930.90163
-  tps: 1704.47705
+  dps: 1925.79471
+  tps: 1699.75311
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1937.8334
-  tps: 1741.6027
+  dps: 1932.71927
+  tps: 1736.80199
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1904.9111
-  tps: 1711.56497
+  dps: 1902.65627
+  tps: 1709.38512
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Devastation-30316"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DirebrewHops-38288"
  value: {
-  dps: 1916.96463
-  tps: 1701.79404
+  dps: 1911.88265
+  tps: 1697.07011
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 1909.53305
-  tps: 1698.88647
+  dps: 1904.46116
+  tps: 1694.16314
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dragonmaw-28438"
  value: {
-  dps: 1929.43225
-  tps: 1731.72309
+  dps: 1925.85655
+  tps: 1728.24119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dragonstrike-28439"
  value: {
-  dps: 1958.93634
-  tps: 1765.76338
+  dps: 1957.12542
+  tps: 1763.99989
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 1913.23664
-  tps: 1715.60924
+  dps: 1910.38112
+  tps: 1712.96259
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 1898.19533
-  tps: 1699.31966
+  dps: 1893.15085
+  tps: 1694.59633
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Earthstrike-21180"
  value: {
-  dps: 1916.84769
-  tps: 1721.33935
+  dps: 1911.92332
+  tps: 1716.7284
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantBoots-Boar'sSpeed-2940"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 1948.98565
-  tps: 1753.25506
+  dps: 1944.94551
+  tps: 1749.26851
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 1937.72065
-  tps: 1708.19101
+  dps: 1936.03979
+  tps: 1706.59479
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1931.10557
-  tps: 1769.35053
+  dps: 1925.78399
+  tps: 1764.24742
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1963.13987
-  tps: 1766.78962
+  dps: 1958.16524
+  tps: 1762.12777
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 1947.37543
-  tps: 1751.90419
+  dps: 1942.30418
+  tps: 1747.1387
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 1978.38582
-  tps: 1782.51961
+  dps: 1973.23354
+  tps: 1777.68076
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantWeapon-Mongoose-2673"
  value: {
-  dps: 1984.31317
-  tps: 1789.92603
+  dps: 1981.31558
+  tps: 1787.0544
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1916.96463
-  tps: 1701.79404
+  dps: 1911.88265
+  tps: 1697.07011
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1912.2396
-  tps: 1704.00567
+  dps: 1907.18387
+  tps: 1699.28234
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeofMoam-21473"
  value: {
-  dps: 1899.90071
-  tps: 1697.27794
+  dps: 1894.84638
+  tps: 1692.55461
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 1927.52623
-  tps: 1704.64517
+  dps: 1922.42774
+  tps: 1699.92123
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1911.29808
-  tps: 1714.55891
+  dps: 1908.64136
+  tps: 1711.95576
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FelSkin"
  value: {
-  dps: 1875.21243
-  tps: 1681.63288
+  dps: 1873.33989
+  tps: 1679.81414
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FelscaleArmor"
  value: {
-  dps: 1819.09222
-  tps: 1625.84449
+  dps: 1816.7514
+  tps: 1623.5574
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1920.15217
-  tps: 1724.85376
+  dps: 1915.20367
+  tps: 1720.21868
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 1917.33318
-  tps: 1701.71581
+  dps: 1912.25014
+  tps: 1696.99187
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 1891.8391
-  tps: 1696.81167
+  dps: 1886.80209
+  tps: 1692.08807
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HandofJustice-11815"
  value: {
-  dps: 1898.80033
-  tps: 1703.67253
+  dps: 1893.74981
+  tps: 1698.93543
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 1892.10633
-  tps: 1697.07889
+  dps: 1887.06916
+  tps: 1692.35514
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 1891.56176
-  tps: 1694.76674
+  dps: 1889.3301
+  tps: 1692.92677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartrazor-29962"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 1905.1142
-  tps: 1697.81719
+  dps: 1900.04969
+  tps: 1693.11323
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1943.52724
-  tps: 1706.68422
+  dps: 1938.39712
+  tps: 1701.96028
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 1911.71314
-  tps: 1698.91263
+  dps: 1906.63528
+  tps: 1694.1893
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1926.72523
-  tps: 1730.61524
+  dps: 1924.27213
+  tps: 1728.21273
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IceGuard-2682"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1930.18359
-  tps: 1738.09985
+  dps: 1928.79721
+  tps: 1736.69091
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 1930.90163
-  tps: 1704.47705
+  dps: 1925.79471
+  tps: 1699.75311
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1766.86295
-  tps: 1553.91554
+  dps: 1765.27351
+  tps: 1552.38264
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InfinityBlade-30312"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JomGabbar-23570"
  value: {
-  dps: 1927.90891
-  tps: 1733.0754
+  dps: 1925.68534
+  tps: 1731.22051
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1926.19582
-  tps: 1732.11339
+  dps: 1922.72169
+  tps: 1730.26753
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1952.36837
-  tps: 1758.65345
+  dps: 1948.62647
+  tps: 1754.73678
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1645.42944
-  tps: 1426.43345
+  dps: 1642.99563
+  tps: 1424.05576
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 1875.22615
-  tps: 1674.95311
+  dps: 1872.80169
+  tps: 1672.58755
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1901.09969
-  tps: 1699.50098
+  dps: 1896.04994
+  tps: 1694.78074
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1888.7358
-  tps: 1691.64786
+  dps: 1886.60231
+  tps: 1689.9072
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 1895.55845
-  tps: 1699.39636
+  dps: 1890.5193
+  tps: 1694.67112
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1932.00887
-  tps: 1699.0048
+  dps: 1926.88428
+  tps: 1694.28147
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NetherscaleArmor"
  value: {
-  dps: 1894.45099
-  tps: 1699.24716
+  dps: 1889.56711
+  tps: 1694.67671
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NetherstrikeArmor"
  value: {
-  dps: 1815.56521
-  tps: 1600.83028
+  dps: 1812.40712
+  tps: 1597.7181
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NetherweaveVestments"
  value: {
-  dps: 1656.47385
-  tps: 1432.74084
+  dps: 1654.47852
+  tps: 1431.24512
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 1921.55613
-  tps: 1726.04342
+  dps: 1916.53943
+  tps: 1721.34014
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 1909.34043
-  tps: 1700.21462
+  dps: 1904.2718
+  tps: 1695.49069
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1906.76037
-  tps: 1711.22027
+  dps: 1904.10627
+  tps: 1708.61916
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1906.76037
-  tps: 1711.22027
+  dps: 1904.10627
+  tps: 1708.61916
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1906.76037
-  tps: 1711.22027
+  dps: 1904.10627
+  tps: 1708.61916
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1906.76037
-  tps: 1711.22027
+  dps: 1904.10627
+  tps: 1708.61916
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1906.76037
-  tps: 1711.22027
+  dps: 1904.10627
+  tps: 1708.61916
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1892.85223
-  tps: 1697.06375
+  dps: 1887.81469
+  tps: 1692.34787
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PrimalIntent"
  value: {
-  dps: 1930.46403
-  tps: 1738.19058
+  dps: 1929.21586
+  tps: 1737.80834
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PrimalMooncloth"
  value: {
-  dps: 1783.86972
-  tps: 1571.61932
+  dps: 1781.26688
+  tps: 1569.06661
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Prismcharm-15867"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 1900.34731
-  tps: 1699.13671
+  dps: 1895.29845
+  tps: 1694.41427
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 1885.29496
-  tps: 1690.31281
+  dps: 1879.94193
+  tps: 1685.27781
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1878.86518
-  tps: 1677.50701
+  dps: 1876.45499
+  tps: 1675.14034
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1936.46105
-  tps: 1747.37048
+  dps: 1937.53388
+  tps: 1748.02837
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofForce-25994"
  value: {
-  dps: 1899.43137
-  tps: 1704.2454
+  dps: 1894.42906
+  tps: 1699.55651
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SavageGuard-2681"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1879.89671
-  tps: 1684.86928
+  dps: 1874.78399
+  tps: 1680.06998
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 1897.69006
-  tps: 1698.65192
+  dps: 1892.64488
+  tps: 1693.92859
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 1924.64372
-  tps: 1728.14034
+  dps: 1921.90729
+  tps: 1726.23585
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1923.96447
-  tps: 1705.66794
+  dps: 1918.87078
+  tps: 1700.94187
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1912.98495
-  tps: 1703.48518
+  dps: 1906.46616
+  tps: 1698.7708
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1747.20411
-  tps: 1553.8701
+  dps: 1744.66405
+  tps: 1552.00871
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1982.63108
-  tps: 1789.1446
+  dps: 1982.77137
+  tps: 1789.22982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1894.07417
-  tps: 1698.25913
+  dps: 1889.03637
+  tps: 1693.53502
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1948.86932
-  tps: 1704.13762
+  dps: 1947.16811
+  tps: 1702.94387
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 1933.45364
-  tps: 1737.58744
+  dps: 1928.51128
+  tps: 1732.9585
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 2032.76069
-  tps: 1830.35614
+  dps: 2030.12675
+  tps: 1827.62983
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 1616.61723
-  tps: 1336.31344
+  dps: 1614.71818
+  tps: 1335.73214
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1938.72556
-  tps: 1742.93042
+  dps: 1933.74911
+  tps: 1738.26739
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1746.26218
-  tps: 1549.93147
+  dps: 1743.87647
+  tps: 1547.59632
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1806.44912
-  tps: 1595.21584
+  dps: 1804.42348
+  tps: 1593.24203
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1891.39536
-  tps: 1696.36792
+  dps: 1886.35861
+  tps: 1691.64459
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 1918.97755
-  tps: 1703.99387
+  dps: 1913.89322
+  tps: 1699.26849
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 1904.17052
-  tps: 1698.30936
+  dps: 1899.10857
+  tps: 1693.58542
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 1944.99788
-  tps: 1751.7033
+  dps: 1945.10761
+  tps: 1751.75128
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1736.80854
-  tps: 1542.80797
+  dps: 1735.22077
+  tps: 1541.26777
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1918.9184
-  tps: 1723.81676
+  dps: 1917.2631
+  tps: 1722.21335
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 1898.29464
-  tps: 1696.99054
+  dps: 1893.24466
+  tps: 1692.26804
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 1921.7852
-  tps: 1700.17412
+  dps: 1916.68696
+  tps: 1695.45079
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 1914.17756
-  tps: 1721.02001
+  dps: 1911.49617
+  tps: 1718.18437
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 1910.81568
-  tps: 1701.57838
+  dps: 1905.74659
+  tps: 1696.85395
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheBladefist-29348"
  value: {
-  dps: 1933.45087
-  tps: 1736.50345
+  dps: 1931.53839
+  tps: 1734.64452
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1893.31227
-  tps: 1697.60185
+  dps: 1888.27606
+  tps: 1692.87752
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1925.64925
-  tps: 1703.63106
+  dps: 1920.55216
+  tps: 1698.90712
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1914.02577
-  tps: 1706.6254
+  dps: 1912.42042
+  tps: 1705.43623
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThickDraenicArmor"
  value: {
-  dps: 1796.27352
-  tps: 1604.29864
+  dps: 1793.93261
+  tps: 1602.00801
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 1641.09985
-  tps: 1420.13518
+  dps: 1638.67091
+  tps: 1417.76954
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 1915.51533
-  tps: 1699.35835
+  dps: 1910.43159
+  tps: 1694.64714
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofAncestralGuidance-32330"
  value: {
-  dps: 1933.45364
-  tps: 1737.58744
+  dps: 1928.51128
+  tps: 1732.9585
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofImpact-27947"
  value: {
-  dps: 1937.83131
-  tps: 1741.96511
+  dps: 1932.88894
+  tps: 1737.33617
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofImpact-27984"
  value: {
-  dps: 1937.83131
-  tps: 1741.96511
+  dps: 1932.88894
+  tps: 1737.33617
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofLightning-28066"
  value: {
-  dps: 1933.45364
-  tps: 1737.58744
+  dps: 1928.51128
+  tps: 1732.9585
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheStorm-23199"
  value: {
-  dps: 1933.45364
-  tps: 1737.58744
+  dps: 1928.51128
+  tps: 1732.9585
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheVoid-28248"
  value: {
-  dps: 1933.45364
-  tps: 1737.58744
+  dps: 1928.51128
+  tps: 1732.9585
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1942.05574
-  tps: 1747.87943
+  dps: 1939.6787
+  tps: 1745.50887
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnitingCharm-25633"
  value: {
-  dps: 1921.55613
-  tps: 1726.04342
+  dps: 1916.53943
+  tps: 1721.34014
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 1914.00926
-  tps: 1700.32013
+  dps: 1908.92937
+  tps: 1695.59601
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 1908.7277
-  tps: 1698.66191
+  dps: 1903.65731
+  tps: 1693.95519
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WastewalkerArmor"
  value: {
-  dps: 1800.48107
-  tps: 1610.67604
+  dps: 1798.82988
+  tps: 1609.27867
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WhitemendWisdom"
  value: {
-  dps: 1783.10864
-  tps: 1580.45329
+  dps: 1781.09011
+  tps: 1578.49101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WindhawkArmor"
  value: {
-  dps: 1816.08603
-  tps: 1601.15018
+  dps: 1812.93908
+  tps: 1598.03773
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldBreaker-30090"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 1904.55705
-  tps: 1708.80389
+  dps: 1901.05156
+  tps: 1705.29203
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathofSpellfire"
  value: {
-  dps: 1780.48297
-  tps: 1579.43969
+  dps: 1779.15385
+  tps: 1578.02812
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 1891.56176
-  tps: 1694.76674
+  dps: 1889.3301
+  tps: 1692.92677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1919.41801
-  tps: 1700.97637
+  dps: 1914.32751
+  tps: 1696.25225
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 1960.86799
-  tps: 1762.98849
+  dps: 1958.35014
+  tps: 1760.5197
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4029.18319
-  tps: 2464.0818
+  dps: 4025.25613
+  tps: 2460.64997
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1953.58897
-  tps: 1754.57218
+  dps: 1950.27047
+  tps: 1751.2746
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2113.28195
-  tps: 1885.98436
+  dps: 2111.51935
+  tps: 1884.23975
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1809.44087
-  tps: 1228.16966
+  dps: 1802.12509
+  tps: 1220.02998
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 801.81995
-  tps: 696.14748
+  dps: 805.78859
+  tps: 700.13297
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 956.92601
-  tps: 829.70431
+  dps: 956.76158
+  tps: 829.71714
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3996.01987
-  tps: 2434.83133
+  dps: 3989.14878
+  tps: 2428.21837
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1920.50491
-  tps: 1720.71921
+  dps: 1914.25684
+  tps: 1714.26093
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2082.17452
-  tps: 1854.07923
+  dps: 2075.03478
+  tps: 1846.87117
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1805.46952
-  tps: 1237.3922
+  dps: 1819.27444
+  tps: 1241.04428
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 798.20379
-  tps: 693.94602
+  dps: 802.1985
+  tps: 698.29731
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-DefaultTalents-Sync OH Swings-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 952.30184
-  tps: 826.88005
+  dps: 950.73645
+  tps: 825.49117
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4312.31169
-  tps: 2961.64434
+  dps: 4308.00516
+  tps: 2943.68654
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1994.03978
-  tps: 1813.27971
+  dps: 1991.2893
+  tps: 1810.51219
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2114.83159
-  tps: 1892.51501
+  dps: 2109.3647
+  tps: 1887.40659
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1847.40864
-  tps: 1261.04875
+  dps: 1851.42453
+  tps: 1263.39296
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 801.22792
-  tps: 702.5455
+  dps: 804.58178
+  tps: 706.72599
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 986.80095
-  tps: 865.61954
+  dps: 985.4232
+  tps: 863.91241
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4286.03561
-  tps: 2931.49187
+  dps: 4283.46953
+  tps: 2920.4087
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1972.01081
-  tps: 1788.67874
+  dps: 1972.81584
+  tps: 1789.40472
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2109.9589
-  tps: 1884.41991
+  dps: 2106.19146
+  tps: 1880.35838
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1838.38893
-  tps: 1244.29802
+  dps: 1813.20271
+  tps: 1229.83195
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 787.58766
-  tps: 689.86559
+  dps: 790.07599
+  tps: 691.22489
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Elemental-Sync OH Swings-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 973.95853
-  tps: 855.54138
+  dps: 972.78055
+  tps: 854.03632
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4029.18319
-  tps: 2464.0818
+  dps: 4025.25613
+  tps: 2460.64997
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1953.58897
-  tps: 1754.57218
+  dps: 1950.27047
+  tps: 1751.2746
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2113.28195
-  tps: 1885.98436
+  dps: 2111.51935
+  tps: 1884.23975
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1809.44087
-  tps: 1228.16966
+  dps: 1802.12509
+  tps: 1220.02998
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 801.81995
-  tps: 696.14748
+  dps: 805.78859
+  tps: 700.13297
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 956.92601
-  tps: 829.70431
+  dps: 956.76158
+  tps: 829.71714
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3996.01987
-  tps: 2434.83133
+  dps: 3989.14878
+  tps: 2428.21837
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1920.50491
-  tps: 1720.71921
+  dps: 1914.25684
+  tps: 1714.26093
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2082.17452
-  tps: 1854.07923
+  dps: 2075.03478
+  tps: 1846.87117
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1805.46952
-  tps: 1237.3922
+  dps: 1819.27444
+  tps: 1241.04428
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 798.20379
-  tps: 693.94602
+  dps: 802.1985
+  tps: 698.29731
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Sub-Restoration ILS-Sync OH Swings-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 952.30184
-  tps: 826.88005
+  dps: 950.73645
+  tps: 825.49117
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4201.34454
-  tps: 2495.27813
+  dps: 4197.20857
+  tps: 2492.24973
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2010.55766
-  tps: 1779.41109
+  dps: 2007.24794
+  tps: 1776.30934
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2191.84688
-  tps: 1916.19741
+  dps: 2189.05327
+  tps: 1913.92562
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1950.3248
-  tps: 1271.35342
+  dps: 1936.42867
+  tps: 1266.4051
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 855.29896
-  tps: 726.68992
+  dps: 860.64418
+  tps: 732.45925
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1026.76963
-  tps: 870.85625
+  dps: 1026.43974
+  tps: 870.49847
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4163.83689
-  tps: 2457.44623
+  dps: 4156.1386
+  tps: 2450.58202
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1972.8552
-  tps: 1740.86065
+  dps: 1965.99211
+  tps: 1733.93368
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2159.34664
-  tps: 1882.89942
+  dps: 2150.84765
+  tps: 1874.83499
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1930.08613
-  tps: 1247.77282
+  dps: 1929.81909
+  tps: 1254.5619
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 844.26578
-  tps: 714.95432
+  dps: 849.9229
+  tps: 721.1315
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-DefaultTalents-Sync OH Swings-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1012.27935
-  tps: 857.64529
+  dps: 1011.95579
+  tps: 857.29309
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4483.56966
-  tps: 2974.23181
+  dps: 4481.04733
+  tps: 2968.36097
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2048.42078
-  tps: 1836.00982
+  dps: 2045.25961
+  tps: 1832.81086
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2210.80255
-  tps: 1950.44736
+  dps: 2207.56002
+  tps: 1947.759
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1969.98206
-  tps: 1296.47868
+  dps: 1980.62725
+  tps: 1294.10165
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 844.03039
-  tps: 723.47302
+  dps: 839.81353
+  tps: 719.09627
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1039.32587
-  tps: 887.27183
+  dps: 1038.99826
+  tps: 886.91565
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4466.55609
-  tps: 2975.16091
+  dps: 4463.65901
+  tps: 2969.07599
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2034.57083
-  tps: 1819.97959
+  dps: 2032.67486
+  tps: 1819.01922
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2207.19091
-  tps: 1940.96453
+  dps: 2202.96118
+  tps: 1937.28959
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1963.52619
-  tps: 1279.36306
+  dps: 1966.14175
+  tps: 1282.42812
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 830.56814
-  tps: 710.907
+  dps: 835.21148
+  tps: 715.25028
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Elemental-Sync OH Swings-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1031.94766
-  tps: 880.46329
+  dps: 1031.62167
+  tps: 880.11159
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4201.34454
-  tps: 2495.27813
+  dps: 4197.20857
+  tps: 2492.24973
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 2010.55766
-  tps: 1779.41109
+  dps: 2007.24794
+  tps: 1776.30934
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2191.84688
-  tps: 1916.19741
+  dps: 2189.05327
+  tps: 1913.92562
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1950.3248
-  tps: 1271.35342
+  dps: 1936.42867
+  tps: 1266.4051
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 855.29896
-  tps: 726.68992
+  dps: 860.64418
+  tps: 732.45925
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1026.76963
-  tps: 870.85625
+  dps: 1026.43974
+  tps: 870.49847
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4163.83689
-  tps: 2457.44623
+  dps: 4156.1386
+  tps: 2450.58202
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1972.8552
-  tps: 1740.86065
+  dps: 1965.99211
+  tps: 1733.93368
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2159.34664
-  tps: 1882.89942
+  dps: 2150.84765
+  tps: 1874.83499
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1930.08613
-  tps: 1247.77282
+  dps: 1929.81909
+  tps: 1254.5619
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 844.26578
-  tps: 714.95432
+  dps: 849.9229
+  tps: 721.1315
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Sub-Restoration ILS-Sync OH Swings-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1012.27935
-  tps: 857.64529
+  dps: 1011.95579
+  tps: 857.29309
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3983.55253
-  tps: 2465.35926
+  dps: 3980.74945
+  tps: 2463.97248
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2105.83886
-  tps: 1882.09978
+  dps: 2105.77446
+  tps: 1882.5849
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1822.52942
-  tps: 1227.07728
+  dps: 1824.85624
+  tps: 1237.74943
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 809.63694
-  tps: 701.19361
+  dps: 811.4658
+  tps: 703.28048
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 971.88861
-  tps: 846.03103
+  dps: 971.2565
+  tps: 845.37086
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3956.96862
-  tps: 2428.11628
+  dps: 3954.44436
+  tps: 2424.64757
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1908.14599
-  tps: 1709.79772
+  dps: 1906.39931
+  tps: 1709.16316
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2074.01996
-  tps: 1847.9157
+  dps: 2066.73722
+  tps: 1841.30105
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1799.03833
-  tps: 1224.74533
+  dps: 1808.62663
+  tps: 1229.57999
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 796.7942
-  tps: 690.72188
+  dps: 797.15317
+  tps: 690.37646
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-DefaultTalents-Sync OH Swings-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 957.43257
-  tps: 832.90336
+  dps: 956.80045
+  tps: 832.17273
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4298.97399
-  tps: 2959.1359
+  dps: 4291.57325
+  tps: 2951.71231
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1995.8526
-  tps: 1812.94431
+  dps: 1992.0926
+  tps: 1809.83125
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2123.97858
-  tps: 1900.9462
+  dps: 2120.03394
+  tps: 1897.52959
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1856.93076
-  tps: 1279.85245
+  dps: 1829.64696
+  tps: 1272.5308
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 793.82652
-  tps: 694.73334
+  dps: 792.87907
+  tps: 695.67188
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 977.0108
-  tps: 855.85248
+  dps: 976.0513
+  tps: 854.86702
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4254.27353
-  tps: 2913.71767
+  dps: 4250.72523
+  tps: 2912.88664
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1949.6422
-  tps: 1769.55388
+  dps: 1946.86726
+  tps: 1766.91964
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2095.70451
-  tps: 1873.79338
+  dps: 2092.45719
+  tps: 1870.55279
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1811.00767
-  tps: 1227.10357
+  dps: 1813.04264
+  tps: 1246.73782
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 779.09334
-  tps: 679.73518
+  dps: 780.4933
+  tps: 681.46409
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Elemental-Sync OH Swings-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 964.85418
-  tps: 843.45321
+  dps: 963.795
+  tps: 842.33068
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3983.55253
-  tps: 2465.35926
+  dps: 3980.74945
+  tps: 2463.97248
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1943.32377
-  tps: 1747.45757
+  dps: 1938.34904
+  tps: 1742.79626
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2105.83886
-  tps: 1882.09978
+  dps: 2105.77446
+  tps: 1882.5849
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1822.52942
-  tps: 1227.07728
+  dps: 1824.85624
+  tps: 1237.74943
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 809.63694
-  tps: 701.19361
+  dps: 811.4658
+  tps: 703.28048
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 971.88861
-  tps: 846.03103
+  dps: 971.2565
+  tps: 845.37086
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3956.96862
-  tps: 2428.11628
+  dps: 3954.44436
+  tps: 2424.64757
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1908.14599
-  tps: 1709.79772
+  dps: 1906.39931
+  tps: 1709.16316
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Sync OH Swings-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2074.01996
-  tps: 1847.9157
+  dps: 2066.73722
+  tps: 1841.30105
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Sync OH Swings-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1799.03833
-  tps: 1224.74533
+  dps: 1808.62663
+  tps: 1229.57999
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Sync OH Swings-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 796.7942
-  tps: 690.72188
+  dps: 797.15317
+  tps: 690.37646
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Sub-Restoration ILS-Sync OH Swings-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 957.43257
-  tps: 832.90336
+  dps: 956.80045
+  tps: 832.17273
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1684.61381
-  tps: 1506.83814
+  dps: 1683.3862
+  tps: 1505.79711
  }
 }

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -1239,36 +1239,36 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1917.82004
-  tps: 2416.57723
+  dps: 1916.1719
+  tps: 2413.58195
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1917.82004
-  tps: 1205.4596
+  dps: 1916.1719
+  tps: 1204.40443
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2237.80425
-  tps: 1451.68466
+  dps: 2236.33562
+  tps: 1450.65862
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 950.63073
-  tps: 1871.22339
+  dps: 950.6732
+  tps: 1871.31366
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 950.63073
-  tps: 604.72983
+  dps: 950.6732
+  tps: 604.8201
  }
 }
 dps_results: {

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestAffliction-CharacterStats-Default"
  value: {
-  final_stats: 195.58
-  final_stats: 185.295
-  final_stats: 651.86
-  final_stats: 403.59
-  final_stats: 1007.299
-  final_stats: 994.299
+  final_stats: 193
+  final_stats: 183
+  final_stats: 650
+  final_stats: 402
+  final_stats: 1007.2
+  final_stats: 994.2
   final_stats: 0
   final_stats: 0
   final_stats: 233
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 203
   final_stats: 0
   final_stats: 15
-  final_stats: 242.99
-  final_stats: 1052.788
+  final_stats: 242
+  final_stats: 1049.4
   final_stats: 389
   final_stats: 0
   final_stats: 0
@@ -32,21 +32,21 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 7
-  final_stats: 3092.99
+  final_stats: 3088
   final_stats: 0
-  final_stats: 10988.6
-  final_stats: 8388.85
-  final_stats: 122.7
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
+  final_stats: 10970
+  final_stats: 8365
+  final_stats: 122.5
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
   final_stats: 70
   final_stats: 0
   final_stats: 0
   final_stats: 16.07927
   final_stats: 9.17422
-  final_stats: 25.81892
+  final_stats: 25.79952
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -55,1206 +55,1206 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 1973.56792
-  tps: 1232.90026
+  dps: 1970.90948
+  tps: 1230.07892
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 1963.80196
-  tps: 1229.08743
+  dps: 1957.80658
+  tps: 1223.47879
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 1926.51036
-  tps: 1199.55879
+  dps: 1923.46351
+  tps: 1197.33238
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 1967.16497
-  tps: 1229.06295
+  dps: 1966.52562
+  tps: 1229.17599
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1775.59416
-  tps: 1103.48209
+  dps: 1774.36822
+  tps: 1102.76524
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 1972.85431
-  tps: 1232.0865
+  dps: 1977.67861
+  tps: 1234.8809
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1911.69441
-  tps: 1190.46693
+  dps: 1913.23949
+  tps: 1190.41805
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 1943.80881
-  tps: 1212.87345
+  dps: 1949.22842
+  tps: 1215.80001
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1965.97719
-  tps: 1228.63286
+  dps: 1969.9893
+  tps: 1231.95784
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 1930.33649
-  tps: 1202.65894
+  dps: 1927.82636
+  tps: 1200.25852
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BattlecastGarb"
  value: {
-  dps: 1753.04981
-  tps: 1060.48711
+  dps: 1744.81356
+  tps: 1053.21259
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 1929.14189
-  tps: 1206.1189
+  dps: 1924.57166
+  tps: 1202.19791
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 1929.14189
-  tps: 1206.1189
+  dps: 1924.57166
+  tps: 1202.19791
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1969.10087
-  tps: 1230.34771
+  dps: 1970.34505
+  tps: 1230.89236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1948.18847
-  tps: 1218.02104
+  dps: 1945.64217
+  tps: 1215.79052
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1951.22447
-  tps: 1217.79287
+  dps: 1959.48109
+  tps: 1224.18017
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1926.51036
-  tps: 1199.55879
+  dps: 1923.46351
+  tps: 1197.33238
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 1889.96052
-  tps: 1177.56079
+  dps: 1882.7995
+  tps: 1171.76436
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1914.03782
-  tps: 1192.22579
+  dps: 1915.77199
+  tps: 1192.1768
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1936.6648
-  tps: 1207.01466
+  dps: 1936.8494
+  tps: 1207.13971
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1818.42126
-  tps: 1109.30909
+  dps: 1819.55124
+  tps: 1110.3693
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1792.17189
-  tps: 1089.4188
+  dps: 1793.16779
+  tps: 1089.94678
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorruptorRaiment"
  value: {
-  dps: 1834.85984
-  tps: 1112.70185
+  dps: 1837.42703
+  tps: 1114.95576
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1986.2862
-  tps: 1237.87954
+  dps: 1982.65892
+  tps: 1235.18783
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1974.37871
-  tps: 1231.02848
+  dps: 1977.55447
+  tps: 1233.52899
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1942.68957
-  tps: 1213.47078
+  dps: 1940.97037
+  tps: 1211.8976
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Despair-28573"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DirebrewHops-38288"
  value: {
-  dps: 1974.64747
-  tps: 1233.14064
+  dps: 1976.16657
+  tps: 1234.85133
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 1939.29854
-  tps: 1207.83956
+  dps: 1938.91382
+  tps: 1207.11246
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 1960.72994
-  tps: 1225.20984
+  dps: 1950.69313
+  tps: 1216.98144
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Earthstrike-21180"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1924.94829
-  tps: 1224.46384
+  dps: 1926.60473
+  tps: 1225.18785
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1900.67844
-  tps: 1186.25106
+  dps: 1902.89449
+  tps: 1188.2982
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1974.64747
-  tps: 1233.14064
+  dps: 1976.16657
+  tps: 1234.85133
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1974.1271
-  tps: 1232.41723
+  dps: 1981.29924
+  tps: 1237.93954
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofMoam-21473"
  value: {
-  dps: 1933.68399
-  tps: 1204.94297
+  dps: 1931.84259
+  tps: 1202.97265
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 2003.26033
-  tps: 1252.82037
+  dps: 1997.5267
+  tps: 1247.66565
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1933.27249
-  tps: 1209.02962
+  dps: 1937.54283
+  tps: 1211.16491
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FrostscytheofLordAhune-278953"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 1973.56792
-  tps: 1232.90026
+  dps: 1970.90948
+  tps: 1230.07892
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 1933.93957
-  tps: 1206.22403
+  dps: 1930.04657
+  tps: 1202.86399
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HandofJustice-11815"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 1934.41133
-  tps: 1206.64012
+  dps: 1930.51832
+  tps: 1203.28007
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 1915.30434
-  tps: 1192.12989
+  dps: 1913.35521
+  tps: 1191.2956
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Heartrazor-29962"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 1923.41227
-  tps: 1195.70291
+  dps: 1923.08471
+  tps: 1194.83123
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 2007.73296
-  tps: 1255.1398
+  dps: 2004.36936
+  tps: 1250.96639
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 1939.6776
-  tps: 1206.8319
+  dps: 1939.07111
+  tps: 1206.19113
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IceGuard-2682"
  value: {
-  dps: 1907.0522
-  tps: 1185.68093
+  dps: 1905.33501
+  tps: 1184.18098
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1794.8507
-  tps: 1107.68479
+  dps: 1794.55261
+  tps: 1107.80905
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InfinityBlade-30312"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JomGabbar-23570"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MaleficRaiment"
  value: {
-  dps: 2004.78666
-  tps: 1288.59802
+  dps: 1998.39791
+  tps: 1282.98739
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1659.18596
-  tps: 1006.55081
+  dps: 1660.54254
+  tps: 1007.49287
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 1905.65055
-  tps: 1188.46069
+  dps: 1904.47264
+  tps: 1187.47009
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1919.77029
-  tps: 1188.07878
+  dps: 1943.87161
+  tps: 1208.97017
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1928.40692
-  tps: 1206.91312
+  dps: 1924.09657
+  tps: 1203.61268
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1955.88738
-  tps: 1222.20162
+  dps: 1953.51986
+  tps: 1220.01939
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NetherweaveVestments"
  value: {
-  dps: 1609.90524
-  tps: 966.8244
+  dps: 1611.92898
+  tps: 967.98226
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-OblivionRaiment"
  value: {
-  dps: 1636.65257
-  tps: 983.82652
+  dps: 1641.8919
+  tps: 988.44282
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 1964.4836
-  tps: 1227.12208
+  dps: 1957.77837
+  tps: 1221.56231
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1914.03782
-  tps: 1192.22579
+  dps: 1915.77199
+  tps: 1192.1768
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1914.03782
-  tps: 1192.22579
+  dps: 1915.77199
+  tps: 1192.1768
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1914.03782
-  tps: 1192.22579
+  dps: 1915.77199
+  tps: 1192.1768
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1914.03782
-  tps: 1192.22579
+  dps: 1915.77199
+  tps: 1192.1768
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1914.03782
-  tps: 1192.22579
+  dps: 1915.77199
+  tps: 1192.1768
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1923.12508
-  tps: 1195.75226
+  dps: 1922.78879
+  tps: 1196.26394
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PrimalMooncloth"
  value: {
-  dps: 1836.78655
-  tps: 1137.79444
+  dps: 1829.00808
+  tps: 1130.74862
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prismcharm-15867"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1926.57017
-  tps: 1203.70918
+  dps: 1927.70686
+  tps: 1205.44267
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofForce-25994"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SavageGuard-2681"
  value: {
-  dps: 1907.0522
-  tps: 1185.68093
+  dps: 1905.33501
+  tps: 1184.18098
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 1952.65296
-  tps: 1219.40281
+  dps: 1941.73176
+  tps: 1210.36322
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 1928.40692
-  tps: 1206.91312
+  dps: 1924.09657
+  tps: 1203.61268
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1955.89958
-  tps: 1222.08108
+  dps: 1948.73481
+  tps: 1215.2468
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1992.10965
-  tps: 1250.10833
+  dps: 1989.97465
+  tps: 1248.79609
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1882.98246
-  tps: 1170.5598
+  dps: 1885.04062
+  tps: 1172.39583
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1950.68485
-  tps: 1218.06982
+  dps: 1951.10924
+  tps: 1218.62171
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1993.80518
-  tps: 1258.92199
+  dps: 1987.87464
+  tps: 1252.78667
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1715.65988
-  tps: 1056.88649
+  dps: 1712.28231
+  tps: 1053.51544
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1809.72689
-  tps: 1110.65909
+  dps: 1812.65973
+  tps: 1112.7146
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 1951.45901
-  tps: 1218.74094
+  dps: 1944.3904
+  tps: 1212.28569
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 1939.97042
-  tps: 1210.24652
+  dps: 1934.55517
+  tps: 1205.10085
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1917.17552
-  tps: 1191.02943
+  dps: 1913.96854
+  tps: 1187.97829
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 1934.55502
-  tps: 1205.27697
+  dps: 1940.86479
+  tps: 1210.45175
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 1960.26531
-  tps: 1224.9488
+  dps: 1954.1239
+  tps: 1219.53365
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 1926.51036
-  tps: 1199.55879
+  dps: 1923.46351
+  tps: 1197.33238
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 1941.32012
-  tps: 1210.97002
+  dps: 1935.91313
+  tps: 1205.84391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheBlackBook-19337"
  value: {
-  dps: 1942.76315
-  tps: 1200.99031
+  dps: 1938.87045
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1933.84422
-  tps: 1183.44825
+  dps: 1930.76344
+  tps: 1182.90488
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1976.70353
-  tps: 1231.50282
+  dps: 1977.71114
+  tps: 1233.08188
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1977.53745
-  tps: 1238.00682
+  dps: 1976.64983
+  tps: 1237.05089
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1724.7495
-  tps: 1072.68195
+  dps: 1723.18958
+  tps: 1071.07821
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 1936.19836
-  tps: 1201.84544
+  dps: 1942.06549
+  tps: 1207.25786
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnitingCharm-25633"
  value: {
-  dps: 1927.99109
-  tps: 1200.99031
+  dps: 1924.09839
+  tps: 1197.63054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 1965.67305
-  tps: 1230.54846
+  dps: 1958.05486
+  tps: 1223.69778
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VoidStarTalisman-30449"
  value: {
-  dps: 1969.94757
-  tps: 1230.18678
+  dps: 1971.19207
+  tps: 1231.46871
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VoidheartRaiment"
  value: {
-  dps: 1804.38371
-  tps: 1110.66103
+  dps: 1800.7652
+  tps: 1109.05751
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 1939.93788
-  tps: 1207.86301
+  dps: 1935.34435
+  tps: 1204.58287
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WhitemendWisdom"
  value: {
-  dps: 1716.00745
-  tps: 1034.5557
+  dps: 1718.77301
+  tps: 1037.28503
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 1930.79594
-  tps: 1202.08009
+  dps: 1935.87314
+  tps: 1206.22986
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofSpellfire"
  value: {
-  dps: 1755.45951
-  tps: 1073.89702
+  dps: 1764.5725
+  tps: 1080.92203
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 1915.30434
-  tps: 1192.12989
+  dps: 1913.35521
+  tps: 1191.2956
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1972.54472
-  tps: 1235.95536
+  dps: 1966.75803
+  tps: 1230.35558
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 1954.66258
-  tps: 1221.99979
+  dps: 1954.51392
+  tps: 1221.8915
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1920.68122
-  tps: 2419.86689
+  dps: 1917.82004
+  tps: 2416.57723
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1920.68122
-  tps: 1208.24751
+  dps: 1917.82004
+  tps: 1205.4596
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2236.74656
-  tps: 1450.4102
+  dps: 2237.80425
+  tps: 1451.68466
  }
 }
 dps_results: {
@@ -1281,22 +1281,22 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Orc-preraid-Affliction-affliction-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1949.14325
-  tps: 2434.99254
+  dps: 1945.76237
+  tps: 2427.5369
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-preraid-Affliction-affliction-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-preraid-Affliction-affliction-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2277.76417
-  tps: 1467.80994
+  dps: 2278.80656
+  tps: 1468.92893
  }
 }
 dps_results: {
@@ -1323,7 +1323,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1949.14325
-  tps: 1218.76623
+  dps: 1945.76237
+  tps: 1215.56173
  }
 }

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 193
   final_stats: 183
-  final_stats: 650
+  final_stats: 651
   final_stats: 402
   final_stats: 1007.2
   final_stats: 994.2
@@ -34,7 +34,7 @@ character_stats_results: {
   final_stats: 7
   final_stats: 3088
   final_stats: 0
-  final_stats: 10970
+  final_stats: 10980
   final_stats: 8365
   final_stats: 122.5
   final_stats: 33
@@ -1239,36 +1239,36 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1916.1719
-  tps: 2413.58195
+  dps: 1917.73606
+  tps: 2416.47757
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1916.1719
-  tps: 1204.40443
+  dps: 1917.73606
+  tps: 1205.40237
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2236.33562
-  tps: 1450.65862
+  dps: 2237.70634
+  tps: 1451.61625
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 950.6732
-  tps: 1871.31366
+  dps: 950.63073
+  tps: 1871.22339
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction-affliction-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 950.6732
-  tps: 604.8201
+  dps: 950.63073
+  tps: 604.72983
  }
 }
 dps_results: {

--- a/sim/warlock/TestDestruction.results
+++ b/sim/warlock/TestDestruction.results
@@ -1239,36 +1239,36 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1872.04218
-  tps: 2774.71542
+  dps: 1876.18588
+  tps: 2795.34309
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1872.04218
-  tps: 1636.50902
+  dps: 1876.18588
+  tps: 1640.87205
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2256.26707
-  tps: 1963.21404
+  dps: 2252.4446
+  tps: 1961.45968
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 963.58483
-  tps: 2067.76477
+  dps: 961.52403
+  tps: 2067.33478
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 963.58483
-  tps: 862.90088
+  dps: 961.52403
+  tps: 860.83478
  }
 }
 dps_results: {

--- a/sim/warlock/TestDestruction.results
+++ b/sim/warlock/TestDestruction.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestDestruction-CharacterStats-Default"
  value: {
-  final_stats: 195.58
-  final_stats: 185.295
-  final_stats: 749.639
-  final_stats: 403.59
-  final_stats: 1003.65415
-  final_stats: 990.65415
+  final_stats: 193
+  final_stats: 183
+  final_stats: 747
+  final_stats: 402
+  final_stats: 1003.5
+  final_stats: 990.5
   final_stats: 0
   final_stats: 0
   final_stats: 233
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 203
   final_stats: 0
   final_stats: 15
-  final_stats: 206.5415
-  final_stats: 1052.788
+  final_stats: 205
+  final_stats: 1049.4
   final_stats: 389
   final_stats: 0
   final_stats: 0
@@ -32,21 +32,21 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 7
-  final_stats: 3092.99
+  final_stats: 3088
   final_stats: 0
-  final_stats: 12325.3817
-  final_stats: 8640.5155
-  final_stats: 122.7
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
+  final_stats: 12298.2
+  final_stats: 8615.95
+  final_stats: 122.5
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
   final_stats: 70
   final_stats: 0
   final_stats: 0
   final_stats: 16.07927
   final_stats: 9.17422
-  final_stats: 28.81892
+  final_stats: 28.79952
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -55,1220 +55,1220 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 1881.06271
-  tps: 1641.81748
+  dps: 1882.64017
+  tps: 1644.39397
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 1872.35293
-  tps: 1636.70719
+  dps: 1869.14634
+  tps: 1634.39201
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 1835.95185
-  tps: 1605.40485
+  dps: 1834.77617
+  tps: 1603.87171
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 1873.29607
-  tps: 1637.8964
+  dps: 1871.50189
+  tps: 1634.52493
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1686.93274
-  tps: 1475.78815
+  dps: 1688.11943
+  tps: 1477.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1832.8534
-  tps: 1603.50164
+  dps: 1834.35873
+  tps: 1605.09845
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 1893.01448
-  tps: 1651.90772
+  dps: 1890.18028
+  tps: 1650.4928
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1917.81898
-  tps: 1676.39484
+  dps: 1907.12846
+  tps: 1667.67861
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 1837.80682
-  tps: 1607.21991
+  dps: 1836.87894
+  tps: 1606.26963
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BattlecastGarb"
  value: {
-  dps: 1669.09044
-  tps: 1458.58657
+  dps: 1666.89332
+  tps: 1457.50318
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 1868.59692
-  tps: 1634.15731
+  dps: 1873.21296
+  tps: 1637.32842
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 1868.59692
-  tps: 1634.15731
+  dps: 1873.21296
+  tps: 1637.32842
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1880.81438
-  tps: 1642.43903
+  dps: 1877.83443
+  tps: 1638.57982
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1865.91385
-  tps: 1632.1961
+  dps: 1862.70032
+  tps: 1628.2587
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1862.29682
-  tps: 1626.33918
+  dps: 1859.78202
+  tps: 1623.96391
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1835.95185
-  tps: 1605.40485
+  dps: 1834.77617
+  tps: 1603.87171
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 1862.63839
-  tps: 1628.76212
+  dps: 1850.30441
+  tps: 1618.60357
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1833.88409
-  tps: 1604.40231
+  dps: 1835.38935
+  tps: 1605.99905
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1876.09707
-  tps: 1642.71762
+  dps: 1872.02516
+  tps: 1638.72739
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1737.13681
-  tps: 1519.61661
+  dps: 1732.31503
+  tps: 1515.36907
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1720.32362
-  tps: 1503.08652
+  dps: 1721.65061
+  tps: 1504.05717
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorruptorRaiment"
  value: {
-  dps: 1724.44353
-  tps: 1506.364
+  dps: 1732.78902
+  tps: 1514.15343
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1909.54121
-  tps: 1667.01711
+  dps: 1909.36377
+  tps: 1665.84852
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1907.12134
-  tps: 1664.21472
+  dps: 1908.09308
+  tps: 1666.06657
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1855.52584
-  tps: 1623.01467
+  dps: 1852.35146
+  tps: 1619.11181
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Despair-28573"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DirebrewHops-38288"
  value: {
-  dps: 1885.51176
-  tps: 1644.86291
+  dps: 1874.96797
+  tps: 1637.05779
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 1848.61699
-  tps: 1615.62797
+  dps: 1852.48634
+  tps: 1619.65291
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 1861.09071
-  tps: 1625.83831
+  dps: 1859.59648
+  tps: 1626.53402
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Earthstrike-21180"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1859.45844
-  tps: 1658.52737
+  dps: 1858.5545
+  tps: 1657.37847
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1839.91247
-  tps: 1608.64167
+  dps: 1844.42227
+  tps: 1612.87216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1885.51176
-  tps: 1644.86291
+  dps: 1874.96797
+  tps: 1637.05779
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1891.96162
-  tps: 1651.61894
+  dps: 1892.80872
+  tps: 1651.55905
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeofMoam-21473"
  value: {
-  dps: 1845.23276
-  tps: 1611.39019
+  dps: 1843.3564
+  tps: 1611.98809
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 1913.08589
-  tps: 1668.96704
+  dps: 1902.8696
+  tps: 1661.7752
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1860.39546
-  tps: 1627.77537
+  dps: 1861.69364
+  tps: 1629.2418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FrostscytheofLordAhune-278953"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 1881.06271
-  tps: 1641.81748
+  dps: 1882.64017
+  tps: 1644.39397
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 1843.34216
-  tps: 1612.24418
+  dps: 1839.96544
+  tps: 1608.16285
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HandofJustice-11815"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 1847.49859
-  tps: 1615.92223
+  dps: 1844.12153
+  tps: 1611.8406
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 1837.12574
-  tps: 1606.91901
+  dps: 1840.1602
+  tps: 1609.5533
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Heartrazor-29962"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 1848.38125
-  tps: 1614.55061
+  dps: 1846.35428
+  tps: 1612.99841
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1931.76514
-  tps: 1684.81812
+  dps: 1930.19568
+  tps: 1683.50711
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 1850.14013
-  tps: 1617.60609
+  dps: 1851.14413
+  tps: 1617.75578
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IceGuard-2682"
  value: {
-  dps: 1846.49209
-  tps: 1616.42916
+  dps: 1845.1696
+  tps: 1615.73826
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1702.45997
-  tps: 1484.21689
+  dps: 1707.44691
+  tps: 1488.54965
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InfinityBlade-30312"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JomGabbar-23570"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MaleficRaiment"
  value: {
-  dps: 1995.15928
-  tps: 1740.02323
+  dps: 1994.05453
+  tps: 1739.02217
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1582.9531
-  tps: 1383.60317
+  dps: 1582.02016
+  tps: 1383.38355
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 1831.6585
-  tps: 1600.50177
+  dps: 1840.50008
+  tps: 1608.20029
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1874.50338
-  tps: 1635.42339
+  dps: 1873.89199
+  tps: 1635.44153
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1889.96938
-  tps: 1655.58629
+  dps: 1884.22889
+  tps: 1650.51455
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1868.16843
-  tps: 1631.69216
+  dps: 1866.03027
+  tps: 1630.00451
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NetherweaveVestments"
  value: {
-  dps: 1546.46308
-  tps: 1355.18103
+  dps: 1551.35173
+  tps: 1359.33159
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OblivionRaiment"
  value: {
-  dps: 1565.58412
-  tps: 1367.11847
+  dps: 1566.16115
+  tps: 1367.2293
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 1865.13131
-  tps: 1627.95688
+  dps: 1866.89754
+  tps: 1632.86828
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1833.88409
-  tps: 1604.40231
+  dps: 1835.38935
+  tps: 1605.99905
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1833.88409
-  tps: 1604.40231
+  dps: 1835.38935
+  tps: 1605.99905
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1833.88409
-  tps: 1604.40231
+  dps: 1835.38935
+  tps: 1605.99905
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1833.88409
-  tps: 1604.40231
+  dps: 1835.38935
+  tps: 1605.99905
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1833.88409
-  tps: 1604.40231
+  dps: 1835.38935
+  tps: 1605.99905
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1862.93173
-  tps: 1625.81423
+  dps: 1858.40592
+  tps: 1622.94923
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PrimalMooncloth"
  value: {
-  dps: 1751.15638
-  tps: 1526.27492
+  dps: 1744.87251
+  tps: 1521.74544
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prismcharm-15867"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1881.88894
-  tps: 1645.29675
+  dps: 1875.91753
+  tps: 1639.54166
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuneofForce-25994"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SavageGuard-2681"
  value: {
-  dps: 1846.49209
-  tps: 1616.42916
+  dps: 1845.1696
+  tps: 1615.73826
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 1855.15704
-  tps: 1620.12182
+  dps: 1853.39997
+  tps: 1620.24066
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 1889.96938
-  tps: 1655.58629
+  dps: 1884.22889
+  tps: 1650.51455
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1859.31607
-  tps: 1625.44997
+  dps: 1856.99651
+  tps: 1623.58424
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1898.78779
-  tps: 1659.03893
+  dps: 1901.78047
+  tps: 1663.04546
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1798.95995
-  tps: 1575.08636
+  dps: 1798.15735
+  tps: 1574.08749
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1890.9453
-  tps: 1654.46277
+  dps: 1887.5445
+  tps: 1650.28018
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1944.84121
-  tps: 1702.9615
+  dps: 1949.29672
+  tps: 1706.71659
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1628.75409
-  tps: 1424.8516
+  dps: 1624.32887
+  tps: 1420.84006
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1745.38369
-  tps: 1528.41321
+  dps: 1743.42958
+  tps: 1526.30417
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 1856.13581
-  tps: 1622.32189
+  dps: 1853.33928
+  tps: 1620.40002
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 1846.48769
-  tps: 1615.12751
+  dps: 1844.36306
+  tps: 1612.59512
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1838.28686
-  tps: 1608.8936
+  dps: 1840.36441
+  tps: 1610.4568
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 1842.44065
-  tps: 1610.30426
+  dps: 1848.15496
+  tps: 1615.93744
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 1861.9657
-  tps: 1627.14602
+  dps: 1862.27343
+  tps: 1627.98686
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 1835.95185
-  tps: 1605.40485
+  dps: 1834.77617
+  tps: 1603.87171
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 1847.79071
-  tps: 1615.78292
+  dps: 1847.73618
+  tps: 1615.35384
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheBlackBook-19337"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1873.97275
-  tps: 1608.00842
+  dps: 1871.53629
+  tps: 1605.00571
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1897.42885
-  tps: 1656.06259
+  dps: 1902.02486
+  tps: 1658.91623
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1939.491
-  tps: 1698.65275
+  dps: 1941.78433
+  tps: 1700.58705
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1624.98411
-  tps: 1424.49519
+  dps: 1619.05408
+  tps: 1419.09807
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 1875.29818
-  tps: 1635.20498
+  dps: 1871.72723
+  tps: 1633.57973
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnitingCharm-25633"
  value: {
-  dps: 1835.1301
-  tps: 1604.99493
+  dps: 1831.75403
+  tps: 1600.91418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 1876.16566
-  tps: 1640.08186
+  dps: 1875.69168
+  tps: 1640.18613
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VoidStarTalisman-30449"
  value: {
-  dps: 1881.72962
-  tps: 1643.23104
+  dps: 1878.94207
+  tps: 1639.53667
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VoidheartRaiment"
  value: {
-  dps: 1688.32664
-  tps: 1468.40121
+  dps: 1687.21749
+  tps: 1468.65883
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 1859.39166
-  tps: 1622.66364
+  dps: 1857.57886
+  tps: 1620.66533
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WhitemendWisdom"
  value: {
-  dps: 1628.6571
-  tps: 1424.13897
+  dps: 1627.40362
+  tps: 1422.95106
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 1861.99947
-  tps: 1628.57614
+  dps: 1857.55409
+  tps: 1624.96419
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WrathofSpellfire"
  value: {
-  dps: 1711.19555
-  tps: 1494.07839
+  dps: 1708.01328
+  tps: 1489.70873
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 1837.12574
-  tps: 1606.91901
+  dps: 1840.1602
+  tps: 1609.5533
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1886.57577
-  tps: 1649.54533
+  dps: 1884.43287
+  tps: 1647.83541
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 1913.82764
-  tps: 1674.15123
+  dps: 1913.50592
+  tps: 1673.91518
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1866.20103
-  tps: 2766.47373
+  dps: 1872.04218
+  tps: 2774.71542
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1866.20103
-  tps: 1631.73623
+  dps: 1872.04218
+  tps: 1636.50902
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2255.21635
-  tps: 1962.13727
+  dps: 2256.26707
+  tps: 1963.21404
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 963.92871
-  tps: 2060.8234
+  dps: 963.58483
+  tps: 2067.76477
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 963.92871
-  tps: 862.4934
+  dps: 963.58483
+  tps: 862.90088
  }
 }
 dps_results: {
@@ -1281,22 +1281,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Orc-preraid-Destruction-destruction-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1876.24353
-  tps: 2799.21589
+  dps: 1878.48529
+  tps: 2801.15146
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-preraid-Destruction-destruction-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-preraid-Destruction-destruction-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2280.98677
-  tps: 1985.6206
+  dps: 2280.81704
+  tps: 1985.42565
  }
 }
 dps_results: {
@@ -1323,7 +1323,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1876.24353
-  tps: 1642.37572
+  dps: 1878.48529
+  tps: 1644.08376
  }
 }

--- a/sim/warlock/TestDestruction.results
+++ b/sim/warlock/TestDestruction.results
@@ -5,8 +5,8 @@ character_stats_results: {
   final_stats: 183
   final_stats: 748
   final_stats: 402
-  final_stats: 1003.5
-  final_stats: 990.5
+  final_stats: 1005.9
+  final_stats: 992.9
   final_stats: 0
   final_stats: 0
   final_stats: 233
@@ -17,7 +17,7 @@ character_stats_results: {
   final_stats: 203
   final_stats: 0
   final_stats: 15
-  final_stats: 205
+  final_stats: 229
   final_stats: 1049.4
   final_stats: 389
   final_stats: 0
@@ -55,1206 +55,1206 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 1882.64017
-  tps: 1644.39397
+  dps: 1885.88065
+  tps: 1646.23814
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 1869.14634
-  tps: 1634.39201
+  dps: 1871.10487
+  tps: 1636.18273
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 1834.77617
-  tps: 1603.87171
+  dps: 1837.57379
+  tps: 1606.73196
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 1871.50189
-  tps: 1634.52493
+  dps: 1874.37679
+  tps: 1636.5679
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1688.11943
-  tps: 1477.27684
+  dps: 1689.52127
+  tps: 1478.57643
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 1834.35873
-  tps: 1605.09845
+  dps: 1836.3245
+  tps: 1606.80244
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 1890.18028
-  tps: 1650.4928
+  dps: 1889.12356
+  tps: 1649.33619
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 1907.12846
-  tps: 1667.67861
+  dps: 1908.25401
+  tps: 1668.61185
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 1836.87894
-  tps: 1606.26963
+  dps: 1839.27962
+  tps: 1608.50865
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BattlecastGarb"
  value: {
-  dps: 1666.89332
-  tps: 1457.50318
+  dps: 1669.12939
+  tps: 1459.46556
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 1873.21296
-  tps: 1637.32842
+  dps: 1873.83286
+  tps: 1637.86486
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 1873.21296
-  tps: 1637.32842
+  dps: 1873.83286
+  tps: 1637.86486
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 1877.83443
-  tps: 1638.57982
+  dps: 1880.79872
+  tps: 1640.90358
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 1862.70032
-  tps: 1628.2587
+  dps: 1867.2947
+  tps: 1633.19268
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 1859.78202
-  tps: 1623.96391
+  dps: 1861.97153
+  tps: 1625.85819
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 1834.77617
-  tps: 1603.87171
+  dps: 1837.57379
+  tps: 1606.73196
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 1850.30441
-  tps: 1618.60357
+  dps: 1857.1557
+  tps: 1624.02311
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Blinkstrike-31332"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 1835.38935
-  tps: 1605.99905
+  dps: 1837.35624
+  tps: 1607.70403
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 1872.02516
-  tps: 1638.72739
+  dps: 1874.5952
+  tps: 1641.74324
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1732.31503
-  tps: 1515.36907
+  dps: 1736.16529
+  tps: 1518.53175
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1721.65061
-  tps: 1504.05717
+  dps: 1723.61622
+  tps: 1505.3792
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorruptorRaiment"
  value: {
-  dps: 1732.78902
-  tps: 1514.15343
+  dps: 1732.14294
+  tps: 1513.28964
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 1909.36377
-  tps: 1665.84852
+  dps: 1910.10072
+  tps: 1666.76683
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 1908.09308
-  tps: 1666.06657
+  dps: 1911.81108
+  tps: 1669.36206
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 1852.35146
-  tps: 1619.11181
+  dps: 1856.93384
+  tps: 1624.03519
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Despair-28573"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DirebrewHops-38288"
  value: {
-  dps: 1874.96797
-  tps: 1637.05779
+  dps: 1883.65269
+  tps: 1642.86207
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 1852.48634
-  tps: 1619.65291
+  dps: 1855.35779
+  tps: 1622.14186
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 1859.59648
-  tps: 1626.53402
+  dps: 1861.77608
+  tps: 1628.18566
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Earthstrike-21180"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 1858.5545
-  tps: 1657.37847
+  dps: 1860.75044
+  tps: 1659.31865
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 1844.42227
-  tps: 1612.87216
+  dps: 1845.13671
+  tps: 1613.42147
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 1874.96797
-  tps: 1637.05779
+  dps: 1883.65269
+  tps: 1642.86207
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 1892.80872
-  tps: 1651.55905
+  dps: 1892.17989
+  tps: 1650.9545
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeofMoam-21473"
  value: {
-  dps: 1843.3564
-  tps: 1611.98809
+  dps: 1843.87581
+  tps: 1612.21034
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 1902.8696
-  tps: 1661.7752
+  dps: 1904.96094
+  tps: 1663.50853
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 1861.69364
-  tps: 1629.2418
+  dps: 1863.69339
+  tps: 1630.9758
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FrostscytheofLordAhune-278953"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 1882.64017
-  tps: 1644.39397
+  dps: 1885.88065
+  tps: 1646.23814
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 1839.96544
-  tps: 1608.16285
+  dps: 1844.53331
+  tps: 1613.07341
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HandofJustice-11815"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 1844.12153
-  tps: 1611.8406
+  dps: 1848.69473
+  tps: 1616.75588
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 1840.1602
-  tps: 1609.5533
+  dps: 1843.11667
+  tps: 1611.80749
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Heartrazor-29962"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 1846.35428
-  tps: 1612.99841
+  dps: 1848.51539
+  tps: 1614.84263
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 1930.19568
-  tps: 1683.50711
+  dps: 1933.28293
+  tps: 1685.97405
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 1851.14413
-  tps: 1617.75578
+  dps: 1852.08569
+  tps: 1618.35272
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IceGuard-2682"
  value: {
-  dps: 1845.1696
-  tps: 1615.73826
+  dps: 1845.30974
+  tps: 1614.82746
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1707.44691
-  tps: 1488.54965
+  dps: 1709.87721
+  tps: 1490.63014
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InfinityBlade-30312"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JomGabbar-23570"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KhoriumScope-2723"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LionheartChampion-28429"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MaleficRaiment"
  value: {
-  dps: 1994.05453
-  tps: 1739.02217
+  dps: 1997.26951
+  tps: 1741.87537
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1582.02016
-  tps: 1383.38355
+  dps: 1584.43801
+  tps: 1385.69274
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 1840.50008
-  tps: 1608.20029
+  dps: 1842.40325
+  tps: 1608.93976
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 1873.89199
-  tps: 1635.44153
+  dps: 1874.74633
+  tps: 1635.68352
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 1884.22889
-  tps: 1650.51455
+  dps: 1887.26883
+  tps: 1653.11871
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 1866.03027
-  tps: 1630.00451
+  dps: 1868.9877
+  tps: 1632.99265
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NetherweaveVestments"
  value: {
-  dps: 1551.35173
-  tps: 1359.33159
+  dps: 1548.69466
+  tps: 1356.48918
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OblivionRaiment"
  value: {
-  dps: 1566.16115
-  tps: 1367.2293
+  dps: 1568.34368
+  tps: 1369.20606
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 1866.89754
-  tps: 1632.86828
+  dps: 1866.81712
+  tps: 1632.54273
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 1835.38935
-  tps: 1605.99905
+  dps: 1837.35624
+  tps: 1607.70403
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 1835.38935
-  tps: 1605.99905
+  dps: 1837.35624
+  tps: 1607.70403
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantofThawing-24093"
  value: {
-  dps: 1835.38935
-  tps: 1605.99905
+  dps: 1837.35624
+  tps: 1607.70403
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantofWithering-24095"
  value: {
-  dps: 1835.38935
-  tps: 1605.99905
+  dps: 1837.35624
+  tps: 1607.70403
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 1835.38935
-  tps: 1605.99905
+  dps: 1837.35624
+  tps: 1607.70403
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 1858.40592
-  tps: 1622.94923
+  dps: 1857.27293
+  tps: 1621.9333
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PrimalMooncloth"
  value: {
-  dps: 1744.87251
-  tps: 1521.74544
+  dps: 1754.37496
+  tps: 1528.51324
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prismcharm-15867"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 1875.91753
-  tps: 1639.54166
+  dps: 1877.65853
+  tps: 1641.05555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuneofForce-25994"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SavageGuard-2681"
  value: {
-  dps: 1845.1696
-  tps: 1615.73826
+  dps: 1845.30974
+  tps: 1614.82746
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 1853.39997
-  tps: 1620.24066
+  dps: 1853.08746
+  tps: 1620.26301
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 1884.22889
-  tps: 1650.51455
+  dps: 1887.26883
+  tps: 1653.11871
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 1856.99651
-  tps: 1623.58424
+  dps: 1859.07442
+  tps: 1625.24174
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 1901.78047
-  tps: 1663.04546
+  dps: 1901.8076
+  tps: 1662.28444
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1798.15735
-  tps: 1574.08749
+  dps: 1800.79837
+  tps: 1576.52806
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShardofContempt-34472"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 1887.5445
-  tps: 1650.28018
+  dps: 1890.82969
+  tps: 1653.82392
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 1949.29672
-  tps: 1706.71659
+  dps: 1950.53639
+  tps: 1707.72649
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1624.32887
-  tps: 1420.84006
+  dps: 1626.1764
+  tps: 1422.15525
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1743.42958
-  tps: 1526.30417
+  dps: 1746.73862
+  tps: 1529.42476
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StaffoftheQirajiProphets-21128"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 1853.33928
-  tps: 1620.40002
+  dps: 1855.50228
+  tps: 1622.40928
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 1844.36306
-  tps: 1612.59512
+  dps: 1847.19087
+  tps: 1615.08069
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 1840.36441
-  tps: 1610.4568
+  dps: 1843.16747
+  tps: 1612.84519
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 1848.15496
-  tps: 1615.93744
+  dps: 1850.35005
+  tps: 1617.83883
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 1862.27343
-  tps: 1627.98686
+  dps: 1864.46699
+  tps: 1629.88783
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 1834.77617
-  tps: 1603.87171
+  dps: 1837.57379
+  tps: 1606.73196
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 1847.73618
-  tps: 1615.35384
+  dps: 1850.06074
+  tps: 1617.62867
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheBlackBook-19337"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 1871.53629
-  tps: 1605.00571
+  dps: 1874.67067
+  tps: 1608.54143
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheNightBlade-31331"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 1902.02486
-  tps: 1658.91623
+  dps: 1902.39941
+  tps: 1660.45874
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 1941.78433
-  tps: 1700.58705
+  dps: 1943.07901
+  tps: 1701.87529
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 1619.05408
-  tps: 1419.09807
+  dps: 1622.71703
+  tps: 1422.4859
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 1871.72723
-  tps: 1633.57973
+  dps: 1873.54676
+  tps: 1634.23731
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnitingCharm-25633"
  value: {
-  dps: 1831.75403
-  tps: 1600.91418
+  dps: 1836.31158
+  tps: 1605.81562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 1875.69168
-  tps: 1640.18613
+  dps: 1877.65823
+  tps: 1641.98395
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VoidStarTalisman-30449"
  value: {
-  dps: 1878.94207
-  tps: 1639.53667
+  dps: 1883.18813
+  tps: 1643.18019
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VoidheartRaiment"
  value: {
-  dps: 1687.21749
-  tps: 1468.65883
+  dps: 1688.40971
+  tps: 1469.08481
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 1857.57886
-  tps: 1620.66533
+  dps: 1860.34644
+  tps: 1622.60375
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WarpSlicer-30311"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WhitemendWisdom"
  value: {
-  dps: 1627.40362
-  tps: 1422.95106
+  dps: 1628.60834
+  tps: 1423.92055
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 1857.55409
-  tps: 1624.96419
+  dps: 1860.52936
+  tps: 1627.62295
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WrathofSpellfire"
  value: {
-  dps: 1708.01328
-  tps: 1489.70873
+  dps: 1709.14618
+  tps: 1490.86709
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 1840.1602
-  tps: 1609.5533
+  dps: 1843.11667
+  tps: 1611.80749
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 1884.43287
-  tps: 1647.83541
+  dps: 1886.54327
+  tps: 1649.52162
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 1913.50592
-  tps: 1673.91518
+  dps: 1915.82974
+  tps: 1675.95838
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1871.94955
-  tps: 2774.59384
+  dps: 1873.11721
+  tps: 2771.77014
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1871.94955
-  tps: 1636.42881
+  dps: 1873.11721
+  tps: 1636.81442
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2256.15549
-  tps: 1963.11826
+  dps: 2258.83339
+  tps: 1965.41702
  }
 }
 dps_results: {
@@ -1281,22 +1281,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Orc-preraid-Destruction-destruction-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1878.48529
-  tps: 2801.15146
+  dps: 1881.39325
+  tps: 2804.6457
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-preraid-Destruction-destruction-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-preraid-Destruction-destruction-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2280.81704
-  tps: 1985.42565
+  dps: 2283.4596
+  tps: 1987.69605
  }
 }
 dps_results: {
@@ -1323,7 +1323,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1878.48529
-  tps: 1644.08376
+  dps: 1881.39325
+  tps: 1646.56467
  }
 }

--- a/sim/warlock/TestDestruction.results
+++ b/sim/warlock/TestDestruction.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 193
   final_stats: 183
-  final_stats: 747
+  final_stats: 748
   final_stats: 402
   final_stats: 1003.5
   final_stats: 990.5
@@ -34,7 +34,7 @@ character_stats_results: {
   final_stats: 7
   final_stats: 3088
   final_stats: 0
-  final_stats: 12298.2
+  final_stats: 12308.5
   final_stats: 8615.95
   final_stats: 122.5
   final_stats: 33
@@ -1239,36 +1239,36 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1876.18588
-  tps: 2795.34309
+  dps: 1871.94955
+  tps: 2774.59384
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 1876.18588
-  tps: 1640.87205
+  dps: 1871.94955
+  tps: 1636.42881
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2252.4446
-  tps: 1961.45968
+  dps: 2256.15549
+  tps: 1963.11826
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 961.52403
-  tps: 2067.33478
+  dps: 963.58483
+  tps: 2067.76477
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Gnome-preraid-Destruction-destruction-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 961.52403
-  tps: 860.83478
+  dps: 963.58483
+  tps: 862.90088
  }
 }
 dps_results: {

--- a/sim/warlock/talents.go
+++ b/sim/warlock/talents.go
@@ -271,7 +271,7 @@ func (warlock *Warlock) applyDemonicEmbrace() {
 	}
 
 	warlock.MultiplyStat(stats.Stamina, 1.0+(0.03)*float64(warlock.Talents.DemonicEmbrace))
-	warlock.MultiplyStat(stats.Spirit, 1.0-(0.03)*float64(warlock.Talents.DemonicEmbrace))
+	warlock.MultiplyStat(stats.Spirit, 1.0-(0.01)*float64(warlock.Talents.DemonicEmbrace))
 }
 
 func (warlock *Warlock) applyFelIntellect() {

--- a/sim/warrior/dps/TestDpsWarrior.results
+++ b/sim/warrior/dps/TestDpsWarrior.results
@@ -3,10 +3,10 @@ character_stats_results: {
  value: {
   final_stats: 785
   final_stats: 398
-  final_stats: 775
+  final_stats: 776
   final_stats: 103
-  final_stats: 232.7
-  final_stats: 219.7
+  final_stats: 232.2
+  final_stats: 219.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,7 +17,7 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 167
+  final_stats: 162
   final_stats: 3759.47
   final_stats: 965
   final_stats: 0
@@ -34,7 +34,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 10288
   final_stats: 0
-  final_stats: 13184
+  final_stats: 13194
   final_stats: 0
   final_stats: 122.5
   final_stats: 33

--- a/sim/warrior/dps/TestDpsWarrior.results
+++ b/sim/warrior/dps/TestDpsWarrior.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestDpsWarrior-CharacterStats-Default"
  value: {
-  final_stats: 787.38
-  final_stats: 399.795
-  final_stats: 777.26
-  final_stats: 104.39
-  final_stats: 232.819
-  final_stats: 219.819
+  final_stats: 785
+  final_stats: 398
+  final_stats: 775
+  final_stats: 103
+  final_stats: 232.7
+  final_stats: 219.7
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 168.19
-  final_stats: 3765.8346
+  final_stats: 167
+  final_stats: 3759.47
   final_stats: 965
   final_stats: 0
   final_stats: 96
@@ -28,24 +28,24 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 39.369
-  final_stats: 252.17841
+  final_stats: 39.25
+  final_stats: 251.04618
   final_stats: 0
   final_stats: 0
-  final_stats: 10291.99
+  final_stats: 10288
   final_stats: 0
-  final_stats: 13206.6
+  final_stats: 13184
   final_stats: 0
-  final_stats: 122.7
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
+  final_stats: 122.5
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
   final_stats: 70
   final_stats: 0
   final_stats: 6.0878
   final_stats: 3
-  final_stats: 41.69978
+  final_stats: 41.64539
   final_stats: 12.17422
   final_stats: 0
   final_stats: 0
@@ -55,5024 +55,5024 @@ character_stats_results: {
 dps_results: {
  key: "TestDpsWarrior-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 2086.14513
-  tps: 1571.30654
-  dtps: 7.2778
+  dps: 2092.19317
+  tps: 1575.78073
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 2051.68326
-  tps: 1545.60628
-  dtps: 7.2778
+  dps: 2048.45231
+  tps: 1543.56904
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Annihilator-12798"
  value: {
-  dps: 1883.78847
-  tps: 1430.06729
-  dtps: 7.2778
+  dps: 1881.69746
+  tps: 1427.27617
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 1868.61836
-  tps: 1412.10495
-  dtps: 7.2778
+  dps: 1871.45131
+  tps: 1413.79425
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 2046.3888
-  tps: 1542.63838
-  dtps: 7.2778
+  dps: 2042.5741
+  tps: 1539.43289
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 2120.68273
-  tps: 1598.34366
-  dtps: 7.2778
+  dps: 2126.82724
+  tps: 1602.60167
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 2051.43206
-  tps: 1546.70484
-  dtps: 7.2778
+  dps: 2044.81372
+  tps: 1541.52699
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 2051.43206
-  tps: 1546.70484
-  dtps: 7.2778
+  dps: 2044.81372
+  tps: 1541.52699
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-BattlecastGarb"
  value: {
-  dps: 1761.40424
-  tps: 1327.61763
-  dtps: 7.21755
+  dps: 1762.04365
+  tps: 1329.5559
+  dtps: 7.3006
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 2042.60721
-  tps: 1540.71116
-  dtps: 7.2778
+  dps: 2044.51536
+  tps: 1542.8597
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 2042.60721
-  tps: 1540.71116
-  dtps: 7.2778
+  dps: 2044.51536
+  tps: 1542.8597
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 2074.78344
-  tps: 1563.59
-  dtps: 7.2778
+  dps: 2059.12496
+  tps: 1552.43227
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 2056.1399
-  tps: 1548.12469
-  dtps: 7.2778
+  dps: 2064.2802
+  tps: 1553.66341
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 2108.53629
-  tps: 1588.30401
-  dtps: 7.2778
+  dps: 2109.8041
+  tps: 1589.37648
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 2148.42415
-  tps: 1618.18592
-  dtps: 7.2778
+  dps: 2148.96997
+  tps: 1618.45266
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 2093.19289
-  tps: 1578.12434
-  dtps: 7.2778
+  dps: 2090.21327
+  tps: 1574.86674
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 1848.54387
-  tps: 1398.42279
-  dtps: 7.2778
+  dps: 1844.82904
+  tps: 1394.74544
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Blinkstrike-31332"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 2112.47298
-  tps: 1591.44169
-  dtps: 7.2778
+  dps: 2106.0007
+  tps: 1586.71346
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 2099.22599
-  tps: 1583.39995
-  dtps: 7.2778
+  dps: 2107.93319
+  tps: 1590.50446
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 2080.04797
-  tps: 1568.85687
-  dtps: 7.2778
+  dps: 2080.7259
+  tps: 1570.29079
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 1953.41882
-  tps: 1475.25153
-  dtps: 7.21755
+  dps: 1950.07144
+  tps: 1472.12145
+  dtps: 7.3006
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 2061.10013
-  tps: 1552.08304
-  dtps: 7.2778
+  dps: 2053.30921
+  tps: 1545.89798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 1953.41882
-  tps: 1475.25153
-  dtps: 7.21755
+  dps: 1950.07144
+  tps: 1472.12145
+  dtps: 7.3006
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 2049.10389
-  tps: 1544.05325
-  dtps: 7.2778
+  dps: 2036.84593
+  tps: 1534.19201
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 2071.13945
-  tps: 1561.63292
-  dtps: 7.2778
+  dps: 2076.30513
+  tps: 1564.46853
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 2062.32909
-  tps: 1553.80311
-  dtps: 7.2778
+  dps: 2059.83795
+  tps: 1551.9165
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Despair-28573"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Devastation-30316"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-DirebrewHops-38288"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-DonSantos'FamousHuntingRifle-31323"
  value: {
-  dps: 2130.09107
-  tps: 1605.76361
-  dtps: 7.2778
+  dps: 2121.82927
+  tps: 1601.1455
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Dragonstrike-28439"
  value: {
-  dps: 2084.56573
-  tps: 1570.85879
-  dtps: 7.2778
+  dps: 2072.69557
+  tps: 1563.46461
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 2066.85994
-  tps: 1561.1022
-  dtps: 7.2778
+  dps: 2062.75375
+  tps: 1557.7321
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Earthstrike-21180"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 2112.47298
-  tps: 1591.44169
-  dtps: 7.2778
+  dps: 2106.0007
+  tps: 1586.71346
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EnchantBoots-Boar'sSpeed-2940"
  value: {
-  dps: 2152.52924
-  tps: 1624.0117
-  dtps: 7.2778
+  dps: 2145.34513
+  tps: 1619.57879
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 2149.42387
-  tps: 1589.25483
-  dtps: 7.2778
+  dps: 2135.28789
+  tps: 1579.73811
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EnchantGloves-Threat-2613"
  value: {
-  dps: 2141.94498
-  tps: 1646.38788
-  dtps: 7.2778
+  dps: 2137.45029
+  tps: 1646.75904
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 2111.62208
-  tps: 1591.19814
-  dtps: 7.2778
+  dps: 2116.5459
+  tps: 1595.0618
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 2097.64923
-  tps: 1581.24472
-  dtps: 7.2778
+  dps: 2086.63413
+  tps: 1572.78849
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 2145.10538
-  tps: 1617.31085
-  dtps: 7.2778
+  dps: 2149.9485
+  tps: 1621.7997
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EyeofMoam-21473"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 2073.56871
-  tps: 1564.23209
+  dps: 2072.68801
+  tps: 1563.74474
   dtps: 7.70262
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-FelSkin"
  value: {
-  dps: 1990.37275
-  tps: 1503.17528
-  dtps: 7.2778
+  dps: 2000.84182
+  tps: 1511.181
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 2063.87227
-  tps: 1554.14622
-  dtps: 7.2778
+  dps: 2058.71879
+  tps: 1550.90612
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-HandofJustice-11815"
  value: {
-  dps: 2052.33311
-  tps: 1547.23438
-  dtps: 7.2778
+  dps: 2050.64324
+  tps: 1545.68869
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 2081.37603
-  tps: 1569.16617
-  dtps: 7.2778
+  dps: 2075.00964
+  tps: 1564.08308
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-IceGuard-2682"
  value: {
-  dps: 2061.88893
-  tps: 1553.17971
-  dtps: 7.2778
+  dps: 2066.88312
+  tps: 1557.71399
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-IconofUnyieldingCourage-28121"
  value: {
-  dps: 2076.17915
-  tps: 1564.88988
-  dtps: 7.2778
+  dps: 2086.84389
+  tps: 1572.5026
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-ImbuedNetherweave"
  value: {
-  dps: 1778.43276
-  tps: 1342.06833
-  dtps: 7.2778
+  dps: 1774.4766
+  tps: 1338.63182
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-JomGabbar-23570"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-KhoriumScope-2723"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 2090.13272
-  tps: 1574.71692
-  dtps: 7.2778
+  dps: 2080.49049
+  tps: 1568.92785
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-LionheartChampion-28429"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-LionheartExecutioner-28430"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 2041.67653
-  tps: 1539.54564
+  dps: 2042.82235
+  tps: 1541.03969
   dtps: 7.1912
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 2110.31446
-  tps: 1591.65652
-  dtps: 7.2778
+  dps: 2097.73411
+  tps: 1581.01263
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 1504.37853
-  tps: 1134.89681
+  dps: 1494.74201
+  tps: 1128.31003
   dtps: 7.88953
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 2026.0243
-  tps: 1529.41402
-  dtps: 7.2778
+  dps: 2026.60066
+  tps: 1530.36087
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-NetherweaveVestments"
  value: {
-  dps: 1580.50051
-  tps: 1195.1295
-  dtps: 7.2778
+  dps: 1580.35441
+  tps: 1194.76524
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 2056.02012
-  tps: 1548.86959
-  dtps: 7.2778
+  dps: 2041.74751
+  tps: 1537.41482
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 2082.47629
-  tps: 1571.51124
+  dps: 2078.22332
+  tps: 1567.68406
   dtps: 6.90392
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 2080.04797
-  tps: 1568.85687
-  dtps: 7.2778
+  dps: 2080.7259
+  tps: 1570.29079
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-PendantofThawing-24093"
  value: {
-  dps: 2080.04797
-  tps: 1568.85687
-  dtps: 7.2778
+  dps: 2080.7259
+  tps: 1570.29079
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-PendantofWithering-24095"
  value: {
-  dps: 2080.04797
-  tps: 1568.85687
-  dtps: 7.2778
+  dps: 2080.7259
+  tps: 1570.29079
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 2080.04797
-  tps: 1568.85687
-  dtps: 7.2778
+  dps: 2080.7259
+  tps: 1570.29079
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-PrimalIntent"
  value: {
-  dps: 2069.08859
-  tps: 1560.02848
-  dtps: 7.2778
+  dps: 2064.03031
+  tps: 1555.9698
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-PrimalMooncloth"
  value: {
-  dps: 1821.87185
-  tps: 1375.88477
-  dtps: 7.2778
+  dps: 1821.05146
+  tps: 1374.86994
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Prismcharm-15867"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 2036.95156
-  tps: 1536.25882
-  dtps: 7.2778
+  dps: 2039.37896
+  tps: 1538.59165
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 2026.0243
-  tps: 1529.41402
-  dtps: 7.2778
+  dps: 2026.60066
+  tps: 1530.36087
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 2070.74694
-  tps: 1559.8961
-  dtps: 7.2778
+  dps: 2058.98268
+  tps: 1550.98804
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-RuneofForce-25994"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-SavageGuard-2681"
  value: {
-  dps: 2061.88893
-  tps: 1553.17971
-  dtps: 7.2778
+  dps: 2066.88312
+  tps: 1557.71399
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 1834.15925
-  tps: 1384.17667
-  dtps: 7.2778
+  dps: 1838.37861
+  tps: 1387.37875
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-ShardofContempt-34472"
  value: {
-  dps: 2137.26658
-  tps: 1620.75592
-  dtps: 7.2778
+  dps: 2135.39
+  tps: 1620.43096
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 2042.84073
-  tps: 1540.74623
-  dtps: 7.2778
+  dps: 2045.48294
+  tps: 1543.53267
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 2102.70709
-  tps: 1583.84434
-  dtps: 7.2778
+  dps: 2102.22629
+  tps: 1582.30601
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Solarian'sSapphire-30446"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-SoulclothEmbrace"
  value: {
-  dps: 1810.79148
-  tps: 1368.16394
-  dtps: 7.2778
+  dps: 1811.6949
+  tps: 1369.64795
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 1761.40424
-  tps: 1327.61763
-  dtps: 7.21755
+  dps: 1762.04365
+  tps: 1329.5559
+  dtps: 7.3006
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 2092.25169
-  tps: 1589.16706
-  dtps: 7.2778
+  dps: 2088.7807
+  tps: 1584.97411
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 1778.43276
-  tps: 1342.06833
-  dtps: 7.2778
+  dps: 1774.4766
+  tps: 1338.63182
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2085.76689
-  tps: 1572.47502
-  dtps: 7.21755
+  dps: 2084.09968
+  tps: 1571.60491
+  dtps: 7.3006
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 2042.8506
-  tps: 1540.28096
-  dtps: 7.2778
+  dps: 2050.53216
+  tps: 1546.67672
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-TheBladefist-29348"
  value: {
-  dps: 1982.4682
-  tps: 1494.40675
-  dtps: 7.2778
+  dps: 1988.67835
+  tps: 1498.47069
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2212.53206
-  tps: 1660.70319
-  dtps: 7.2778
+  dps: 2213.57438
+  tps: 1662.52086
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-ThickDraenicArmor"
  value: {
-  dps: 1882.09226
-  tps: 1423.06445
-  dtps: 7.2778
+  dps: 1876.14638
+  tps: 1417.2075
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 2098.12004
-  tps: 1581.45066
-  dtps: 7.2778
+  dps: 2104.68744
+  tps: 1586.10782
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-UnitingCharm-25633"
  value: {
-  dps: 2056.02012
-  tps: 1548.86959
-  dtps: 7.2778
+  dps: 2041.74751
+  tps: 1537.41482
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-WarpSlicer-30311"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-WastewalkerArmor"
  value: {
-  dps: 1816.21707
-  tps: 1373.28643
-  dtps: 7.21755
+  dps: 1809.4684
+  tps: 1367.67851
+  dtps: 7.3006
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-WhitemendWisdom"
  value: {
-  dps: 1761.40424
-  tps: 1327.61763
-  dtps: 7.21755
+  dps: 1762.04365
+  tps: 1329.5559
+  dtps: 7.3006
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-WindhawkArmor"
  value: {
-  dps: 1873.16846
-  tps: 1416.38655
-  dtps: 7.2778
+  dps: 1874.99199
+  tps: 1418.01383
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-WorldBreaker-30090"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 2051.43206
-  tps: 1546.70484
-  dtps: 7.2778
+  dps: 2044.81372
+  tps: 1541.52699
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-WrathofSpellfire"
  value: {
-  dps: 1842.01453
-  tps: 1391.96635
-  dtps: 7.2778
+  dps: 1844.80933
+  tps: 1394.01157
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 2041.34064
-  tps: 1539.30946
-  dtps: 7.2778
+  dps: 2043.15491
+  tps: 1541.21798
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Average-Default"
  value: {
-  dps: 2141.78982
-  tps: 1613.82999
-  dtps: 7.30748
+  dps: 2138.35239
+  tps: 1611.27455
+  dtps: 7.31653
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3946.92134
-  tps: 3370.94828
+  dps: 3944.21476
+  tps: 3368.19696
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1914.36487
-  tps: 1589.50101
-  dtps: 7.2778
+  dps: 1904.91288
+  tps: 1580.86438
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2202.24943
-  tps: 1830.18686
-  dtps: 21.83341
+  dps: 2205.27693
+  tps: 1835.5692
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 911.27589
-  tps: 820.98406
+  dps: 911.18656
+  tps: 821.51971
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 567.48485
-  tps: 497.20524
+  dps: 567.17836
+  tps: 497.10586
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 589.92808
-  tps: 523.46149
+  dps: 592.46942
+  tps: 525.27594
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3618.16029
-  tps: 3158.75017
+  dps: 3614.48853
+  tps: 3154.93816
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1415.59994
-  tps: 1248.06384
-  dtps: 7.2778
+  dps: 1400.12956
+  tps: 1234.74964
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1702.09624
-  tps: 1492.26119
-  dtps: 21.83341
+  dps: 1698.98394
+  tps: 1490.07116
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 905.15954
-  tps: 841.61529
+  dps: 905.04876
+  tps: 841.51917
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 497.93661
-  tps: 459.15293
+  dps: 497.87665
+  tps: 459.10197
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 536.68074
-  tps: 500.11983
+  dps: 536.61581
+  tps: 500.06434
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3628.96675
-  tps: 2908.35667
+  dps: 3630.86272
+  tps: 2910.5135
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1428.08785
-  tps: 1124.2594
-  dtps: 7.2778
+  dps: 1422.84475
+  tps: 1120.48986
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1692.85639
-  tps: 1322.28947
-  dtps: 21.83341
+  dps: 1697.49424
+  tps: 1325.83814
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 899.28976
-  tps: 822.59237
+  dps: 893.78964
+  tps: 818.22822
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 492.62592
-  tps: 409.47337
+  dps: 492.48906
+  tps: 409.46012
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 507.11945
-  tps: 424.484
+  dps: 507.05365
+  tps: 424.6106
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3820.87178
-  tps: 2989.64313
+  dps: 3805.04807
+  tps: 2978.44311
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1696.89999
-  tps: 1274.40354
-  dtps: 7.2778
+  dps: 1701.11656
+  tps: 1277.21126
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1986.15007
-  tps: 1486.92521
-  dtps: 21.83341
+  dps: 1989.89193
+  tps: 1490.32895
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 896.00644
-  tps: 793.98911
+  dps: 896.07688
+  tps: 793.91836
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 514.41862
-  tps: 404.66654
+  dps: 513.83176
+  tps: 404.18097
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 540.01926
-  tps: 431.1948
+  dps: 541.39917
+  tps: 432.69026
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3131.17898
-  tps: 2719.73598
+  dps: 3102.54171
+  tps: 2695.1181
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1478.20056
-  tps: 1236.51788
-  dtps: 7.2778
+  dps: 1478.40931
+  tps: 1236.40194
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1786.30541
-  tps: 1498.6943
-  dtps: 21.83341
+  dps: 1784.02391
+  tps: 1496.45278
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 710.74694
-  tps: 662.31975
+  dps: 705.86859
+  tps: 657.72556
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 426.19403
-  tps: 384.52266
+  dps: 424.64989
+  tps: 383.68965
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 460.80033
-  tps: 422.24064
+  dps: 460.73172
+  tps: 422.18302
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3493.92498
-  tps: 3058.87906
+  dps: 3480.11907
+  tps: 3046.69339
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1591.8549
-  tps: 1403.03029
-  dtps: 7.2778
+  dps: 1585.24287
+  tps: 1396.86059
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1863.27385
-  tps: 1628.32453
-  dtps: 21.83341
+  dps: 1863.51622
+  tps: 1627.40779
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 888.09417
-  tps: 825.30656
+  dps: 887.97331
+  tps: 825.20258
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 535.70477
-  tps: 490.76246
+  dps: 535.63572
+  tps: 490.70505
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 561.52963
-  tps: 521.60217
+  dps: 561.45556
+  tps: 521.54002
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4166.18591
-  tps: 3388.65938
+  dps: 4163.92601
+  tps: 3388.38415
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1908.74812
-  tps: 1499.39084
-  dtps: 7.2778
+  dps: 1906.26052
+  tps: 1498.21171
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2305.85004
-  tps: 1801.77308
-  dtps: 21.83341
+  dps: 2304.6323
+  tps: 1800.93423
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1045.96313
-  tps: 974.28534
+  dps: 1042.11357
+  tps: 970.90511
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 622.2577
-  tps: 516.91628
+  dps: 622.1743
+  tps: 516.85465
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 659.39864
-  tps: 548.38508
+  dps: 659.3076
+  tps: 548.31756
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4300.11893
-  tps: 3415.18277
+  dps: 4278.36549
+  tps: 3397.45499
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2167.25851
-  tps: 1639.69397
-  dtps: 7.2778
+  dps: 2154.22761
+  tps: 1629.33047
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2529.58576
-  tps: 1910.64567
-  dtps: 21.83341
+  dps: 2527.57532
+  tps: 1908.84716
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1050.51788
-  tps: 934.98328
+  dps: 1046.7602
+  tps: 932.08269
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 640.2019
-  tps: 504.29456
+  dps: 640.10221
+  tps: 504.22221
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p1_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 709.65898
-  tps: 561.82167
+  dps: 709.54776
+  tps: 561.74021
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4096.48275
-  tps: 3502.06724
+  dps: 4061.90776
+  tps: 3473.21534
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2068.36455
-  tps: 1714.1434
-  dtps: 7.2778
+  dps: 2062.64487
+  tps: 1711.44976
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2385.86553
-  tps: 1984.40469
-  dtps: 21.83341
+  dps: 2378.90646
+  tps: 1979.03415
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 965.41708
-  tps: 861.96811
+  dps: 975.3346
+  tps: 869.81066
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 651.90682
-  tps: 564.71818
+  dps: 649.32104
+  tps: 562.58608
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 688.69755
-  tps: 602.63716
+  dps: 688.61052
+  tps: 602.5649
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3858.55819
-  tps: 3393.03443
+  dps: 3857.26161
+  tps: 3387.1664
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1492.35264
-  tps: 1326.31985
-  dtps: 7.2778
+  dps: 1486.18812
+  tps: 1319.85962
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1786.35588
-  tps: 1584.37522
-  dtps: 21.83341
+  dps: 1778.51351
+  tps: 1577.3825
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 976.15399
-  tps: 910.35326
+  dps: 976.00696
+  tps: 910.22466
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 549.34415
-  tps: 508.10426
+  dps: 547.25316
+  tps: 506.52777
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 580.49171
-  tps: 543.67264
+  dps: 580.41994
+  tps: 543.61016
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3758.15647
-  tps: 3008.43442
+  dps: 3753.34256
+  tps: 3004.34016
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1533.53777
-  tps: 1211.26847
-  dtps: 7.2778
+  dps: 1532.82922
+  tps: 1211.41141
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1783.36707
-  tps: 1402.30337
-  dtps: 21.83341
+  dps: 1788.99605
+  tps: 1406.43729
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 963.09865
-  tps: 873.11763
+  dps: 965.41961
+  tps: 874.86964
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 518.4458
-  tps: 431.97024
+  dps: 518.37962
+  tps: 431.92023
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 566.56593
-  tps: 473.85842
+  dps: 566.49238
+  tps: 473.80264
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4046.6832
-  tps: 3171.48829
+  dps: 4033.80116
+  tps: 3161.4971
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1787.67408
-  tps: 1344.39573
-  dtps: 7.2778
+  dps: 1780.38684
+  tps: 1339.67905
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2131.34271
-  tps: 1598.71854
-  dtps: 21.83341
+  dps: 2125.20901
+  tps: 1593.28698
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 963.24986
-  tps: 845.85118
+  dps: 963.7316
+  tps: 845.90063
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 563.35875
-  tps: 444.66425
+  dps: 563.27305
+  tps: 444.60124
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 624.86655
-  tps: 494.59163
+  dps: 624.76823
+  tps: 494.51907
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3321.73852
-  tps: 2878.00602
+  dps: 3358.85808
+  tps: 2909.70273
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1639.65173
-  tps: 1371.60091
-  dtps: 7.2778
+  dps: 1643.38402
+  tps: 1375.88454
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1933.15359
-  tps: 1624.8422
-  dtps: 21.83341
+  dps: 1936.37899
+  tps: 1627.7851
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 779.22218
-  tps: 711.41283
+  dps: 777.76505
+  tps: 710.11788
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 485.27635
-  tps: 432.06135
+  dps: 483.20958
+  tps: 429.99559
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 562.05438
-  tps: 502.95237
+  dps: 561.97169
+  tps: 502.88301
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3713.91174
-  tps: 3264.61568
+  dps: 3722.24201
+  tps: 3274.10885
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1731.47204
-  tps: 1534.69191
-  dtps: 7.2778
+  dps: 1734.55902
+  tps: 1537.50598
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2084.58524
-  tps: 1838.17792
-  dtps: 21.83341
+  dps: 2086.48552
+  tps: 1839.03221
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 997.58947
-  tps: 927.51227
+  dps: 997.45814
+  tps: 927.39915
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 596.90177
-  tps: 551.53609
+  dps: 597.8901
+  tps: 552.50197
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 649.18388
-  tps: 604.11493
+  dps: 649.09852
+  tps: 604.04236
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4419.68969
-  tps: 3587.4097
+  dps: 4408.92702
+  tps: 3578.04728
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2046.34607
-  tps: 1609.59522
-  dtps: 7.2778
+  dps: 2037.867
+  tps: 1603.87095
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2466.02988
-  tps: 1925.41108
-  dtps: 21.83341
+  dps: 2466.05143
+  tps: 1926.35948
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1176.76918
-  tps: 1081.07732
+  dps: 1178.39488
+  tps: 1082.81533
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 699.26843
-  tps: 582.87717
+  dps: 694.88638
+  tps: 579.44917
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 738.76545
-  tps: 616.35389
+  dps: 738.66227
+  tps: 616.27659
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4716.27517
-  tps: 3741.72043
+  dps: 4695.76297
+  tps: 3724.83335
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2341.01694
-  tps: 1777.51692
-  dtps: 7.2778
+  dps: 2325.42374
+  tps: 1765.47857
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2799.88043
-  tps: 2115.14925
-  dtps: 21.83341
+  dps: 2799.92133
+  tps: 2114.47826
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1210.46502
-  tps: 1063.98419
+  dps: 1202.67537
+  tps: 1057.19058
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 773.88176
-  tps: 605.34042
+  dps: 775.4431
+  tps: 606.27524
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p2_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 849.3851
-  tps: 669.50065
+  dps: 849.72797
+  tps: 669.62287
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4711.16735
-  tps: 4023.25834
+  dps: 4693.90921
+  tps: 4008.15981
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2360.34773
-  tps: 1960.57637
-  dtps: 7.2778
+  dps: 2362.55686
+  tps: 1962.11275
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2645.95636
-  tps: 2197.77596
-  dtps: 21.83341
+  dps: 2641.01326
+  tps: 2193.3281
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1083.72159
-  tps: 962.53173
+  dps: 1074.32611
+  tps: 954.24192
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 735.15113
-  tps: 633.27846
+  dps: 734.27725
+  tps: 633.06307
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 757.02334
-  tps: 663.00083
+  dps: 756.93272
+  tps: 662.92489
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4212.62248
-  tps: 3675.50974
+  dps: 4210.38231
+  tps: 3676.49958
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1690.7364
-  tps: 1486.57936
-  dtps: 7.2778
+  dps: 1692.25814
+  tps: 1487.95835
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1959.76541
-  tps: 1716.09813
-  dtps: 21.83341
+  dps: 1958.2139
+  tps: 1714.79858
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1078.69314
-  tps: 998.41989
+  dps: 1078.57443
+  tps: 998.31665
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 632.24607
-  tps: 577.91338
+  dps: 632.17623
+  tps: 577.85359
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 669.12736
-  tps: 616.58536
+  dps: 669.05421
+  tps: 616.52263
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4206.11243
-  tps: 3346.27418
+  dps: 4207.54232
+  tps: 3347.49364
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1744.72506
-  tps: 1366.41247
-  dtps: 7.2778
+  dps: 1741.64713
+  tps: 1364.05709
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1996.46618
-  tps: 1553.23208
-  dtps: 21.83341
+  dps: 1994.81659
+  tps: 1552.01855
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1077.4998
-  tps: 961.58211
+  dps: 1075.94032
+  tps: 960.32796
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 602.66168
-  tps: 494.36711
+  dps: 600.54932
+  tps: 492.65124
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 624.63821
-  tps: 516.30416
+  dps: 624.56398
+  tps: 516.24839
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4498.66335
-  tps: 3503.16487
+  dps: 4477.88645
+  tps: 3488.01672
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2076.89784
-  tps: 1556.80357
-  dtps: 7.2778
+  dps: 2079.56568
+  tps: 1557.87047
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2390.46406
-  tps: 1788.77725
-  dtps: 21.83341
+  dps: 2394.2093
+  tps: 1790.9972
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1091.53253
-  tps: 942.47345
+  dps: 1093.38687
+  tps: 943.4778
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 674.36603
-  tps: 526.03411
+  dps: 673.37811
+  tps: 525.38952
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 710.22645
-  tps: 560.47383
+  dps: 710.30063
+  tps: 560.56501
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4370.06787
-  tps: 3764.13465
+  dps: 4345.38818
+  tps: 3740.62821
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2213.7304
-  tps: 1851.60537
-  dtps: 7.2778
+  dps: 2204.62812
+  tps: 1844.11826
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2600.91021
-  tps: 2180.89575
-  dtps: 21.83341
+  dps: 2598.8502
+  tps: 2179.20086
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1126.746
-  tps: 1007.46041
+  dps: 1121.21962
+  tps: 1002.57947
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 774.12546
-  tps: 669.81384
+  dps: 775.53636
+  tps: 670.67761
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 849.0409
-  tps: 741.90482
+  dps: 848.93259
+  tps: 741.81332
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4505.80447
-  tps: 3937.69651
+  dps: 4506.35623
+  tps: 3939.76206
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2171.93984
-  tps: 1907.39842
-  dtps: 7.2778
+  dps: 2173.4749
+  tps: 1909.51643
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2604.72304
-  tps: 2278.20558
-  dtps: 21.83341
+  dps: 2610.12608
+  tps: 2280.73983
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1222.57166
-  tps: 1122.89842
+  dps: 1222.42793
+  tps: 1122.77491
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 804.30293
-  tps: 730.46585
+  dps: 804.2136
+  tps: 730.39125
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 828.56999
-  tps: 757.62766
+  dps: 828.47588
+  tps: 757.54856
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5047.56874
-  tps: 4062.39214
+  dps: 5047.60171
+  tps: 4059.88874
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2396.60978
-  tps: 1869.83422
-  dtps: 7.2778
+  dps: 2398.47601
+  tps: 1871.21728
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2857.85708
-  tps: 2208.18244
-  dtps: 21.83341
+  dps: 2855.33605
+  tps: 2206.77807
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1356.94095
-  tps: 1227.2089
+  dps: 1357.28489
+  tps: 1227.01888
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 853.1366
-  tps: 699.41424
+  dps: 854.29719
+  tps: 700.53199
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 884.28487
-  tps: 728.20305
+  dps: 884.17779
+  tps: 728.12319
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5322.9953
-  tps: 4189.5408
+  dps: 5321.40907
+  tps: 4186.28233
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2725.49635
-  tps: 2057.37351
-  dtps: 7.2778
+  dps: 2729.3017
+  tps: 2059.81999
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3207.2363
-  tps: 2411.31853
-  dtps: 21.83341
+  dps: 3203.56378
+  tps: 2408.0849
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1401.30957
-  tps: 1211.23853
+  dps: 1401.92303
+  tps: 1212.02741
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 939.01011
-  tps: 727.27922
+  dps: 940.34313
+  tps: 728.51441
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p3_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 992.7174
-  tps: 774.5245
+  dps: 992.58107
+  tps: 774.42469
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4756.60818
-  tps: 4063.46978
+  dps: 4755.98132
+  tps: 4061.48162
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2369.1008
-  tps: 1964.58651
-  dtps: 7.2778
+  dps: 2366.29974
+  tps: 1962.66693
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2669.44337
-  tps: 2218.64877
-  dtps: 21.83341
+  dps: 2662.63344
+  tps: 2212.69617
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1073.12092
-  tps: 954.17682
+  dps: 1077.98281
+  tps: 958.20356
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 749.72616
-  tps: 646.62809
+  dps: 748.69506
+  tps: 645.45122
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 801.81642
-  tps: 697.34733
+  dps: 801.72014
+  tps: 697.26662
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4267.15239
-  tps: 3726.8262
+  dps: 4272.86539
+  tps: 3732.99203
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1698.76792
-  tps: 1496.26399
-  dtps: 7.2778
+  dps: 1698.63796
+  tps: 1495.00287
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1968.36283
-  tps: 1723.76612
-  dtps: 21.83341
+  dps: 1956.33222
+  tps: 1712.80627
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1082.25201
-  tps: 1002.71442
+  dps: 1082.13205
+  tps: 1002.61015
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 631.00206
-  tps: 575.61277
+  dps: 631.84589
+  tps: 576.1088
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 666.2346
-  tps: 614.3743
+  dps: 666.16115
+  tps: 614.31136
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4214.55233
-  tps: 3356.08171
+  dps: 4217.30969
+  tps: 3358.68509
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1756.85532
-  tps: 1373.37786
-  dtps: 7.2778
+  dps: 1751.78971
+  tps: 1369.62107
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2014.6481
-  tps: 1567.45113
-  dtps: 21.83341
+  dps: 2012.7158
+  tps: 1566.03287
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1057.88973
-  tps: 943.61835
+  dps: 1057.82594
+  tps: 943.27841
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 600.70634
-  tps: 492.2658
+  dps: 600.63797
+  tps: 492.21476
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 608.13743
-  tps: 503.76974
+  dps: 608.06373
+  tps: 503.71434
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4500.24723
-  tps: 3506.82333
+  dps: 4515.6344
+  tps: 3518.15436
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2073.72931
-  tps: 1553.8856
-  dtps: 7.2778
+  dps: 2080.77599
+  tps: 1558.78366
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2416.27601
-  tps: 1807.03313
-  dtps: 21.83341
+  dps: 2404.54455
+  tps: 1799.25843
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1072.51402
-  tps: 926.9765
+  dps: 1072.37505
+  tps: 926.87126
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 661.01918
-  tps: 516.71843
+  dps: 662.77892
+  tps: 517.67136
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 700.88852
-  tps: 555.37355
+  dps: 700.79162
+  tps: 555.30244
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4475.49459
-  tps: 3854.48272
+  dps: 4496.29002
+  tps: 3873.02306
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2254.5624
-  tps: 1886.32018
-  dtps: 7.2778
+  dps: 2249.43374
+  tps: 1882.0164
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2622.05128
-  tps: 2199.98602
-  dtps: 21.83341
+  dps: 2622.70574
+  tps: 2201.00293
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1067.45157
-  tps: 954.76813
+  dps: 1072.14662
+  tps: 959.04183
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 765.31697
-  tps: 663.18893
+  dps: 764.7602
+  tps: 662.86086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 827.39987
-  tps: 722.71418
+  dps: 827.29319
+  tps: 722.62392
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4612.62219
-  tps: 4034.53396
+  dps: 4597.46584
+  tps: 4022.35426
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2199.57828
-  tps: 1931.65557
-  dtps: 7.2778
+  dps: 2210.35083
+  tps: 1940.54823
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2652.84044
-  tps: 2318.14517
-  dtps: 21.83341
+  dps: 2653.97088
+  tps: 2318.90298
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1248.10165
-  tps: 1143.94477
+  dps: 1243.68849
+  tps: 1140.05353
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 791.86159
-  tps: 719.8411
+  dps: 793.18824
+  tps: 720.83915
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 847.01853
-  tps: 776.97422
+  dps: 846.919
+  tps: 776.88983
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5148.12121
-  tps: 4136.59217
+  dps: 5115.82905
+  tps: 4111.72102
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2451.25524
-  tps: 1909.47729
-  dtps: 7.2778
+  dps: 2447.69212
+  tps: 1906.57408
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2887.11582
-  tps: 2231.33868
-  dtps: 21.83341
+  dps: 2882.3599
+  tps: 2228.02578
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1340.52281
-  tps: 1212.0742
+  dps: 1335.23026
+  tps: 1207.05241
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 856.86181
-  tps: 702.7414
+  dps: 861.02323
+  tps: 706.25969
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 890.02937
-  tps: 731.59352
+  dps: 889.92384
+  tps: 731.51518
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5364.21745
-  tps: 4219.55958
+  dps: 5386.18877
+  tps: 4237.25854
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2783.03684
-  tps: 2099.48294
-  dtps: 7.2778
+  dps: 2766.59509
+  tps: 2087.71747
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3203.31414
-  tps: 2414.58201
-  dtps: 21.83341
+  dps: 3196.47417
+  tps: 2406.77531
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1374.00904
-  tps: 1190.70204
+  dps: 1372.90567
+  tps: 1189.65985
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 952.84418
-  tps: 736.57284
+  dps: 948.90368
+  tps: 733.85888
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p4_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1014.16257
-  tps: 790.90608
+  dps: 1013.74809
+  tps: 790.62168
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5703.92044
-  tps: 4854.89943
+  dps: 5708.28281
+  tps: 4861.08862
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2874.53105
-  tps: 2387.68989
-  dtps: 7.2778
+  dps: 2864.37628
+  tps: 2379.65534
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3210.18708
-  tps: 2676.16451
-  dtps: 21.83341
+  dps: 3205.45586
+  tps: 2672.31605
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1481.53405
-  tps: 1300.78289
+  dps: 1489.21861
+  tps: 1307.57911
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1044.3753
-  tps: 888.30449
+  dps: 1049.37683
+  tps: 891.94026
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1105.32042
-  tps: 953.05051
+  dps: 1105.19604
+  tps: 952.94557
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5265.96012
-  tps: 4580.89038
+  dps: 5243.6797
+  tps: 4561.87744
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2176.30727
-  tps: 1909.69944
-  dtps: 7.2778
+  dps: 2172.32469
+  tps: 1907.60763
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2525.49392
-  tps: 2198.92735
-  dtps: 21.83341
+  dps: 2526.22796
+  tps: 2199.06149
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1484.72898
-  tps: 1348.44636
+  dps: 1484.57614
+  tps: 1348.31447
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 831.41316
-  tps: 754.7918
+  dps: 831.33097
+  tps: 754.72207
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 858.82413
-  tps: 784.8641
+  dps: 858.73376
+  tps: 784.78675
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5147.42791
-  tps: 4072.01666
+  dps: 5138.83624
+  tps: 4065.41097
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2205.49661
-  tps: 1715.32914
-  dtps: 7.2778
+  dps: 2204.49311
+  tps: 1714.53714
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2541.25829
-  tps: 1967.43662
-  dtps: 21.83341
+  dps: 2539.39229
+  tps: 1966.16185
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1425.41911
-  tps: 1235.95738
+  dps: 1423.09727
+  tps: 1233.74566
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 815.94571
-  tps: 662.05447
+  dps: 815.86007
+  tps: 661.99072
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 861.72671
-  tps: 702.16032
+  dps: 861.63126
+  tps: 702.08859
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5600.25518
-  tps: 4334.86971
+  dps: 5576.04781
+  tps: 4318.10362
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2592.18946
-  tps: 1944.80659
-  dtps: 7.2778
+  dps: 2588.67733
+  tps: 1941.05706
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2960.52616
-  tps: 2212.88995
-  dtps: 21.83341
+  dps: 2966.88472
+  tps: 2217.81241
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1453.17118
-  tps: 1222.69147
+  dps: 1452.996
+  tps: 1222.56276
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 899.26698
-  tps: 695.46562
+  dps: 893.80482
+  tps: 691.40726
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 951.6339
-  tps: 743.60333
+  dps: 949.26978
+  tps: 742.58352
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5244.35979
-  tps: 4508.02726
+  dps: 5252.50518
+  tps: 4514.62013
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2685.51851
-  tps: 2250.15362
-  dtps: 7.2778
+  dps: 2682.68723
+  tps: 2247.84177
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3133.30534
-  tps: 2628.70664
-  dtps: 21.83341
+  dps: 3125.55065
+  tps: 2623.09358
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1363.18044
-  tps: 1211.45412
+  dps: 1370.15355
+  tps: 1217.91546
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 947.01654
-  tps: 816.2182
+  dps: 942.79916
+  tps: 812.61119
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1012.73661
-  tps: 881.1946
+  dps: 1008.19666
+  tps: 877.89086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5431.88417
-  tps: 4735.1333
+  dps: 5450.63686
+  tps: 4749.84031
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2712.53342
-  tps: 2370.99465
-  dtps: 7.2778
+  dps: 2699.1136
+  tps: 2360.05732
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3104.13579
-  tps: 2701.65644
-  dtps: 21.83341
+  dps: 3088.8872
+  tps: 2688.26875
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1505.19063
-  tps: 1371.19396
+  dps: 1503.87668
+  tps: 1370.00469
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 968.32343
-  tps: 878.873
+  dps: 967.96528
+  tps: 879.05784
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1024.41017
-  tps: 932.74562
+  dps: 1022.65027
+  tps: 931.50936
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 6127.5024
-  tps: 4874.61737
+  dps: 6118.09522
+  tps: 4868.78501
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2969.83891
-  tps: 2299.10074
-  dtps: 7.2778
+  dps: 2958.82259
+  tps: 2289.00617
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3565.13937
-  tps: 2738.98531
-  dtps: 21.83341
+  dps: 3561.46809
+  tps: 2736.29874
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1647.59465
-  tps: 1457.85627
+  dps: 1642.51018
+  tps: 1454.0682
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1048.85706
-  tps: 853.25522
+  dps: 1048.73967
+  tps: 853.16837
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1097.77448
-  tps: 894.25502
+  dps: 1099.5852
+  tps: 895.66435
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 6488.72039
-  tps: 5072.36119
+  dps: 6483.1786
+  tps: 5068.63008
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 3387.569
-  tps: 2552.25322
-  dtps: 7.2778
+  dps: 3397.27441
+  tps: 2559.36946
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3957.63552
-  tps: 2968.36514
-  dtps: 21.83341
+  dps: 3953.71778
+  tps: 2965.8289
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1696.35242
-  tps: 1441.03085
+  dps: 1702.44443
+  tps: 1445.2702
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1182.83732
-  tps: 912.47112
+  dps: 1182.86482
+  tps: 912.55818
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Human-p5_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1200.20045
-  tps: 930.58143
+  dps: 1200.04516
+  tps: 930.46815
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3918.28943
-  tps: 3350.23498
+  dps: 3919.21283
+  tps: 3351.34703
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1908.54109
-  tps: 1582.77967
-  dtps: 7.2778
+  dps: 1898.94047
+  tps: 1574.63818
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2212.94619
-  tps: 1841.22143
-  dtps: 21.83341
+  dps: 2211.46643
+  tps: 1840.03127
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 920.35498
-  tps: 829.7096
+  dps: 920.26387
+  tps: 829.63072
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 555.98151
-  tps: 486.99682
+  dps: 555.99449
+  tps: 486.92794
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 576.24954
-  tps: 511.79745
+  dps: 576.17447
+  tps: 511.73493
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3643.26035
-  tps: 3169.84439
+  dps: 3624.63546
+  tps: 3155.4904
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1401.2251
-  tps: 1230.18366
-  dtps: 7.2778
+  dps: 1401.30642
+  tps: 1229.89322
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1692.61883
-  tps: 1478.99294
-  dtps: 21.83341
+  dps: 1693.62157
+  tps: 1479.43535
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 914.82435
-  tps: 848.84391
+  dps: 913.63784
+  tps: 847.39717
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 508.93762
-  tps: 466.06165
+  dps: 508.87867
+  tps: 466.01199
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 548.28729
-  tps: 507.98891
+  dps: 548.22206
+  tps: 507.93342
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3569.66119
-  tps: 2862.6173
+  dps: 3551.91879
+  tps: 2848.1343
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1436.96435
-  tps: 1127.80875
-  dtps: 7.2778
+  dps: 1431.98629
+  tps: 1123.83164
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1756.99893
-  tps: 1367.82588
-  dtps: 21.83341
+  dps: 1760.61059
+  tps: 1370.47777
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 878.59111
-  tps: 804.33436
+  dps: 880.07552
+  tps: 804.80684
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 487.8634
-  tps: 404.27471
+  dps: 486.37709
+  tps: 403.12837
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 520.43866
-  tps: 434.04159
+  dps: 520.3724
+  tps: 433.99199
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3823.85456
-  tps: 2989.6747
+  dps: 3801.46993
+  tps: 2973.47594
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1705.74982
-  tps: 1277.27116
-  dtps: 7.2778
+  dps: 1697.97589
+  tps: 1271.50678
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1977.14274
-  tps: 1476.50805
-  dtps: 21.83341
+  dps: 1978.14971
+  tps: 1478.14228
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 904.13731
-  tps: 798.84503
+  dps: 902.84722
+  tps: 797.86833
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 503.81808
-  tps: 399.20756
+  dps: 499.6698
+  tps: 396.2654
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 553.38557
-  tps: 441.19842
+  dps: 553.3029
+  tps: 441.13783
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3123.53803
-  tps: 2708.93081
+  dps: 3096.1036
+  tps: 2687.33714
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1492.89107
-  tps: 1247.62227
-  dtps: 7.2778
+  dps: 1497.21114
+  tps: 1251.00132
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1774.99596
-  tps: 1489.12563
-  dtps: 21.83341
+  dps: 1778.41993
+  tps: 1492.21855
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 715.69278
-  tps: 662.95653
+  dps: 713.47532
+  tps: 660.69411
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 429.16286
-  tps: 387.01606
+  dps: 430.32953
+  tps: 388.37148
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 471.19507
-  tps: 431.39506
+  dps: 469.37552
+  tps: 429.39103
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3385.11821
-  tps: 2956.65216
+  dps: 3412.49963
+  tps: 2981.59143
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1573.88075
-  tps: 1375.42978
-  dtps: 7.2778
+  dps: 1572.59092
+  tps: 1374.33289
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1937.93775
-  tps: 1677.94006
-  dtps: 21.83341
+  dps: 1930.9113
+  tps: 1672.46649
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 903.94354
-  tps: 835.02918
+  dps: 903.82231
+  tps: 834.92509
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 540.25271
-  tps: 491.95928
+  dps: 540.08319
+  tps: 491.85095
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 587.66758
-  tps: 539.78725
+  dps: 587.59169
+  tps: 539.72373
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4125.01474
-  tps: 3354.38981
+  dps: 4118.12811
+  tps: 3347.21116
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1894.03071
-  tps: 1478.24345
-  dtps: 7.2778
+  dps: 1891.51998
+  tps: 1476.3633
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2287.20141
-  tps: 1773.72364
-  dtps: 21.83341
+  dps: 2284.93131
+  tps: 1772.0669
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1054.68365
-  tps: 979.37096
+  dps: 1054.46735
+  tps: 979.51612
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 627.77412
-  tps: 516.54563
+  dps: 627.69126
+  tps: 516.48455
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 675.62449
-  tps: 557.29968
+  dps: 675.53396
+  tps: 557.23261
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4211.50202
-  tps: 3339.0985
+  dps: 4212.66407
+  tps: 3339.09313
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2154.30676
-  tps: 1624.94588
-  dtps: 7.2778
+  dps: 2154.71249
+  tps: 1625.74548
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2528.91716
-  tps: 1901.07341
-  dtps: 21.83341
+  dps: 2539.74923
+  tps: 1908.79333
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1077.75566
-  tps: 956.20743
+  dps: 1081.64926
+  tps: 958.7876
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 640.40095
-  tps: 502.36259
+  dps: 641.63989
+  tps: 503.53744
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p1_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 711.0956
-  tps: 561.90516
+  dps: 709.90305
+  tps: 561.02251
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4188.98727
-  tps: 3577.81157
+  dps: 4165.31148
+  tps: 3559.81025
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2072.3226
-  tps: 1716.23503
-  dtps: 7.2778
+  dps: 2066.3805
+  tps: 1711.60126
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2418.03893
-  tps: 2008.75784
-  dtps: 21.83341
+  dps: 2415.87975
+  tps: 2006.34324
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 993.40763
-  tps: 886.70286
+  dps: 992.59467
+  tps: 885.92133
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 656.12388
-  tps: 568.1518
+  dps: 656.3216
+  tps: 568.24906
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 703.67777
-  tps: 617.00587
+  dps: 703.58733
+  tps: 616.93012
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3900.10861
-  tps: 3424.92039
+  dps: 3889.06328
+  tps: 3414.30952
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1496.21062
-  tps: 1328.59913
-  dtps: 7.2778
+  dps: 1495.002
+  tps: 1327.32924
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1785.06987
-  tps: 1579.40545
-  dtps: 21.83341
+  dps: 1780.81577
+  tps: 1575.82359
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 981.70863
-  tps: 915.5892
+  dps: 982.15453
+  tps: 915.96609
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 567.73143
-  tps: 524.25429
+  dps: 566.18493
+  tps: 522.73964
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 590.77018
-  tps: 552.58371
+  dps: 590.69854
+  tps: 552.52135
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3772.0246
-  tps: 3019.92592
+  dps: 3772.33691
+  tps: 3019.42737
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1541.11388
-  tps: 1216.83144
-  dtps: 7.2778
+  dps: 1535.75626
+  tps: 1212.55586
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1791.60109
-  tps: 1405.41306
-  dtps: 21.83341
+  dps: 1783.64464
+  tps: 1399.796
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 975.58726
-  tps: 880.72232
+  dps: 975.77477
+  tps: 880.38138
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 534.33266
-  tps: 444.42512
+  dps: 532.26328
+  tps: 442.54877
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 576.73271
-  tps: 481.85509
+  dps: 576.76558
+  tps: 481.70969
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4080.91719
-  tps: 3196.93944
+  dps: 4062.80219
+  tps: 3183.24835
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1807.60481
-  tps: 1360.24892
-  dtps: 7.2778
+  dps: 1786.54291
+  tps: 1344.90816
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2157.77692
-  tps: 1617.6268
-  dtps: 21.83341
+  dps: 2152.78845
+  tps: 1613.10814
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 956.82145
-  tps: 839.51449
+  dps: 956.68853
+  tps: 839.41351
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 584.17278
-  tps: 457.51588
+  dps: 580.70527
+  tps: 455.2596
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 645.54381
-  tps: 508.57608
+  dps: 645.4441
+  tps: 508.50263
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3354.9704
-  tps: 2906.56295
+  dps: 3329.19852
+  tps: 2887.49345
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1634.83724
-  tps: 1367.49284
-  dtps: 7.2778
+  dps: 1635.94719
+  tps: 1368.85628
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1960.35052
-  tps: 1647.80654
-  dtps: 21.83341
+  dps: 1965.16944
+  tps: 1651.47865
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 757.26125
-  tps: 692.49717
+  dps: 757.06338
+  tps: 692.31062
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 486.57538
-  tps: 431.25182
+  dps: 488.13246
+  tps: 432.58628
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 572.67591
-  tps: 513.38126
+  dps: 572.59445
+  tps: 513.31289
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 3687.16267
-  tps: 3233.89809
+  dps: 3674.8205
+  tps: 3222.82882
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1717.25075
-  tps: 1510.19929
-  dtps: 7.2778
+  dps: 1715.09281
+  tps: 1507.57964
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2076.59205
-  tps: 1814.31739
-  dtps: 21.83341
+  dps: 2071.94279
+  tps: 1809.58677
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1000.55993
-  tps: 923.79989
+  dps: 1002.12763
+  tps: 925.42886
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 603.61343
-  tps: 554.45126
+  dps: 604.2996
+  tps: 555.0392
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 659.18358
-  tps: 609.84797
+  dps: 661.85468
+  tps: 611.77142
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4473.45702
-  tps: 3624.13866
+  dps: 4462.42774
+  tps: 3615.89818
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2028.60748
-  tps: 1589.47559
-  dtps: 7.2778
+  dps: 2019.03974
+  tps: 1581.90927
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2478.93918
-  tps: 1926.10193
-  dtps: 21.83341
+  dps: 2470.43917
+  tps: 1919.46795
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1178.86409
-  tps: 1081.80551
+  dps: 1175.24237
+  tps: 1078.95419
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 708.87562
-  tps: 586.28573
+  dps: 707.63657
+  tps: 585.20188
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 754.02291
-  tps: 622.76037
+  dps: 753.92374
+  tps: 622.6866
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4640.50018
-  tps: 3673.12967
+  dps: 4624.04115
+  tps: 3660.15624
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2332.84757
-  tps: 1762.48911
-  dtps: 7.2778
+  dps: 2324.74672
+  tps: 1757.12495
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2791.14429
-  tps: 2105.15501
-  dtps: 21.83341
+  dps: 2774.52949
+  tps: 2091.19328
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1201.70362
-  tps: 1053.57793
+  dps: 1201.52955
+  tps: 1053.44711
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 767.50044
-  tps: 599.78004
+  dps: 767.22265
+  tps: 599.94116
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p2_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 855.89777
-  tps: 673.73977
+  dps: 858.52098
+  tps: 675.71648
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4669.80335
-  tps: 3988.60458
+  dps: 4679.56997
+  tps: 3995.75673
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2353.39127
-  tps: 1954.07536
-  dtps: 7.2778
+  dps: 2359.67858
+  tps: 1959.17196
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2634.90495
-  tps: 2190.05473
-  dtps: 21.83341
+  dps: 2627.80366
+  tps: 2183.45311
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1088.27447
-  tps: 965.82096
+  dps: 1089.68612
+  tps: 967.28763
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 736.00219
-  tps: 634.31163
+  dps: 735.93692
+  tps: 634.25725
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 776.89436
-  tps: 678.67064
+  dps: 776.80317
+  tps: 678.59424
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4276.39189
-  tps: 3718.64273
+  dps: 4281.03493
+  tps: 3725.22403
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1723.59899
-  tps: 1509.07824
-  dtps: 7.2778
+  dps: 1721.5318
+  tps: 1509.10904
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1966.2651
-  tps: 1710.17323
-  dtps: 21.83341
+  dps: 1961.45732
+  tps: 1707.05735
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1096.75768
-  tps: 1009.46107
+  dps: 1097.74069
+  tps: 1010.25686
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 633.54845
-  tps: 574.64081
+  dps: 633.48232
+  tps: 574.58498
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 665.903
-  tps: 611.56172
+  dps: 665.83185
+  tps: 611.50093
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4212.18249
-  tps: 3349.38134
+  dps: 4217.64504
+  tps: 3353.44485
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1750.46941
-  tps: 1363.49281
-  dtps: 7.2778
+  dps: 1746.38564
+  tps: 1360.66292
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2005.02105
-  tps: 1552.62893
-  dtps: 21.83341
+  dps: 2000.90758
+  tps: 1549.68474
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1060.50616
-  tps: 945.36148
+  dps: 1062.38692
+  tps: 946.72464
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 614.69227
-  tps: 502.56693
+  dps: 614.62429
+  tps: 502.51632
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 631.65881
-  tps: 519.73753
+  dps: 630.60933
+  tps: 518.99159
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4497.22933
-  tps: 3496.03638
+  dps: 4481.8288
+  tps: 3486.55721
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2083.23629
-  tps: 1558.35395
-  dtps: 7.2778
+  dps: 2065.11665
+  tps: 1545.47026
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2397.51402
-  tps: 1789.26784
-  dtps: 21.83341
+  dps: 2392.59114
+  tps: 1785.76041
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1066.20716
-  tps: 922.41021
+  dps: 1069.1028
+  tps: 924.66618
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 657.40885
-  tps: 514.10476
+  dps: 657.50279
+  tps: 513.54576
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 694.79146
-  tps: 550.00073
+  dps: 694.5947
+  tps: 549.83653
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4327.98304
-  tps: 3723.17025
+  dps: 4336.0607
+  tps: 3730.11307
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2211.8917
-  tps: 1851.57303
-  dtps: 7.2778
+  dps: 2210.55998
+  tps: 1850.06024
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2600.70429
-  tps: 2178.30729
-  dtps: 21.83341
+  dps: 2593.69602
+  tps: 2171.71295
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1121.19943
-  tps: 1002.09437
+  dps: 1115.05421
+  tps: 996.8485
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 765.48768
-  tps: 664.57876
+  dps: 765.40011
+  tps: 664.5048
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 845.44429
-  tps: 737.70862
+  dps: 845.33818
+  tps: 737.61898
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4446.53845
-  tps: 3869.58101
+  dps: 4443.84522
+  tps: 3868.6854
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2151.18556
-  tps: 1873.4324
-  dtps: 7.2778
+  dps: 2157.35041
+  tps: 1878.67534
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2527.40013
-  tps: 2195.46589
-  dtps: 21.83341
+  dps: 2529.62066
+  tps: 2195.46735
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1257.19326
-  tps: 1143.78022
+  dps: 1257.04736
+  tps: 1143.65541
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 817.96485
-  tps: 738.7966
+  dps: 820.28793
+  tps: 740.99763
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 838.63294
-  tps: 761.13527
+  dps: 838.53967
+  tps: 761.05734
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5057.73206
-  tps: 4063.02336
+  dps: 5050.08597
+  tps: 4058.0188
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2394.67345
-  tps: 1858.42787
-  dtps: 7.2778
+  dps: 2406.33029
+  tps: 1867.38207
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2875.10284
-  tps: 2217.74176
-  dtps: 21.83341
+  dps: 2865.59443
+  tps: 2210.40889
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1362.5709
-  tps: 1229.52718
+  dps: 1367.01669
+  tps: 1232.19985
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 866.36847
-  tps: 704.06269
+  dps: 866.26869
+  tps: 703.98902
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 914.96988
-  tps: 747.14668
+  dps: 914.86397
+  tps: 747.06814
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5297.72892
-  tps: 4164.66154
+  dps: 5309.75236
+  tps: 4172.62339
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2719.67617
-  tps: 2044.58814
-  dtps: 7.2778
+  dps: 2712.47494
+  tps: 2039.52072
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3179.30649
-  tps: 2386.56042
-  dtps: 21.83341
+  dps: 3166.19644
+  tps: 2377.535
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1390.99027
-  tps: 1199.70766
+  dps: 1390.26085
+  tps: 1199.42307
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 955.20256
-  tps: 737.69819
+  dps: 955.85089
+  tps: 738.07969
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p3_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1004.54912
-  tps: 781.56929
+  dps: 1004.41603
+  tps: 781.47235
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4708.67575
-  tps: 4018.28843
+  dps: 4728.94182
+  tps: 4035.36403
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2360.80854
-  tps: 1958.5465
-  dtps: 7.2778
+  dps: 2347.43461
+  tps: 1946.87792
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2662.46999
-  tps: 2213.1131
-  dtps: 21.83341
+  dps: 2647.89337
+  tps: 2200.22151
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1088.44473
-  tps: 969.85875
+  dps: 1080.83356
+  tps: 962.79679
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 732.67728
-  tps: 631.31202
+  dps: 730.17208
+  tps: 629.84014
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 787.84456
-  tps: 687.68514
+  dps: 793.25033
+  tps: 691.01043
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4315.68605
-  tps: 3751.28833
+  dps: 4322.60576
+  tps: 3757.56261
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1733.46694
-  tps: 1517.69392
-  dtps: 7.2778
+  dps: 1716.69798
+  tps: 1502.4313
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2003.44906
-  tps: 1742.27104
-  dtps: 21.83341
+  dps: 1998.81939
+  tps: 1738.25462
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1074.38755
-  tps: 988.8627
+  dps: 1074.27031
+  tps: 988.76124
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 634.95361
-  tps: 576.60159
+  dps: 634.88698
+  tps: 576.54527
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 658.53094
-  tps: 604.17551
+  dps: 658.45969
+  tps: 604.11479
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4236.08619
-  tps: 3369.54728
+  dps: 4227.59687
+  tps: 3362.87757
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1768.97374
-  tps: 1380.71989
-  dtps: 7.2778
+  dps: 1762.04619
+  tps: 1374.98899
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2013.07759
-  tps: 1558.27733
-  dtps: 21.83341
+  dps: 2006.50189
+  tps: 1553.73497
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1051.23474
-  tps: 938.12865
+  dps: 1046.63425
+  tps: 934.27313
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 600.62686
-  tps: 489.59972
+  dps: 600.56
+  tps: 489.55006
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 629.96969
-  tps: 518.57737
+  dps: 629.8975
+  tps: 518.52338
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4529.21882
-  tps: 3521.06872
+  dps: 4540.07082
+  tps: 3529.4048
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2106.53957
-  tps: 1574.46015
-  dtps: 7.2778
+  dps: 2108.6757
+  tps: 1576.04019
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2411.12811
-  tps: 1802.16131
-  dtps: 21.83341
+  dps: 2408.20142
+  tps: 1800.04395
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1052.56221
-  tps: 911.46775
+  dps: 1045.20909
+  tps: 905.7764
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 653.47241
-  tps: 511.1229
+  dps: 651.17615
+  tps: 509.11254
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 723.47841
-  tps: 569.3668
+  dps: 723.38031
+  tps: 569.29464
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4441.80574
-  tps: 3826.18526
+  dps: 4424.79568
+  tps: 3811.57934
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2244.36771
-  tps: 1878.45174
-  dtps: 7.2778
+  dps: 2242.17635
+  tps: 1876.42173
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2630.94902
-  tps: 2203.97758
-  dtps: 21.83341
+  dps: 2626.35315
+  tps: 2199.92838
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1106.36559
-  tps: 987.98528
+  dps: 1116.74931
+  tps: 997.96813
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 766.59662
-  tps: 663.00628
+  dps: 769.70885
+  tps: 665.75975
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 810.19319
-  tps: 709.56498
+  dps: 810.09081
+  tps: 709.47865
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 4579.51538
-  tps: 3986.65168
+  dps: 4562.16801
+  tps: 3972.61296
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2205.56303
-  tps: 1920.98195
-  dtps: 7.2778
+  dps: 2206.22195
+  tps: 1919.29107
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2614.35506
-  tps: 2255.50339
-  dtps: 21.83341
+  dps: 2623.66607
+  tps: 2262.22996
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1252.99723
-  tps: 1138.93683
+  dps: 1253.55232
+  tps: 1139.4862
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 827.87995
-  tps: 744.92018
+  dps: 827.78933
+  tps: 744.84488
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 849.28836
-  tps: 772.06013
+  dps: 849.19276
+  tps: 771.97983
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5123.82789
-  tps: 4110.34657
+  dps: 5108.67123
+  tps: 4100.61577
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2410.74729
-  tps: 1869.68887
-  dtps: 7.2778
+  dps: 2401.76486
+  tps: 1862.2196
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2915.10601
-  tps: 2249.10715
-  dtps: 21.83341
+  dps: 2924.61936
+  tps: 2256.50769
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1347.64469
-  tps: 1216.84285
+  dps: 1342.07847
+  tps: 1211.58719
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 852.82248
-  tps: 694.21775
+  dps: 855.3826
+  tps: 696.37642
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 923.11705
-  tps: 751.51352
+  dps: 916.25056
+  tps: 746.2788
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5255.89177
-  tps: 4128.89497
+  dps: 5260.0202
+  tps: 4132.09769
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2758.8148
-  tps: 2075.97429
-  dtps: 7.2778
+  dps: 2748.66638
+  tps: 2067.55336
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3241.67519
-  tps: 2436.1126
-  dtps: 21.83341
+  dps: 3218.65355
+  tps: 2417.18689
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1383.41637
-  tps: 1193.25203
+  dps: 1383.23494
+  tps: 1193.11521
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 956.71203
-  tps: 737.41138
+  dps: 957.80163
+  tps: 738.40509
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p4_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 995.96749
-  tps: 777.20814
+  dps: 995.83516
+  tps: 777.1117
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5702.96367
-  tps: 4863.17452
+  dps: 5689.71371
+  tps: 4855.10646
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2886.13732
-  tps: 2395.28371
-  dtps: 7.2778
+  dps: 2880.67091
+  tps: 2390.35546
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3156.73081
-  tps: 2628.71101
-  dtps: 21.83341
+  dps: 3153.60159
+  tps: 2626.1411
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1503.58644
-  tps: 1319.13787
+  dps: 1510.19576
+  tps: 1324.21678
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1050.32936
-  tps: 892.49656
+  dps: 1052.85588
+  tps: 894.64884
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1129.17791
-  tps: 970.36048
+  dps: 1129.05403
+  tps: 970.25634
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5222.57642
-  tps: 4534.77241
+  dps: 5235.95259
+  tps: 4545.73403
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2183.7434
-  tps: 1906.12515
-  dtps: 7.2778
+  dps: 2185.65659
+  tps: 1908.25375
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2565.26853
-  tps: 2216.40292
-  dtps: 21.83341
+  dps: 2548.65452
+  tps: 2201.62423
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1495.86155
-  tps: 1351.55069
+  dps: 1492.14222
+  tps: 1348.47632
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 831.8972
-  tps: 750.24873
+  dps: 831.48892
+  tps: 749.70904
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 878.15113
-  tps: 800.9826
+  dps: 878.06153
+  tps: 800.90611
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5160.43696
-  tps: 4075.58803
+  dps: 5141.09096
+  tps: 4061.76381
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2209.95339
-  tps: 1710.94362
-  dtps: 7.2778
+  dps: 2215.00717
+  tps: 1715.24181
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2585.03428
-  tps: 1990.17545
-  dtps: 21.83341
+  dps: 2584.34495
+  tps: 1989.61578
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1430.7795
-  tps: 1238.21711
+  dps: 1433.01024
+  tps: 1240.19847
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 833.19856
-  tps: 672.52738
+  dps: 833.11356
+  tps: 672.46441
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 864.77103
-  tps: 704.87178
+  dps: 864.67947
+  tps: 704.80327
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5579.99446
-  tps: 4311.30265
+  dps: 5568.21645
+  tps: 4303.13971
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2589.38972
-  tps: 1937.34266
-  dtps: 7.2778
+  dps: 2594.55835
+  tps: 1940.57937
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 2992.96611
-  tps: 2235.98808
-  dtps: 21.83341
+  dps: 2983.51441
+  tps: 2228.76659
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1472.73867
-  tps: 1233.44883
+  dps: 1475.43588
+  tps: 1235.65574
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 912.20707
-  tps: 701.55522
+  dps: 918.62331
+  tps: 706.52124
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_arms-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 971.49755
-  tps: 758.90914
+  dps: 971.3762
+  tps: 758.81962
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5239.22573
-  tps: 4498.89197
+  dps: 5238.28848
+  tps: 4502.22207
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2642.60019
-  tps: 2213.85566
-  dtps: 7.2778
+  dps: 2635.40713
+  tps: 2208.42249
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3103.46623
-  tps: 2597.58621
-  dtps: 21.83341
+  dps: 3097.83287
+  tps: 2592.82445
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1356.654
-  tps: 1203.93266
+  dps: 1360.02938
+  tps: 1206.73452
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 943.51008
-  tps: 808.03132
+  dps: 943.40254
+  tps: 807.94058
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1032.85047
-  tps: 894.10895
+  dps: 1032.72704
+  tps: 894.00455
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 5405.83335
-  tps: 4687.94543
+  dps: 5384.55523
+  tps: 4670.74637
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2669.57993
-  tps: 2316.49183
-  dtps: 7.2778
+  dps: 2666.42261
+  tps: 2315.21615
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3220.32399
-  tps: 2772.59902
-  dtps: 21.83341
+  dps: 3203.52894
+  tps: 2760.05605
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1488.25969
-  tps: 1345.64055
+  dps: 1488.09567
+  tps: 1345.50046
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 983.30894
-  tps: 881.69777
+  dps: 981.81621
+  tps: 880.24781
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-Arms-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1062.45499
-  tps: 951.90234
+  dps: 1062.34182
+  tps: 951.80812
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 6143.0182
-  tps: 4882.59685
+  dps: 6140.61418
+  tps: 4881.94961
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 2981.18345
-  tps: 2294.74975
-  dtps: 7.2778
+  dps: 2972.13343
+  tps: 2286.04914
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3525.94732
-  tps: 2697.74051
-  dtps: 21.83341
+  dps: 3520.85455
+  tps: 2694.08926
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1623.68575
-  tps: 1435.88887
+  dps: 1626.68092
+  tps: 1438.45185
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1043.44108
-  tps: 842.56661
+  dps: 1043.60954
+  tps: 842.69395
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1102.48684
-  tps: 892.28865
+  dps: 1106.98676
+  tps: 895.78986
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 6413.33524
-  tps: 5006.27729
+  dps: 6390.00889
+  tps: 4988.82592
   dtps: 6.54531
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 3376.1279
-  tps: 2535.72856
-  dtps: 7.2778
+  dps: 3381.88239
+  tps: 2540.84287
+  dtps: 7.36086
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-fury-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 3986.46916
-  tps: 2983.92212
-  dtps: 21.83341
+  dps: 3987.51542
+  tps: 2985.90724
+  dtps: 22.08257
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1684.68465
-  tps: 1425.70857
+  dps: 1683.20309
+  tps: 1424.85683
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 1190.21869
-  tps: 913.34167
+  dps: 1182.37555
+  tps: 907.12098
  }
 }
 dps_results: {
  key: "TestDpsWarrior-Settings-Orc-p5_fury-DefaultTalents-Fury-fury-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 1231.38793
-  tps: 952.41379
+  dps: 1231.23359
+  tps: 952.30141
  }
 }
 dps_results: {
  key: "TestDpsWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1716.3175
-  tps: 1287.79172
-  dtps: 7.2778
+  dps: 1704.18964
+  tps: 1280.75763
+  dtps: 7.36086
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -1,12 +1,12 @@
 character_stats_results: {
  key: "TestProtectionWarrior-CharacterStats-Default"
  value: {
-  final_stats: 551.518
-  final_stats: 467.995
-  final_stats: 1250.403
-  final_stats: 104.39
-  final_stats: 232.819
-  final_stats: 219.819
+  final_stats: 549
+  final_stats: 466
+  final_stats: 1248
+  final_stats: 103
+  final_stats: 232.7
+  final_stats: 219.7
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,8 +17,8 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 168.19
-  final_stats: 2286.3896
+  final_stats: 167
+  final_stats: 2280.3
   final_stats: 403
   final_stats: 0
   final_stats: 37
@@ -28,24 +28,24 @@ character_stats_results: {
   final_stats: 43.65385
   final_stats: 299.3077
   final_stats: 0
-  final_stats: 219.5759
-  final_stats: 334.19688
+  final_stats: 219.45
+  final_stats: 332.93849
   final_stats: 0
   final_stats: 41
-  final_stats: 16971.229
+  final_stats: 16966.4
   final_stats: 294
-  final_stats: 17938.03
+  final_stats: 17914
   final_stats: 0
-  final_stats: 122.7
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
-  final_stats: 33.75
+  final_stats: 122.5
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
+  final_stats: 33
   final_stats: 80
   final_stats: 0
   final_stats: 2.34634
   final_stats: 3
-  final_stats: 28.89168
+  final_stats: 28.83123
   final_stats: 12.17422
   final_stats: 15.04
   final_stats: 0
@@ -55,1809 +55,1809 @@ character_stats_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AbacusofViolentOdds-28288"
  value: {
-  dps: 768.40855
-  tps: 1410.46471
-  dtps: 1298.10704
+  dps: 707.63705
+  tps: 1317.63936
+  dtps: 1294.08409
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AdamantineFigurine-27891"
  value: {
-  dps: 748.82206
-  tps: 1378.10366
-  dtps: 1235.63115
+  dps: 686.43298
+  tps: 1283.1727
+  dtps: 1250.37614
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AdamantiteScope-2722"
  value: {
-  dps: 775.0039
-  tps: 1423.57408
-  dtps: 1294.99259
+  dps: 715.77711
+  tps: 1332.83033
+  dtps: 1284.35457
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AegisofPreservation-19345"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientAqirArtifact-33830"
  value: {
-  dps: 747.23618
-  tps: 1374.56318
-  dtps: 1206.63182
+  dps: 689.49215
+  tps: 1284.93108
+  dtps: 1216.32583
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientCrystalTalisman-25620"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientDraeneiArcaneRelic-31615"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientDraeneiWarTalisman-31617"
  value: {
-  dps: 753.84721
-  tps: 1386.39982
-  dtps: 1297.44977
+  dps: 693.10257
+  tps: 1293.55544
+  dtps: 1299.14713
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Annihilator-12798"
  value: {
-  dps: 702.97799
-  tps: 1352.42224
-  dtps: 1367.07799
+  dps: 656.28868
+  tps: 1280.98891
+  dtps: 1349.83143
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Arcanist'sStone-28223"
  value: {
-  dps: 745.59608
-  tps: 1373.86165
-  dtps: 1295.93175
+  dps: 691.69599
+  tps: 1291.65825
+  dtps: 1300.59801
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ArcanoweaveVestments"
  value: {
-  dps: 743.8939
-  tps: 1378.53862
-  dtps: 1513.91397
+  dps: 693.48182
+  tps: 1300.86677
+  dtps: 1508.54914
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ArgussianCompass-27770"
  value: {
-  dps: 747.89258
-  tps: 1377.05734
-  dtps: 1294.31984
+  dps: 690.08482
+  tps: 1288.71887
+  dtps: 1291.63868
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AshtongueTalismanofValor-32485"
  value: {
-  dps: 753.02054
-  tps: 1384.9881
-  dtps: 1298.25286
+  dps: 695.4849
+  tps: 1296.76543
+  dtps: 1287.72074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 753.83267
-  tps: 1385.30065
-  dtps: 1252.71231
+  dps: 697.85035
+  tps: 1299.70257
+  dtps: 1253.30378
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeoftheSwarmguard-21670"
  value: {
-  dps: 755.50659
-  tps: 1388.99048
-  dtps: 1306.13688
+  dps: 693.62683
+  tps: 1293.41219
+  dtps: 1292.87131
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalChampion-29301"
  value: {
-  dps: 790.67179
-  tps: 1446.88326
-  dtps: 1291.23322
+  dps: 725.41219
+  tps: 1346.33874
+  dtps: 1293.24008
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalRestorer-29309"
  value: {
-  dps: 777.92492
-  tps: 1428.39186
-  dtps: 1318.83297
+  dps: 713.72656
+  tps: 1330.30783
+  dtps: 1316.3778
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BandoftheEternalSage-29305"
  value: {
-  dps: 777.92492
-  tps: 1428.39186
-  dtps: 1318.83297
+  dps: 713.72656
+  tps: 1330.30783
+  dtps: 1316.3778
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BangleofEndlessBlessings-28370"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BattlecastGarb"
  value: {
-  dps: 769.82522
-  tps: 1419.11318
-  dtps: 1460.96185
+  dps: 713.29329
+  tps: 1332.09478
+  dtps: 1466.69717
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sAlacrity-35326"
  value: {
-  dps: 748.29209
-  tps: 1377.1147
-  dtps: 1292.98368
+  dps: 691.73649
+  tps: 1291.82824
+  dtps: 1307.39983
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sAlacrity-35327"
  value: {
-  dps: 748.29209
-  tps: 1377.1147
-  dtps: 1292.98368
+  dps: 691.73649
+  tps: 1291.82824
+  dtps: 1307.39983
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sAudacity-34049"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sCruelty-34163"
  value: {
-  dps: 758.95337
-  tps: 1393.78206
-  dtps: 1299.19563
+  dps: 697.74925
+  tps: 1300.3625
+  dtps: 1292.23164
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sDepravity-34162"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sDetermination-33832"
  value: {
-  dps: 756.17413
-  tps: 1390.18337
-  dtps: 1296.28425
+  dps: 699.36365
+  tps: 1302.76657
+  dtps: 1288.42166
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Battlemaster'sPerseverance-34050"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Berserker'sCall-33831"
  value: {
-  dps: 768.52004
-  tps: 1408.80033
-  dtps: 1303.99176
+  dps: 710.40182
+  tps: 1319.30171
+  dtps: 1288.20717
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Biznicks247x128Accurascope-2523"
  value: {
-  dps: 775.0039
-  tps: 1423.57408
-  dtps: 1294.99259
+  dps: 715.77711
+  tps: 1332.83033
+  dtps: 1284.35457
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackenedNaaruSliver-34427"
  value: {
-  dps: 776.51074
-  tps: 1424.48537
-  dtps: 1299.31125
+  dps: 720.84159
+  tps: 1340.56519
+  dtps: 1298.72675
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bladefist'sBreadth-28041"
  value: {
-  dps: 759.70552
-  tps: 1395.18993
-  dtps: 1297.02042
+  dps: 699.41265
+  tps: 1302.96943
+  dtps: 1298.22764
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BladeofWizardry-31336"
  value: {
-  dps: 684.12388
-  tps: 1314.27885
-  dtps: 1357.00322
+  dps: 633.92393
+  tps: 1235.85979
+  dtps: 1354.20721
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Blinkstrike-31332"
  value: {
-  dps: 775.0039
-  tps: 1423.57408
-  dtps: 1294.99259
+  dps: 715.77711
+  tps: 1332.83033
+  dtps: 1284.35457
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodlustBrooch-29383"
  value: {
-  dps: 764.04603
-  tps: 1401.32987
-  dtps: 1302.84167
+  dps: 705.67903
+  tps: 1312.32596
+  dtps: 1288.22303
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BoldArmor"
  value: {
-  dps: 781.12355
-  tps: 1406.74318
-  dtps: 1386.93054
+  dps: 721.91452
+  tps: 1316.86569
+  dtps: 1388.45621
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BraidedEterniumChain-24114"
  value: {
-  dps: 789.63308
-  tps: 1450.08909
-  dtps: 1313.68517
+  dps: 729.82126
+  tps: 1357.16584
+  dtps: 1318.93514
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BroochoftheImmortalKing-32534"
  value: {
-  dps: 750.78534
-  tps: 1381.10314
-  dtps: 1254.81873
+  dps: 690.45503
+  tps: 1290.04105
+  dtps: 1263.87868
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BrutalGladiator'sPlateGauntlets-35067"
  value: {
-  dps: 785.01512
-  tps: 1411.76334
-  dtps: 1320.19615
+  dps: 727.04183
+  tps: 1325.83375
+  dtps: 1317.86127
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkofAzzinoth-32375"
  value: {
-  dps: 777.35078
-  tps: 1427.3016
-  dtps: 1206.57013
+  dps: 718.68626
+  tps: 1336.6895
+  dtps: 1203.32982
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkofKings-28484"
  value: {
-  dps: 803.54166
-  tps: 1471.64751
-  dtps: 1302.79261
+  dps: 737.18118
+  tps: 1368.45002
+  dtps: 1301.42733
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BulwarkoftheAncientKings-28485"
  value: {
-  dps: 803.27637
-  tps: 1471.32104
-  dtps: 1280.31258
+  dps: 741.27781
+  tps: 1375.48257
+  dtps: 1282.90993
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningRage"
  value: {
-  dps: 838.30491
-  tps: 1501.60352
-  dtps: 1516.27641
+  dps: 778.21181
+  tps: 1411.6537
+  dtps: 1516.129
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChainoftheTwilightOwl-24121"
  value: {
-  dps: 776.11843
-  tps: 1426.19698
-  dtps: 1311.31098
+  dps: 710.49496
+  tps: 1325.20589
+  dtps: 1302.24448
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Chancellor'sPlateGauntlets-32164"
  value: {
-  dps: 775.25648
-  tps: 1396.74656
-  dtps: 1334.89227
+  dps: 716.83317
+  tps: 1310.19332
+  dtps: 1332.5153
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CharmofAlacrity-25787"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 769.7674
-  tps: 1416.4787
-  dtps: 1371.14364
+  dps: 710.57765
+  tps: 1327.5527
+  dtps: 1381.0175
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CloudkeeperLegplates-14554"
  value: {
-  dps: 787.64498
-  tps: 1444.11696
-  dtps: 1332.73538
+  dps: 723.53202
+  tps: 1346.33554
+  dtps: 1329.31163
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CommendationofKael'thas-34473"
  value: {
-  dps: 747.89258
-  tps: 1377.05734
-  dtps: 1294.31984
+  dps: 690.08482
+  tps: 1288.71887
+  dtps: 1291.63868
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Coren'sLuckyCoin-38289"
  value: {
-  dps: 763.61168
-  tps: 1401.33751
-  dtps: 1280.90298
+  dps: 705.79859
+  tps: 1312.54994
+  dtps: 1281.59195
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CoreofAr'kelos-29776"
  value: {
-  dps: 752.50045
-  tps: 1384.18096
-  dtps: 1295.38017
+  dps: 695.62672
+  tps: 1297.11921
+  dtps: 1292.77871
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CoronetofVerdantFlame-24122"
  value: {
-  dps: 772.01517
-  tps: 1420.28903
-  dtps: 1373.17412
+  dps: 710.57765
+  tps: 1327.5527
+  dtps: 1381.0175
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrystalforgedTrinket-32654"
  value: {
-  dps: 752.78017
-  tps: 1384.48393
-  dtps: 1295.38017
+  dps: 695.13144
+  tps: 1296.55144
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dabiri'sEnigma-30300"
  value: {
-  dps: 750.06125
-  tps: 1379.95831
-  dtps: 1246.71832
+  dps: 691.69969
+  tps: 1291.79836
+  dtps: 1258.14152
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkIronSmokingPipe-38290"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Crusade-31856"
  value: {
-  dps: 759.24904
-  tps: 1394.08338
-  dtps: 1297.60682
+  dps: 703.3185
+  tps: 1308.90208
+  dtps: 1287.09593
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Vengeance-31858"
  value: {
-  dps: 745.86203
-  tps: 1374.00042
-  dtps: 1296.85161
+  dps: 690.34238
+  tps: 1289.38143
+  dtps: 1295.14056
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Wrath-31857"
  value: {
-  dps: 756.56194
-  tps: 1390.55292
-  dtps: 1296.69896
+  dps: 697.95593
+  tps: 1301.23917
+  dtps: 1297.75741
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerArmor"
  value: {
-  dps: 820.66857
-  tps: 1467.21016
-  dtps: 1097.44965
+  dps: 748.23473
+  tps: 1357.10046
+  dtps: 1102.50417
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestroyerBattlegear"
  value: {
-  dps: 887.24845
-  tps: 1579.99316
-  dtps: 1454.81003
+  dps: 821.75365
+  tps: 1482.38522
+  dtps: 1449.43063
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DirebrewHops-38288"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DonSantos'FamousHuntingRifle-31323"
  value: {
-  dps: 772.00329
-  tps: 1418.33744
-  dtps: 1296.87533
+  dps: 711.2229
+  tps: 1325.38012
+  dtps: 1290.62106
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DoomplateBattlegear"
  value: {
-  dps: 847.0899
-  tps: 1520.75524
-  dtps: 1565.64721
+  dps: 781.07172
+  tps: 1421.57943
+  dtps: 1566.82503
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DraconicInfusedEmblem-22268"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DragonspineTrophy-28830"
  value: {
-  dps: 775.59127
-  tps: 1424.2875
-  dtps: 1303.19776
+  dps: 714.2115
+  tps: 1329.09071
+  dtps: 1303.83186
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dragonstrike-28439"
  value: {
-  dps: 773.49501
-  tps: 1421.87183
-  dtps: 1349.3963
+  dps: 718.31406
+  tps: 1338.10289
+  dtps: 1341.64419
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DrakefistHammer-28437"
  value: {
-  dps: 753.46593
-  tps: 1391.66234
-  dtps: 1331.03958
+  dps: 698.13738
+  tps: 1307.90288
+  dtps: 1336.06747
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EarringofSoulfulMeditation-30665"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Earthstrike-21180"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmblemofPerseverance-25996"
  value: {
-  dps: 747.89258
-  tps: 1377.05734
-  dtps: 1294.31984
+  dps: 690.08482
+  tps: 1288.71887
+  dtps: 1291.63868
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmptyMugofDirebrew-38287"
  value: {
-  dps: 764.04603
-  tps: 1401.32987
-  dtps: 1302.84167
+  dps: 705.67903
+  tps: 1312.32596
+  dtps: 1288.22303
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantBoots-Cat'sSwiftness-2939"
  value: {
-  dps: 775.85682
-  tps: 1424.24488
-  dtps: 1284.51849
+  dps: 713.03367
+  tps: 1328.37107
+  dtps: 1281.43049
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantCloak-Subtlety-2621"
  value: {
-  dps: 776.27925
-  tps: 1397.65056
-  dtps: 1302.90071
+  dps: 714.86586
+  tps: 1306.33055
+  dtps: 1296.06743
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-Crusader-1900"
  value: {
-  dps: 773.70138
-  tps: 1422.95452
-  dtps: 1340.10635
+  dps: 718.78493
+  tps: 1338.64699
+  dtps: 1336.1873
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-Deathfrost-3273"
  value: {
-  dps: 765.10695
-  tps: 1406.28572
-  dtps: 1281.68238
+  dps: 713.78267
+  tps: 1327.91568
+  dtps: 1275.34029
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-Executioner-3225"
  value: {
-  dps: 783.54872
-  tps: 1438.60058
-  dtps: 1339.60693
+  dps: 722.44067
+  tps: 1342.87417
+  dtps: 1338.9272
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheMartyr-29376"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofMagtheridon-28789"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofMoam-21473"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheDead-23047"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeoftheNight-24116"
  value: {
-  dps: 775.16913
-  tps: 1424.99576
-  dtps: 1322.95558
+  dps: 716.82122
+  tps: 1335.59165
+  dtps: 1325.8195
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FelSkin"
  value: {
-  dps: 823.70634
-  tps: 1482.9588
-  dtps: 1544.14551
+  dps: 764.49918
+  tps: 1393.94968
+  dtps: 1546.85935
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FelscaleArmor"
  value: {
-  dps: 785.48432
-  tps: 1414.15319
-  dtps: 1519.44202
+  dps: 723.2584
+  tps: 1320.41397
+  dtps: 1517.88921
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-DawnstoneCrab-24125"
  value: {
-  dps: 751.2937
-  tps: 1381.93215
-  dtps: 1244.91688
+  dps: 690.56303
+  tps: 1290.03156
+  dtps: 1263.32044
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-EmpyreanTortoise-35693"
  value: {
-  dps: 748.86093
-  tps: 1377.96058
-  dtps: 1233.82383
+  dps: 690.15144
+  tps: 1288.77432
+  dtps: 1244.69014
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-NightseyePanther-24128"
  value: {
-  dps: 756.29774
-  tps: 1389.29567
-  dtps: 1293.81279
+  dps: 698.24727
+  tps: 1300.79525
+  dtps: 1292.77604
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FigurineoftheColossus-27529"
  value: {
-  dps: 749.25155
-  tps: 1378.81254
-  dtps: 1293.34897
+  dps: 690.7934
+  tps: 1290.1272
+  dtps: 1301.60217
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForceReactiveDisk-18168"
  value: {
-  dps: 765.52711
-  tps: 1409.63101
-  dtps: 1420.59072
+  dps: 704.4484
+  tps: 1315.55999
+  dtps: 1413.91209
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 925.07168
-  tps: 1636.00779
-  dtps: 1377.26884
+  dps: 855.41373
+  tps: 1531.25339
+  dtps: 1379.04409
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sPlateGauntlets-24549"
  value: {
-  dps: 778.60006
-  tps: 1401.75039
-  dtps: 1327.71813
+  dps: 721.96721
+  tps: 1318.10448
+  dtps: 1324.82039
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingCrystalInsignia-25619"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlyphofDeflection-23040"
  value: {
-  dps: 761.55689
-  tps: 1397.73122
-  dtps: 1277.69391
+  dps: 705.59433
+  tps: 1312.99131
+  dtps: 1280.22532
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GnomereganAuto-Blocker600-29387"
  value: {
-  dps: 761.26892
-  tps: 1397.50141
-  dtps: 1278.93434
+  dps: 703.99191
+  tps: 1309.09956
+  dtps: 1276.23038
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GrandMarshal'sPlateGauntlets-28700"
  value: {
-  dps: 774.97629
-  tps: 1396.02211
-  dtps: 1341.51176
+  dps: 716.41968
+  tps: 1309.83524
+  dtps: 1336.45628
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gri'lek'sCharmofValor-19952"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HandofJustice-11815"
  value: {
-  dps: 748.52554
-  tps: 1377.99685
-  dtps: 1295.38017
+  dps: 691.29376
+  tps: 1290.65957
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Hazza'rah'sCharmofDestruction-19957"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Hazza'rah'sCharmofHealing-19958"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Hazza'rah'sCharmofMagic-19959"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartoftheScale-13164"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeavenlyInspiration-30293"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HexShrunkenHead-33829"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HibernationCrystal-20636"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HighWarlord'sPlateGauntlets-28852"
  value: {
-  dps: 774.97629
-  tps: 1396.02211
-  dtps: 1341.51176
+  dps: 716.41968
+  tps: 1309.83524
+  dtps: 1336.45628
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HourglassoftheUnraveller-28034"
  value: {
-  dps: 761.46645
-  tps: 1397.24845
-  dtps: 1299.68194
+  dps: 699.79537
+  tps: 1303.52674
+  dtps: 1296.23406
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IceGuard-2682"
  value: {
-  dps: 777.17988
-  tps: 1426.95233
-  dtps: 1299.54573
+  dps: 710.85978
+  tps: 1326.76792
+  dtps: 1299.28679
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IconoftheSilverCrescent-29370"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImbuedNetherweave"
  value: {
-  dps: 750.41157
-  tps: 1389.62519
-  dtps: 1590.79571
+  dps: 694.44774
+  tps: 1303.13059
+  dtps: 1585.53467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JomGabbar-23570"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KhoriumScope-2723"
  value: {
-  dps: 775.0039
-  tps: 1423.57408
-  dtps: 1294.99259
+  dps: 715.77711
+  tps: 1332.83033
+  dtps: 1284.35457
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KhoriumWard"
  value: {
-  dps: 744.12856
-  tps: 1377.81711
-  dtps: 1381.6884
+  dps: 695.35652
+  tps: 1304.55438
+  dtps: 1386.79722
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KissoftheSpider-22954"
  value: {
-  dps: 768.08269
-  tps: 1411.36624
-  dtps: 1299.57064
+  dps: 708.98792
+  tps: 1320.74027
+  dtps: 1302.75281
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Loatheb'sReflection-23042"
  value: {
-  dps: 746.33983
-  tps: 1374.29488
-  dtps: 1297.59873
+  dps: 686.17552
+  tps: 1282.35981
+  dtps: 1298.57065
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MadnessoftheBetrayer-32505"
  value: {
-  dps: 776.92151
-  tps: 1426.06317
-  dtps: 1294.01337
+  dps: 720.59436
+  tps: 1338.88283
+  dtps: 1298.23719
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Mana-EtchedRegalia"
  value: {
-  dps: 738.36893
-  tps: 1347.75343
-  dtps: 1890.52659
+  dps: 686.58487
+  tps: 1270.41036
+  dtps: 1892.06346
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23206"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkoftheChampion-23207"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 761.44557
-  tps: 1403.34702
-  dtps: 1390.69227
+  dps: 700.35755
+  tps: 1311.57666
+  dtps: 1383.40299
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MementoofTyrande-32496"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MercilessGladiator'sPlateGauntlets-30487"
  value: {
-  dps: 780.98561
-  tps: 1405.1447
-  dtps: 1327.4462
+  dps: 720.99396
+  tps: 1316.28749
+  dtps: 1326.41948
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MindQuickeningGem-19339"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Moroes'LuckyPocketWatch-28528"
  value: {
-  dps: 742.64162
-  tps: 1365.06627
-  dtps: 1175.96072
+  dps: 683.05213
+  tps: 1273.62067
+  dtps: 1185.93063
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NatPagle'sBrokenReel-19947"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NaturalAlignmentCrystal-19344"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherscaleArmor"
  value: {
-  dps: 795.1329
-  tps: 1458.9392
-  dtps: 1390.6346
+  dps: 735.70739
+  tps: 1366.87696
+  dtps: 1387.665
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherstrikeArmor"
  value: {
-  dps: 739.31093
-  tps: 1369.9248
-  dtps: 1394.97928
+  dps: 681.53471
+  tps: 1281.85441
+  dtps: 1394.06501
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NetherweaveVestments"
  value: {
-  dps: 713.37217
-  tps: 1309.02321
-  dtps: 1817.27682
+  dps: 663.14115
+  tps: 1233.68083
+  dtps: 1823.39203
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Oathbound'sSavagePlateBattlegear"
  value: {
-  dps: 796.45837
-  tps: 1434.77293
-  dtps: 1564.20322
+  dps: 733.17799
+  tps: 1339.07362
+  dtps: 1550.51352
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OgreMauler'sBadge-25628"
  value: {
-  dps: 752.00492
-  tps: 1383.42552
-  dtps: 1295.38017
+  dps: 695.17368
+  tps: 1296.42842
+  dtps: 1292.77871
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtArmor"
  value: {
-  dps: 790.23049
-  tps: 1413.26235
-  dtps: 801.455
+  dps: 720.79075
+  tps: 1306.61697
+  dtps: 793.61703
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-OnslaughtBattlegear"
  value: {
-  dps: 997.73389
-  tps: 1750.81334
-  dtps: 1211.92624
+  dps: 924.12665
+  tps: 1640.27753
+  dtps: 1209.69072
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Oshu'gunRelic-25634"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantofFrozenFlame-24092"
  value: {
-  dps: 773.55122
-  tps: 1422.38429
-  dtps: 1320.39922
+  dps: 715.98233
+  tps: 1335.36606
+  dtps: 1322.53235
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantofShadow'sEnd-24097"
  value: {
-  dps: 775.6051
-  tps: 1425.52071
-  dtps: 1319.56902
+  dps: 716.55046
+  tps: 1336.18755
+  dtps: 1321.68738
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantofThawing-24093"
  value: {
-  dps: 775.6051
-  tps: 1425.52071
-  dtps: 1319.56902
+  dps: 716.55046
+  tps: 1336.18755
+  dtps: 1321.68738
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantofWithering-24095"
  value: {
-  dps: 775.6051
-  tps: 1425.52071
-  dtps: 1319.56902
+  dps: 716.55046
+  tps: 1336.18755
+  dtps: 1321.68738
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantoftheNullRune-24098"
  value: {
-  dps: 775.6051
-  tps: 1425.52071
-  dtps: 1319.56902
+  dps: 716.55046
+  tps: 1336.18755
+  dtps: 1321.68738
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PendantoftheVioletEye-28727"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PrimalIntent"
  value: {
-  dps: 789.79029
-  tps: 1447.46231
-  dtps: 1334.81233
+  dps: 731.09804
+  tps: 1356.26988
+  dtps: 1347.40721
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PrimalMooncloth"
  value: {
-  dps: 734.78118
-  tps: 1365.98169
-  dtps: 1567.41919
+  dps: 681.78495
+  tps: 1283.06736
+  dtps: 1558.38382
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Prismcharm-15867"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PrismofInnerCalm-30621"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Quagmirran'sEye-27683"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RaggedJohn'sNeverendingCup-15873"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RegalProtectorate-28042"
  value: {
-  dps: 750.96006
-  tps: 1381.34764
-  dtps: 1259.04619
+  dps: 690.16942
+  tps: 1288.7682
+  dtps: 1271.03123
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RobeoftheElderScribes-28602"
  value: {
-  dps: 763.08233
-  tps: 1406.52322
-  dtps: 1393.49647
+  dps: 701.50931
+  tps: 1313.23819
+  dtps: 1386.41788
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RodoftheSunKing-29996"
  value: {
-  dps: 775.0039
-  tps: 1423.57408
-  dtps: 1294.99259
+  dps: 715.77711
+  tps: 1332.83033
+  dtps: 1284.35457
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Romulo'sPoisonVial-28579"
  value: {
-  dps: 774.04837
-  tps: 1422.55274
-  dtps: 1292.68035
+  dps: 718.40521
+  tps: 1338.46959
+  dtps: 1290.37164
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofForce-25994"
  value: {
-  dps: 747.89258
-  tps: 1377.05734
-  dtps: 1294.31984
+  dps: 690.08482
+  tps: 1288.71887
+  dtps: 1291.63868
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SavageGuard-2681"
  value: {
-  dps: 777.17988
-  tps: 1426.95233
-  dtps: 1299.54573
+  dps: 710.85978
+  tps: 1326.76792
+  dtps: 1299.28679
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SavagePlateGauntlets-35408"
  value: {
-  dps: 774.97629
-  tps: 1396.02211
-  dtps: 1341.51176
+  dps: 716.41968
+  tps: 1309.83524
+  dtps: 1336.45628
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScarabofDisplacement-30629"
  value: {
-  dps: 743.05475
-  tps: 1369.23862
-  dtps: 1235.55968
+  dps: 688.30907
+  tps: 1285.26863
+  dtps: 1234.35024
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScaraboftheInfiniteCycle-28190"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScrollsofBlindingLight-19343"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Scryer'sBloodgem-29132"
  value: {
-  dps: 745.63605
-  tps: 1373.9226
-  dtps: 1295.93175
+  dps: 691.73407
+  tps: 1291.71633
+  dtps: 1300.59801
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SextantofUnstableCurrents-30626"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shadow'sEmbrace"
  value: {
-  dps: 740.11138
-  tps: 1375.07045
-  dtps: 1623.68869
+  dps: 682.19964
+  tps: 1285.1469
+  dtps: 1606.52899
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShadowmoonInsignia-32501"
  value: {
-  dps: 746.62697
-  tps: 1373.74526
-  dtps: 1211.26928
+  dps: 685.4797
+  tps: 1279.31888
+  dtps: 1215.84594
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShardofContempt-34472"
  value: {
-  dps: 815.10549
-  tps: 1491.89578
-  dtps: 1257.87601
+  dps: 758.12925
+  tps: 1404.47378
+  dtps: 1258.77748
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shiffar'sNexus-Horn-28418"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShiftingNaaruSliver-34429"
  value: {
-  dps: 749.17568
-  tps: 1378.6727
-  dtps: 1295.73145
+  dps: 691.40534
+  tps: 1290.90801
+  dtps: 1305.43687
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SkullflameShield-1168"
  value: {
-  dps: 767.64519
-  tps: 1413.7339
-  dtps: 1445.49972
+  dps: 707.87209
+  tps: 1323.30012
+  dtps: 1447.63708
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Slayer'sCrest-23041"
  value: {
-  dps: 763.15967
-  tps: 1399.67825
-  dtps: 1298.18244
+  dps: 704.00408
+  tps: 1309.77276
+  dtps: 1288.22303
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Solarian'sSapphire-30446"
  value: {
-  dps: 747.89258
-  tps: 1377.05734
-  dtps: 1294.31984
+  dps: 690.08482
+  tps: 1288.71887
+  dtps: 1291.63868
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulclothEmbrace"
  value: {
-  dps: 741.78712
-  tps: 1350.55736
-  dtps: 1624.88836
+  dps: 689.36092
+  tps: 1271.32822
+  dtps: 1621.52748
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpellstrikeInfusion"
  value: {
-  dps: 770.12698
-  tps: 1418.36319
-  dtps: 1480.84187
+  dps: 718.19266
+  tps: 1338.9137
+  dtps: 1475.74684
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpyglassoftheHiddenFleet-30620"
  value: {
-  dps: 747.37827
-  tps: 1376.19225
-  dtps: 1294.82938
+  dps: 688.54627
+  tps: 1286.07391
+  dtps: 1294.26449
   hps: 14.44444
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StabilitzedEterniumScope-2724"
  value: {
-  dps: 775.0039
-  tps: 1423.57408
-  dtps: 1294.99259
+  dps: 715.77711
+  tps: 1332.83033
+  dtps: 1284.35457
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Starkiller'sBauble-30340"
  value: {
-  dps: 745.59608
-  tps: 1373.86165
-  dtps: 1295.93175
+  dps: 691.69599
+  tps: 1291.65825
+  dtps: 1300.59801
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StarofSha'naar-25995"
  value: {
-  dps: 747.89258
-  tps: 1377.05734
-  dtps: 1294.31984
+  dps: 690.08482
+  tps: 1288.71887
+  dtps: 1291.63868
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SteelyNaaruSliver-34428"
  value: {
-  dps: 809.63254
-  tps: 1483.72246
-  dtps: 1268.19864
+  dps: 755.16418
+  tps: 1399.64603
+  dtps: 1263.92324
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StrengthoftheClefthoof"
  value: {
-  dps: 745.02255
-  tps: 1379.26497
-  dtps: 1459.1102
+  dps: 686.82221
+  tps: 1290.35084
+  dtps: 1457.10618
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 777.52478
-  tps: 1427.5147
-  dtps: 1295.11345
+  dps: 714.57389
+  tps: 1330.94161
+  dtps: 1287.86602
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SyphonoftheNathrezim-32262"
  value: {
-  dps: 775.0039
-  tps: 1423.57408
-  dtps: 1294.99259
+  dps: 715.77711
+  tps: 1332.83033
+  dtps: 1284.35457
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofAscendance-22678"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofEphemeralPower-18820"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TerokkarTabletofPrecision-25937"
  value: {
-  dps: 766.18867
-  tps: 1408.83069
-  dtps: 1287.69727
+  dps: 709.04573
+  tps: 1322.20832
+  dtps: 1286.31672
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TerokkarTabletofVim-25936"
  value: {
-  dps: 745.57006
-  tps: 1373.82197
-  dtps: 1295.93175
+  dps: 691.66997
+  tps: 1291.61858
+  dtps: 1300.59801
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheBladefist-29348"
  value: {
-  dps: 741.97261
-  tps: 1375.02231
-  dtps: 1328.37212
+  dps: 686.46791
+  tps: 1290.34674
+  dtps: 1322.23823
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheLightningCapacitor-28785"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheRestrainedEssenceofSapphiron-23046"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheSkullofGul'dan-32483"
  value: {
-  dps: 745.59608
-  tps: 1373.86165
-  dtps: 1295.93175
+  dps: 691.69599
+  tps: 1291.65825
+  dtps: 1300.59801
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 975.96914
-  tps: 1711.25729
-  dtps: 2051.28718
+  dps: 974.53858
+  tps: 1709.461
+  dtps: 2054.92506
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ThickDraenicArmor"
  value: {
-  dps: 784.16861
-  tps: 1416.18522
-  dtps: 1595.6988
+  dps: 729.03003
+  tps: 1332.78459
+  dtps: 1595.22838
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Thunderfury,BlessedBladeoftheWindseeker-19019"
  value: {
-  dps: 775.0039
-  tps: 1423.57408
-  dtps: 1294.99259
+  dps: 715.77711
+  tps: 1332.83033
+  dtps: 1284.35457
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TomeofDiabolicRemedy-33828"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TsunamiTalisman-30627"
  value: {
-  dps: 775.78754
-  tps: 1421.57036
-  dtps: 1300.64002
+  dps: 720.84745
+  tps: 1338.70685
+  dtps: 1299.08438
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnitingCharm-25633"
  value: {
-  dps: 752.00492
-  tps: 1383.42552
-  dtps: 1295.38017
+  dps: 695.17368
+  tps: 1296.42842
+  dtps: 1292.77871
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VengeanceoftheIllidari-28040"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VengefulGladiator'sPlateGauntlets-33729"
  value: {
-  dps: 783.20942
-  tps: 1409.12359
-  dtps: 1323.83952
+  dps: 722.82348
+  tps: 1319.98775
+  dtps: 1318.91866
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerArmor"
  value: {
-  dps: 776.20016
-  tps: 1392.41442
-  dtps: 1131.34258
+  dps: 718.19288
+  tps: 1305.71357
+  dtps: 1142.35235
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarbringerBattlegear"
  value: {
-  dps: 864.25924
-  tps: 1544.05903
-  dtps: 1422.36069
+  dps: 800.56103
+  tps: 1448.00697
+  dtps: 1425.33854
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Warp-ScarabBrooch-27828"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WarpSlicer-30311"
  value: {
-  dps: 775.0039
-  tps: 1423.57408
-  dtps: 1294.99259
+  dps: 715.77711
+  tps: 1332.83033
+  dtps: 1284.35457
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WastewalkerArmor"
  value: {
-  dps: 826.53527
-  tps: 1487.64204
-  dtps: 1647.42361
+  dps: 770.67741
+  tps: 1403.62374
+  dtps: 1656.20937
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WhitemendWisdom"
  value: {
-  dps: 766.89425
-  tps: 1414.0594
-  dtps: 1466.78907
+  dps: 710.47289
+  tps: 1327.46623
+  dtps: 1465.15554
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WindhawkArmor"
  value: {
-  dps: 741.52872
-  tps: 1374.44158
-  dtps: 1447.28016
+  dps: 679.71772
+  tps: 1279.1839
+  dtps: 1457.77434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofCenarius-21190"
  value: {
-  dps: 778.25083
-  tps: 1429.03228
-  dtps: 1317.69937
+  dps: 713.63659
+  tps: 1330.39624
+  dtps: 1315.24407
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofSpellfire"
  value: {
-  dps: 734.23128
-  tps: 1337.54886
-  dtps: 1535.40411
+  dps: 680.74553
+  tps: 1256.71566
+  dtps: 1524.66813
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wushoolay'sCharmofNature-19955"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Xi'ri'sGift-29179"
  value: {
-  dps: 747.07856
-  tps: 1375.83781
-  dtps: 1295.45955
+  dps: 689.03454
+  tps: 1287.21592
+  dtps: 1297.43859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 781.74863
-  tps: 1431.04865
-  dtps: 1263.78627
+  dps: 719.81817
+  tps: 1335.97993
+  dtps: 1264.07181
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Protection-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2868.47409
-  tps: 2914.99202
-  dtps: 31028.40744
+  dps: 2685.4019
+  tps: 2751.16051
+  dtps: 31087.47955
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Protection-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 953.75988
-  tps: 1719.56607
-  dtps: 1124.06253
+  dps: 886.74007
+  tps: 1616.1694
+  dtps: 1124.02321
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Protection-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1030.1959
-  tps: 1865.54592
-  dtps: 1030.86719
+  dps: 960.03198
+  tps: 1756.29216
+  dtps: 1027.80584
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Protection-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 808.16951
-  tps: 1042.79409
-  dtps: 53352.43257
+  dps: 794.10559
+  tps: 1030.51518
+  dtps: 53352.51573
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Protection-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 385.02358
-  tps: 984.28345
-  dtps: 1694.67208
+  dps: 382.31484
+  tps: 980.22588
+  dtps: 1693.69587
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Protection-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 360.23461
-  tps: 921.12623
-  dtps: 1558.4901
+  dps: 360.13744
+  tps: 920.97805
+  dtps: 1558.49846
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Protection-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2713.56957
-  tps: 2781.83111
-  dtps: 31683.23723
+  dps: 2540.33669
+  tps: 2622.56169
+  dtps: 31725.88392
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Protection-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 874.39242
-  tps: 1590.6534
-  dtps: 1187.92456
+  dps: 827.22627
+  tps: 1518.76949
+  dtps: 1196.2636
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Protection-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 925.78332
-  tps: 1695.85811
-  dtps: 1111.96453
+  dps: 868.22946
+  tps: 1606.61073
+  dtps: 1115.31282
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Protection-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 747.52208
-  tps: 983.68144
-  dtps: 55262.40509
+  dps: 735.06219
+  tps: 972.69954
+  dtps: 55262.45821
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Protection-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 341.53878
-  tps: 903.31538
-  dtps: 1785.0471
+  dps: 340.34344
+  tps: 901.46012
+  dtps: 1785.05365
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Protection-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 315.48289
-  tps: 838.47197
-  dtps: 1646.1148
+  dps: 315.40434
+  tps: 838.3522
+  dtps: 1646.12145
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Protection-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2846.58166
-  tps: 2895.72133
-  dtps: 31098.31393
+  dps: 2665.66922
+  tps: 2731.96671
+  dtps: 31136.03359
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Protection-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 941.53589
-  tps: 1698.93239
-  dtps: 1126.99489
+  dps: 882.29245
+  tps: 1607.35565
+  dtps: 1125.44407
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Protection-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 1012.18755
-  tps: 1834.84497
-  dtps: 1024.23752
+  dps: 948.12057
+  tps: 1736.28678
+  dtps: 1023.61097
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Protection-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 801.18913
-  tps: 1034.46439
-  dtps: 53450.74734
+  dps: 787.08327
+  tps: 1022.11669
+  dtps: 53450.87235
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Protection-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 382.65368
-  tps: 975.19686
-  dtps: 1688.18738
+  dps: 377.00745
+  tps: 966.95489
+  dtps: 1688.29958
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Protection-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 357.82135
-  tps: 913.67177
-  dtps: 1563.80662
+  dps: 357.5789
+  tps: 913.30208
+  dtps: 1563.8192
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Protection-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2673.85015
-  tps: 2740.63997
-  dtps: 31730.59669
+  dps: 2496.81824
+  tps: 2579.11015
+  dtps: 31771.3422
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Protection-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 859.27077
-  tps: 1564.71987
-  dtps: 1196.33305
+  dps: 806.33495
+  tps: 1483.153
+  dtps: 1199.13416
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Protection-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 916.85212
-  tps: 1679.28951
-  dtps: 1124.31714
+  dps: 857.58912
+  tps: 1587.21785
+  dtps: 1124.72709
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Protection-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 740.48606
-  tps: 973.81986
-  dtps: 55414.17378
+  dps: 728.11794
+  tps: 962.93657
+  dtps: 55414.25875
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Protection-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 336.21618
-  tps: 889.89408
-  dtps: 1788.15552
+  dps: 335.00318
+  tps: 888.01315
+  dtps: 1788.166
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Protection-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 312.34428
-  tps: 830.12704
-  dtps: 1653.33352
+  dps: 312.22168
+  tps: 829.94012
+  dtps: 1653.34404
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 859.27077
-  tps: 1564.71987
-  dtps: 1196.33305
+  dps: 806.33495
+  tps: 1483.153
+  dtps: 1199.13416
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -3,10 +3,10 @@ character_stats_results: {
  value: {
   final_stats: 549
   final_stats: 466
-  final_stats: 1248
+  final_stats: 1249
   final_stats: 103
-  final_stats: 232.7
-  final_stats: 219.7
+  final_stats: 232.2
+  final_stats: 219.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -17,7 +17,7 @@ character_stats_results: {
   final_stats: 48
   final_stats: 0
   final_stats: 0
-  final_stats: 167
+  final_stats: 162
   final_stats: 2280.3
   final_stats: 403
   final_stats: 0
@@ -34,7 +34,7 @@ character_stats_results: {
   final_stats: 41
   final_stats: 16966.4
   final_stats: 294
-  final_stats: 17914
+  final_stats: 17924
   final_stats: 0
   final_stats: 122.5
   final_stats: 33
@@ -159,9 +159,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BadgeofTenacity-32658"
  value: {
-  dps: 697.85035
-  tps: 1299.70257
-  dtps: 1253.30378
+  dps: 696.4152
+  tps: 1297.82969
+  dtps: 1255.67006
  }
 }
 dps_results: {
@@ -415,9 +415,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CircletofArcaneMight-24123"
  value: {
-  dps: 710.57765
-  tps: 1327.5527
-  dtps: 1381.0175
+  dps: 708.5675
+  tps: 1324.10715
+  dtps: 1378.98667
  }
 }
 dps_results: {
@@ -983,9 +983,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MasqueradeGown-28578"
  value: {
-  dps: 700.35755
-  tps: 1311.57666
-  dtps: 1383.40299
+  dps: 700.92735
+  tps: 1312.36481
+  dtps: 1382.95614
  }
 }
 dps_results: {
@@ -1335,8 +1335,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SkullflameShield-1168"
  value: {
-  dps: 707.87209
-  tps: 1323.30012
+  dps: 707.8664
+  tps: 1323.29144
   dtps: 1447.63708
  }
 }
@@ -1656,9 +1656,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 719.81817
-  tps: 1335.97993
-  dtps: 1264.07181
+  dps: 719.81584
+  tps: 1335.9847
+  dtps: 1264.22002
  }
 }
 dps_results: {


### PR DESCRIPTION
This PR makes character attributes match the real (anniversary) client exactly, verified against naked-character screenshots and Warcraft Logs audit data.

### Attribute rounding
- The five primary attributes are floored the way the game does it: flats (gear, gems, buffs) add to base, multipliers (racials, Kings, %-stat talents) stack multiplicatively on the *unfloored* value, and a single floor is applied at the end. Derived stats (armor, dodge, health) consume the floored attribute.
- Talent-improved buff aura amounts are truncated to integers like the game (imp GotW 18, imp PW:F 102, imp Battle Shout 382, etc).

### Base stats
Verified base attributes for every playable race/class by crawling 420 players' `COMBATANT_INFO` audit snapshots from Warcraft Logs and inverting `floor((base + flats) × mults)` per stat, requiring agreement across independent players:

- Three class spirit values were as-shown human sheet values instead of true pre-racial bases (Warrior 56→51, Paladin 97→89, Priest 166→151) — non-human warriors/paladins/priests were up to 15 spirit too high. Warlock spirit was off by one (144→143).
- Seven race offsets were off by one: blood elf int/spirit, undead agi, gnome agi, orc stamina/spirit, troll stamina.
- With those fixed, plain `class + race offset` reproduces every verified combo, so no per-combo special cases are needed. The Human Spirit (×1.1) and Expansive Mind (×1.05) racials apply as true multipliers on top (e.g. naked human paladin: 89 base → 97 shown → 107 with Kings, matching in-game screenshots).
- Hunter rows couldn't be pinned precisely (pre-pull potion/proc noise in the audit data) and are unchanged.

### Warlock
- Demonic Embrace reduced spirit by 3% per point; the real penalty is 1% per point (stamina bonus unchanged).