### PR TITLE
Fix to Empowered Arc Missiles talent. Updates it to only give the app…

### DIFF
--- a/sim/core/TestProtoVersioning.results
+++ b/sim/core/TestProtoVersioning.results
@@ -1,0 +1,1 @@
+saved_version_number: 14

--- a/sim/core/TestProtoVersioning.results
+++ b/sim/core/TestProtoVersioning.results
@@ -1,1 +1,0 @@
-saved_version_number: 14

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -231,7 +231,7 @@ func (mage *Mage) registerEmpoweredArcaneMissiles() {
 
 	mage.AddStaticMod(core.SpellModConfig{
 		ClassMask:  MageSpellArcaneMissilesTick,
-		FloatValue: .15 * float64(mage.Talents.EmpoweredArcaneMissiles),
+		FloatValue: .03 * float64(mage.Talents.EmpoweredArcaneMissiles),
 		Kind:       core.SpellMod_BonusCoeffecient_Flat,
 	})
 


### PR DESCRIPTION
Fix to Empowered Arc Missiles talent. Updates it to only give the appropriate +3% spellpower per missile per point. Previously was adding 15% of spellpower per missile