### PR TITLE
[UI] Fix racial expertise display issue

### DIFF
--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -603,7 +603,7 @@ export class CharacterStats extends Component {
 
 			// Remove the rating display and only show %
 			if (rootRatingValue !== null && rootRatingValue > 0 && mhWeaponExpertiseActive) {
-				rootRatingValue -= Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION * 4;
+				rootRatingValue -= Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION * 5;
 			}
 
 			const matchesBothHands = mhWeaponExpertiseActive && ohWeaponExpertiseActive;
@@ -618,7 +618,8 @@ export class CharacterStats extends Component {
 				const hideRootRating = rootRatingValue === null || (rootRatingValue === 0 && derivedPercentOrPointsValue !== null);
 				const rootRatingString = hideRootRating ? '' : String(Math.round(rootRatingValue!));
 				const mhPercentString = `${derivedPercentOrPointsValue!.toFixed(percentDecimals)}` + displaySuffix;
-				const ohPercentValue = derivedPercentOrPointsValue! + (ohWeaponExpertiseActive ? 1 : -1);
+				const racialExpertisePercent = 5 * 0.25;
+				const ohPercentValue = derivedPercentOrPointsValue! + (ohWeaponExpertiseActive ? racialExpertisePercent : -racialExpertisePercent);
 				const ohPercentString = `${ohPercentValue.toFixed(percentDecimals)}` + displaySuffix;
 				const wrappedPercentString = hideRootRating ? `${mhPercentString} / ${ohPercentString}` : ` (${mhPercentString} / ${ohPercentString})`;
 				return rootRatingString + wrappedPercentString;


### PR DESCRIPTION
It's 5 expertise (1.25%) in TBC, not 4 (1%).
UI didn't match the backend so it was showing a leftover 4 rating as well as offhands showing 0.25% too much