### PR TITLE
Edited Period for VampTouch OnAction from 5 to 1

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -1580,14 +1580,14 @@ func BlessingOfWisdomAura(char *Character, improved bool) *Aura {
 func ShadowPriestDPSManaAura(char *Character, dps float64) *Aura {
 	manaMetrics := char.NewManaMetrics(ActionID{SpellID: 34914})
 
-	manaGain := dps * 0.25
+	manaGain := dps * 0.05
 
 	return char.GetOrRegisterAura(Aura{
 		Label:    "Vampiric Touch",
 		ActionID: ActionID{SpellID: 34914},
 		OnGain: func(aura *Aura, sim *Simulation) {
 			StartPeriodicAction(sim, PeriodicActionOptions{
-				Period: DurationFromSeconds(5),
+				Period: DurationFromSeconds(1),
 				OnAction: func(s *Simulation) {
 					char.AddMana(sim, manaGain, manaMetrics)
 				},


### PR DESCRIPTION
This more closely resembles mana gained in fights after reviewing some logs.

<img width="515" height="80" alt="image" src="https://github.com/user-attachments/assets/bdac0b00-cb06-4f98-badf-ca3a3ed4949d" />

Swapped:
<img width="1411" height="51" alt="image" src="https://github.com/user-attachments/assets/fdbddb71-c5f9-43dc-a155-5f3bd105aa60" />

vs(5 sec period):
<img width="1431" height="51" alt="image" src="https://github.com/user-attachments/assets/8fbe9cef-c235-4704-8694-51ef7e342353" />


the avg gain is the same, 50*5 = 250 but it really matters on situations where it could cause it to go into a conserve rotation too early or not get enough ticks.