### PR TITLE
Fail make proto early on deprecated protoc-gen-go plugin

### DIFF
--- a/makefile
+++ b/makefile
@@ -207,6 +207,13 @@ release: wowsimtbc wowsimtbc-windows.exe
 	zip wowsimcli-windows.exe.zip wowsimcli-windows.exe
 
 sim/core/proto/api.pb.go: proto/*.proto
+	@if go version -m "$$(command -v protoc-gen-go)" 2>/dev/null | grep -qE '^[[:space:]]+mod[[:space:]]+github\.com/golang/protobuf[[:space:]]'; then \
+		echo "ERROR: your protoc-gen-go is the deprecated github.com/golang/protobuf plugin;"; \
+		echo "it generates code that no longer builds against this repo's protobuf version."; \
+		echo "Fix:  go install google.golang.org/protobuf/cmd/protoc-gen-go@latest"; \
+		echo "then: rm -f sim/core/proto/*.pb.go && retry"; \
+		exit 1; \
+	fi
 	protoc -I=./proto --go_out=./sim/core ./proto/*.proto
 
 # Only useful for building the lib on a host platform that matches the target platform


### PR DESCRIPTION
Devs with an old `github.com/golang/protobuf`-lineage protoc-gen-go generate code that resolves to v1.5.0 and no longer compiles (`undefined: descriptorpb.Default_FileOptions_PhpGenericServices`). Fail regeneration early with instructions instead.