### PR TITLE
Swap StatBuff for Vampiric Touch to Aura and use periodic action

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -1578,11 +1578,20 @@ func BlessingOfWisdomAura(char *Character, improved bool) *Aura {
 ////////////////////////////
 
 func ShadowPriestDPSManaAura(char *Character, dps float64) *Aura {
-	return makeStatBuff(char, BuffConfig{
+	manaMetrics := char.NewManaMetrics(ActionID{SpellID: 34914})
+
+	manaGain := dps * 0.25
+
+	return char.GetOrRegisterAura(Aura{
 		Label:    "Vampiric Touch",
 		ActionID: ActionID{SpellID: 34914},
-		Stats: []StatConfig{
-			{stats.MP5, dps * 0.25, false},
+		OnGain: func(aura *Aura, sim *Simulation) {
+			StartPeriodicAction(sim, PeriodicActionOptions{
+				Period: DurationFromSeconds(5),
+				OnAction: func(s *Simulation) {
+					char.AddMana(sim, manaGain, manaMetrics)
+				},
+			})
 		},
 	})
 }


### PR DESCRIPTION
Made Vamp Touch a mana metric instead of a "mp5 buff" which could be impacted by other factors. Also allows you to view the metrics easier.

Before
<img width="1414" height="165" alt="image" src="https://github.com/user-attachments/assets/0fd46d13-1025-40c0-9413-2a0ae07bcddd" />

After
<img width="1427" height="200" alt="image" src="https://github.com/user-attachments/assets/4287eb87-34e8-4fc6-bf88-b7e618bb9ef0" />

