### PR TITLE
Port the APL editor and timeline cleanup from MoP (#1555)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"i18next-browser-languagedetector": "^8.2.0",
 				"i18next-http-backend": "^3.0.2",
 				"pako": "^2.0.4",
+				"shallow-equal": "^3.1.0",
 				"tippy.js": "^6.3.7",
 				"tsx-vanilla": "^1.2.0",
 				"uuid": "^11.1.0",
@@ -6080,6 +6081,12 @@
 			"resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
 			"integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/shallow-equal": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+			"integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
 			"license": "MIT"
 		},
 		"node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"i18next-browser-languagedetector": "^8.2.0",
 		"i18next-http-backend": "^3.0.2",
 		"pako": "^2.0.4",
+		"shallow-equal": "^3.1.0",
 		"tippy.js": "^6.3.7",
 		"tsx-vanilla": "^1.2.0",
 		"uuid": "^11.1.0",

--- a/ui/core/components/component.ts
+++ b/ui/core/components/component.ts
@@ -3,6 +3,8 @@ export abstract class Component {
 
 	private disposeCallbacks: Array<() => void> = [];
 	private disposed = false;
+	// Child components disposed together with this one (cascade before own callbacks).
+	private readonly children: Array<Component> = [];
 
 	readonly rootElem: HTMLElement;
 
@@ -18,12 +20,35 @@ export abstract class Component {
 		this.disposeCallbacks.push(callback);
 	}
 
+	addChild<C extends Component>(child: C): C {
+		this.children.push(child);
+		return child;
+	}
+
+	// Disposes a registered child ahead of this component's own disposal.
+	disposeChild(child: Component) {
+		const idx = this.children.indexOf(child);
+		if (idx >= 0) this.children.splice(idx, 1);
+		child.dispose();
+	}
+
+	// Disposes a registered child and removes its root element from the DOM.
+	removeChild(child: Component) {
+		this.disposeChild(child);
+		child.rootElem.remove();
+	}
+
+	protected get isDisposed(): boolean {
+		return this.disposed;
+	}
+
 	dispose() {
 		if (this.disposed) {
 			return;
 		}
 		this.disposed = true;
 
+		this.children.splice(0).forEach(child => child.dispose());
 		this.disposeCallbacks.forEach(callback => callback());
 		this.disposeCallbacks = [];
 	}

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -29,6 +29,16 @@ const cachedSpellCastIcon = new CacheHandler<HTMLAnchorElement>();
 
 interface TimelineConfig extends ResultComponentConfig {}
 
+interface RotationSlot {
+	key: string;
+	labels: Array<Node>;
+	timeline: Array<Node>;
+	hiddenIdsNodes: Array<Node>;
+	emitter: TypedEvent<void>;
+	resetCallbacks: Array<() => void>;
+	plotOptions: any;
+}
+
 export class Timeline extends ResultComponent {
 	private readonly dpsResourcesPlotElem: HTMLElement;
 	private dpsResourcesPlot: any;
@@ -36,37 +46,35 @@ export class Timeline extends ResultComponent {
 	private readonly rotationPlotElem: HTMLElement;
 	private readonly rotationLabels: HTMLElement;
 	private readonly rotationTimeline: HTMLElement;
-	private rotationTimelineTimeRulerElem: HTMLCanvasElement | null = null;
 	private readonly rotationHiddenIdsContainer: HTMLElement;
 	private readonly chartPicker: HTMLSelectElement;
 	private showGcd = false;
 	private readonly showGcdChangeEmitter = new TypedEvent<void>();
 
-	private prevResultData: SimResultData | null;
 	private resultData: SimResultData | null;
 	rendered: boolean;
 
-	private hiddenIds: Array<ActionId>;
-	private hiddenIdsChangeEmitter;
-	private cacheHandler = new CacheHandler<{
-		dpsResourcesPlotOptions: any;
-		rotationLabels: Timeline['rotationLabels'];
-		rotationTimeline: Timeline['rotationTimeline'];
-		rotationHiddenIdsContainer: Timeline['rotationHiddenIdsContainer'];
-		rotationTimelineTimeRulerElem: Timeline['rotationTimelineTimeRulerElem'];
-		rotationTimelineTimeRulerImage: ImageData | undefined;
-	}>({
-		keysToKeep: 2,
-	});
+	// A rendered rotation timeline for one (result, filter, chart) key. The DOM
+	// nodes are kept LIVE (moved in and out of the containers, never cloned) so
+	// their tippy instances, click handlers and emitter subscriptions survive a
+	// switch between the current result and a saved reference. Eviction runs the
+	// slot's reset callbacks (tooltip destroy, listener removal).
+	private liveSlot: RotationSlot | null = null;
+	// The most recently stashed slot. One is enough for the current <-> reference
+	// swap, and each parked slot keeps its full tippy instance set alive.
+	private parkedSlot: RotationSlot | null = null;
+
+	// Hidden rows are keyed by section (player '', pet name, target label) plus
+	// action, so ids shared across sections (e.g. main-hand Attack) hide independently.
+	private hiddenIds: Array<{ scope: string; actionId: ActionId }>;
 
 	constructor(config: TimelineConfig) {
 		config.rootCssClass = 'timeline-root';
 		super(config);
 		this.resultData = null;
-		this.prevResultData = null;
 		this.rendered = false;
 		this.hiddenIds = [];
-		this.hiddenIdsChangeEmitter = new TypedEvent<void>();
+		this.addOnDisposeCallback(() => this.reset());
 
 		const showGcdContainerRef = ref<HTMLDivElement>();
 		this.rootElem.appendChild(
@@ -199,7 +207,6 @@ export class Timeline extends ResultComponent {
 	}
 
 	onSimResult(resultData: SimResultData) {
-		this.prevResultData = this.resultData;
 		this.resultData = resultData;
 		this.update();
 	}
@@ -209,22 +216,26 @@ export class Timeline extends ResultComponent {
 			return;
 		}
 
-		const cachedData = this.cacheHandler.get(this.resultData.result.request.requestId);
-		if (cachedData) {
-			const { dpsResourcesPlotOptions, rotationLabels, rotationTimeline, rotationHiddenIdsContainer, rotationTimelineTimeRulerImage } = cachedData;
-			this.rotationLabels.replaceChildren(...rotationLabels.cloneNode(true).childNodes);
-			this.rotationTimeline.replaceChildren(...rotationTimeline.cloneNode(true).childNodes);
-
-			this.rotationHiddenIdsContainer.replaceChildren(...rotationHiddenIdsContainer.cloneNode(true).childNodes);
-			this.dpsResourcesPlot.updateOptions(dpsResourcesPlotOptions);
-
-			if (rotationTimelineTimeRulerImage)
-				this.rotationTimeline
-					.querySelector<HTMLCanvasElement>('.rotation-timeline-canvas')
-					?.getContext('2d')
-					?.putImageData(rotationTimelineTimeRulerImage, 0, 0);
-
+		const players = this.resultData.result.getRaidIndexedPlayers(this.resultData.filter);
+		const singlePlayer = players.length == 1;
+		if (!singlePlayer && this.chartPicker.value == 'rotation') {
+			// Programmatic select changes fire no 'change' event: sync the plot containers by hand.
+			this.chartPicker.value = 'dps';
 			this.onChartPickerSelectHandler();
+		}
+
+		// Fast path: this result was rendered before and its slot is either live
+		// or parked in the cache.
+		const key = this.resultKey(!singlePlayer);
+		const hit = this.liveSlot?.key === key ? this.liveSlot : this.parkedSlot?.key === key ? this.parkedSlot : null;
+		if (hit?.plotOptions) {
+			if (hit !== this.liveSlot) {
+				this.parkedSlot = null;
+				this.stashLiveSlot();
+				this.attachSlot(hit);
+			}
+			this.setRotationOptionVisible(singlePlayer);
+			this.dpsResourcesPlot.updateOptions(hit.plotOptions);
 			return;
 		}
 
@@ -277,14 +288,10 @@ export class Timeline extends ResultComponent {
 			},
 		};
 
-		const players = this.resultData!.result.getRaidIndexedPlayers(this.resultData!.filter);
-		if (players.length == 1) {
+		if (singlePlayer) {
 			const player = players[0];
 
-			const rotationOption = this.rootElem.querySelector('.rotation-option')!;
-			rotationOption.classList.remove('hide');
-			const threatOption = this.rootElem.querySelector('.threat-option')!;
-			threatOption.classList.add('hide');
+			this.setRotationOptionVisible(true);
 
 			try {
 				this.updateRotationChart(player, duration);
@@ -301,16 +308,12 @@ export class Timeline extends ResultComponent {
 
 			this.addMajorCooldownAnnotations(player, options);
 		} else {
-			if (this.chartPicker.value == 'rotation') {
-				this.chartPicker.value = 'dps';
-				return;
-			}
-			const rotationOption = this.rootElem.querySelector('.rotation-option')!;
-			rotationOption.classList.add('hide');
-			const threatOption = this.rootElem.querySelector('.threat-option')!;
-			threatOption.classList.remove('hide');
+			this.setRotationOptionVisible(false);
 
+			this.stashLiveSlot();
 			this.clearRotationChart();
+			// No rotation subtree, but the (expensive) per-player series are worth caching for swaps.
+			this.liveSlot = Timeline.newSlot(key);
 
 			if (this.chartPicker.value == 'dps') {
 				let maxDps = 0;
@@ -331,20 +334,8 @@ export class Timeline extends ResultComponent {
 			}
 		}
 
+		if (this.liveSlot?.key === key) this.liveSlot.plotOptions = options;
 		this.dpsResourcesPlot.updateOptions(options);
-
-		this.rotationTimelineTimeRulerElem?.toBlob(() => {
-			this.cacheHandler.set(this.resultData!.result.request.requestId, {
-				dpsResourcesPlotOptions: options,
-				rotationLabels: this.rotationLabels.cloneNode(true) as HTMLElement,
-				rotationTimeline: this.rotationTimeline.cloneNode(true) as HTMLElement,
-				rotationHiddenIdsContainer: this.rotationHiddenIdsContainer.cloneNode(true) as HTMLElement,
-				rotationTimelineTimeRulerElem: this.rotationTimelineTimeRulerElem?.cloneNode(true) as HTMLCanvasElement,
-				rotationTimelineTimeRulerImage: this.rotationTimelineTimeRulerElem
-					?.getContext('2d')
-					?.getImageData(0, 0, this.rotationTimelineTimeRulerElem.width, this.rotationTimelineTimeRulerElem.height),
-			});
-		});
 	}
 
 	private addDpsYAxis(maxDps: number, options: any) {
@@ -556,15 +547,12 @@ export class Timeline extends ResultComponent {
 
 	private clearRotationChart() {
 		this.rotationLabels.replaceChildren(<div className="rotation-label-header"></div>);
-		const canvasRef = ref<HTMLCanvasElement>();
 		this.rotationTimeline.replaceChildren(
 			<div className="rotation-timeline-header">
-				<canvas ref={canvasRef} className="rotation-timeline-canvas" />
+				<canvas className="rotation-timeline-canvas" />
 			</div>,
 		);
-		this.rotationTimelineTimeRulerElem = canvasRef.value || null;
 		this.rotationHiddenIdsContainer.replaceChildren();
-		this.hiddenIdsChangeEmitter = new TypedEvent<void>();
 	}
 
 	private updateRotationChart(player: UnitMetrics, duration: number) {
@@ -573,6 +561,18 @@ export class Timeline extends ResultComponent {
 			return;
 		}
 
+		const key = this.resultKey();
+		if (this.liveSlot?.key === key) {
+			return;
+		}
+		// Take before stashing so the stash can't evict the slot we want.
+		const parked = this.takeParkedSlot(key);
+		this.stashLiveSlot();
+		if (parked) {
+			this.attachSlot(parked);
+			return;
+		}
+		this.liveSlot = Timeline.newSlot(key);
 		this.clearRotationChart();
 
 		try {
@@ -629,7 +629,7 @@ export class Timeline extends ResultComponent {
 				orderedResourceTypes.forEach(resourceType => this.addResourceRow(resourceType, pet.groupedResourceLogs[resourceType], duration));
 				this.addGcdStripRow(pet, duration);
 				const petCastsByAbility = this.getSortedCastsByAbility(pet);
-				petCastsByAbility.forEach(castLogs => this.addCastRow(castLogs, buffsAndDebuffsById, duration));
+				petCastsByAbility.forEach(castLogs => this.addCastRow(castLogs, buffsAndDebuffsById, duration, pet.name));
 			});
 		}
 
@@ -650,7 +650,7 @@ export class Timeline extends ResultComponent {
 			if (targetCastsByAbility.length > 0) {
 				this.addSeparatorRow(duration);
 				this.addTargetRow(target.label, duration);
-				targetCastsByAbility.forEach(castLogs => this.addCastRow(castLogs, buffsAndDebuffsById, duration));
+				targetCastsByAbility.forEach(castLogs => this.addCastRow(castLogs, buffsAndDebuffsById, duration, target.label));
 			}
 		});
 
@@ -659,7 +659,7 @@ export class Timeline extends ResultComponent {
 			if (debuffsToShow.length > 0) {
 				this.addSeparatorRow(duration);
 				this.addTargetRow(targets?.[index]?.label, duration);
-				debuffsToShow.forEach(auraUptimeLogs => this.addAuraRow(auraUptimeLogs, duration));
+				debuffsToShow.forEach(auraUptimeLogs => this.addAuraRow(auraUptimeLogs, duration, targets?.[index]?.label ?? ''));
 			}
 		});
 	}
@@ -705,8 +705,14 @@ export class Timeline extends ResultComponent {
 		return castsByAbility;
 	}
 
-	private makeLabelElem(actionId: ActionId, isHiddenLabel: boolean, isAura?: boolean): JSX.Element {
-		const labelText = idsToGroupForRotation.includes(actionId.spellId) ? actionId.baseName : actionId.name;
+	private hiddenIndex(scope: string, actionId: ActionId): number {
+		return this.hiddenIds.findIndex(hidden => hidden.scope === scope && hidden.actionId.equals(actionId));
+	}
+
+	private makeLabelElem(actionId: ActionId, isHiddenLabel: boolean, isAura: boolean, scope: string): JSX.Element {
+		const baseText = idsToGroupForRotation.includes(actionId.spellId) ? actionId.baseName : actionId.name;
+		// Hidden chips for pet/target rows name their section so two "Attack" chips are telling apart.
+		const labelText = isHiddenLabel && scope ? `${baseText} (${scope})` : baseText;
 		const labelIcon = ref<HTMLAnchorElement>();
 		const hideElem = ref<HTMLElement>();
 		const labelElem = (
@@ -716,18 +722,22 @@ export class Timeline extends ResultComponent {
 				<span className="rotation-label-text">{labelText}</span>
 			</div>
 		);
-		const onClickHandler = () => {
+		// The whole hidden chip un-hides; on the visible label only the eye hides.
+		const clickTarget = isHiddenLabel ? labelElem : hideElem.value!;
+		const onClickHandler = (event: Event) => {
+			// The spell icon keeps its own link + Wowhead tooltip.
+			if (isHiddenLabel && (event.target as Element).closest('.rotation-label-icon')) return;
 			if (isHiddenLabel) {
-				const index = this.hiddenIds.findIndex(hiddenId => hiddenId.equals(actionId));
+				const index = this.hiddenIndex(scope, actionId);
 				if (index != -1) {
 					this.hiddenIds.splice(index, 1);
 				}
 			} else {
-				this.hiddenIds.push(actionId);
+				this.hiddenIds.push({ scope, actionId });
 			}
-			this.hiddenIdsChangeEmitter.emit(TypedEvent.nextEventID());
+			this.liveSlot?.emitter.emit(TypedEvent.nextEventID());
 		};
-		hideElem.value!.addEventListener('click', onClickHandler);
+		clickTarget.addEventListener('click', onClickHandler);
 		const tooltip = tippy(hideElem.value!, {
 			theme: 'timeline-tooltip',
 			placement: 'bottom',
@@ -735,19 +745,19 @@ export class Timeline extends ResultComponent {
 		});
 
 		const updateHidden = () => {
-			if (isHiddenLabel == Boolean(this.hiddenIds.find(hiddenId => hiddenId.equals(actionId)))) {
+			if (isHiddenLabel == (this.hiddenIndex(scope, actionId) != -1)) {
 				labelElem.classList.remove('hide');
 			} else {
 				labelElem.classList.add('hide');
 			}
 		};
-		const event = this.hiddenIdsChangeEmitter.on(updateHidden);
+		const event = this.liveSlot!.emitter.on(updateHidden);
 		updateHidden();
 		actionId.setBackgroundAndHref(labelIcon.value!);
 		actionId.setWowheadDataset(labelIcon.value!, { useBuffAura: isAura });
 
 		this.addOnResetCallback(() => {
-			hideElem.value?.removeEventListener('click', onClickHandler);
+			clickTarget.removeEventListener('click', onClickHandler);
 			tooltip.destroy();
 			event.dispose();
 		});
@@ -755,23 +765,28 @@ export class Timeline extends ResultComponent {
 		return labelElem;
 	}
 
-	private makeRowElem(actionId: ActionId, duration: number): JSX.Element {
-		const rowElem = (
+	// A timeline row that is never hidden (section headers: pet name, target name).
+	private makePlainRowElem(duration: number): JSX.Element {
+		return (
 			<div
 				className="rotation-timeline-row rotation-row"
 				style={{
 					width: this.timeToPx(duration),
 				}}></div>
 		);
+	}
+
+	private makeRowElem(actionId: ActionId, duration: number, scope: string): JSX.Element {
+		const rowElem = this.makePlainRowElem(duration);
 
 		const updateHidden = () => {
-			if (this.hiddenIds.find(hiddenId => hiddenId.equals(actionId))) {
+			if (this.hiddenIndex(scope, actionId) != -1) {
 				rowElem.classList.add('hide');
 			} else {
 				rowElem.classList.remove('hide');
 			}
 		};
-		const event = this.hiddenIdsChangeEmitter.on(updateHidden);
+		const event = this.liveSlot!.emitter.on(updateHidden);
 		updateHidden();
 		this.addOnResetCallback(() => event.dispose());
 		return rowElem;
@@ -779,7 +794,10 @@ export class Timeline extends ResultComponent {
 
 	private addPetRow(petName: string, duration: number) {
 		const actionId = ActionId.fromPetName(petName);
-		const rowElem = this.makeRowElem(actionId, duration);
+		// Header row: must not follow hiddenIds. fromPetName resolves to the summon
+		// spell's id, so hiding e.g. the "Dire Beast" cast row used to hide this
+		// row but not its label, shifting every row below it.
+		const rowElem = this.makePlainRowElem(duration);
 
 		const iconElem = document.createElement('div');
 		this.rotationLabels.appendChild(iconElem);
@@ -801,7 +819,7 @@ export class Timeline extends ResultComponent {
 	}
 
 	private addTargetRow(targetName: string, duration: number) {
-		const rowElem = this.makeRowElem(ActionId.fromEmpty(), duration);
+		const rowElem = this.makePlainRowElem(duration);
 		this.rotationLabels.appendChild(
 			<div>
 				<div className="rotation-label rotation-row">
@@ -813,9 +831,7 @@ export class Timeline extends ResultComponent {
 	}
 
 	private addGcdStripRow(player: UnitMetrics, duration: number) {
-		const gcdCasts = player.castLogs
-			.filter(c => c.gcd > 0 && !c.castCancelledLog)
-			.sort((a, b) => a.timestamp - b.timestamp);
+		const gcdCasts = player.castLogs.filter(c => c.gcd > 0 && !c.castCancelledLog).sort((a, b) => a.timestamp - b.timestamp);
 		if (gcdCasts.length === 0) return;
 
 		this.rotationLabels.appendChild(
@@ -942,13 +958,13 @@ export class Timeline extends ResultComponent {
 		this.rotationTimeline.appendChild(rowElem);
 	}
 
-	private addCastRow(castLogs: Array<CastLog>, aurasById: Array<Array<AuraUptimeLog>>, duration: number) {
+	private addCastRow(castLogs: Array<CastLog>, aurasById: Array<Array<AuraUptimeLog>>, duration: number, scope = '') {
 		const actionId = castLogs[0].actionId!;
 
-		this.rotationLabels.appendChild(this.makeLabelElem(actionId, false));
-		this.rotationHiddenIdsContainer.appendChild(this.makeLabelElem(actionId, true));
+		this.rotationLabels.appendChild(this.makeLabelElem(actionId, false, false, scope));
+		this.rotationHiddenIdsContainer.appendChild(this.makeLabelElem(actionId, true, false, scope));
 
-		const rowElem = this.makeRowElem(actionId, duration);
+		const rowElem = this.makeRowElem(actionId, duration, scope);
 		castLogs.forEach(castLog => {
 			if (castLog.delay > 0) {
 				const delayElem = (
@@ -966,7 +982,9 @@ export class Timeline extends ResultComponent {
 					placement: 'bottom',
 					content: (
 						<div className="timeline-tooltip">
-							<span>Auto delayed by {castLog.delayText}, was ready at {castLog.readyAtText}</span>
+							<span>
+								Auto delayed by {castLog.delayText}, was ready at {castLog.readyAtText}
+							</span>
 						</div>
 					),
 				});
@@ -1054,8 +1072,7 @@ export class Timeline extends ResultComponent {
 				<div className="timeline-tooltip">
 					<span>
 						{castLog.actionId!.name} from {castLog.timestamp.toFixed(2)}s to{' '}
-						{(castLog.castCancelledLog?.timestamp || castLog.timestamp + castLog.castTime).toFixed(2)}s
-						{timingStr}
+						{(castLog.castCancelledLog?.timestamp || castLog.timestamp + castLog.castTime).toFixed(2)}s{timingStr}
 						{travelTimeStr.length > 0 && travelTimeStr}
 					</span>
 					{totalDamage > 0 && (
@@ -1136,12 +1153,12 @@ export class Timeline extends ResultComponent {
 		this.rotationTimeline.appendChild(rowElem);
 	}
 
-	private addAuraRow(auraUptimeLogs: Array<AuraUptimeLog>, duration: number) {
+	private addAuraRow(auraUptimeLogs: Array<AuraUptimeLog>, duration: number, scope = '') {
 		const actionId = auraUptimeLogs[0].actionId!;
 
-		const rowElem = this.makeRowElem(actionId, duration);
-		this.rotationLabels.appendChild(this.makeLabelElem(actionId, false, true));
-		this.rotationHiddenIdsContainer.appendChild(this.makeLabelElem(actionId, true, true));
+		const rowElem = this.makeRowElem(actionId, duration, scope);
+		this.rotationLabels.appendChild(this.makeLabelElem(actionId, false, true, scope));
+		this.rotationHiddenIdsContainer.appendChild(this.makeLabelElem(actionId, true, true, scope));
 		this.rotationTimeline.appendChild(rowElem);
 
 		this.applyAuraUptimeLogsToRow(auraUptimeLogs, rowElem, false);
@@ -1399,10 +1416,69 @@ export class Timeline extends ResultComponent {
 	}
 
 	update() {
-		this.reset();
 		if (!this.rendered) this.dpsResourcesPlot.render();
 		this.updatePlot();
 		this.rendered = true;
+	}
+
+	// Per-render resources (tooltips, listeners) belong to the slot being
+	// rendered so a parked slot can be destroyed independently. Rows are only
+	// ever built under a live slot (see updateRotationChart).
+	addOnResetCallback(callback: () => void) {
+		this.liveSlot!.resetCallbacks.push(callback);
+	}
+
+	// A single player's slot holds the rotation subtree plus every series, so the
+	// chart choice is irrelevant to it; multi-player options depend on the chart.
+	private resultKey(includeChart = false): string {
+		const rd = this.resultData!;
+		return [rd.result.request.requestId, JSON.stringify(rd.filter), includeChart ? this.chartPicker.value : ''].join('|');
+	}
+
+	// Single-player results offer the rotation chart; multi-player ones the threat chart.
+	private setRotationOptionVisible(visible: boolean) {
+		this.rootElem.querySelector('.rotation-option')!.classList.toggle('hide', !visible);
+		this.rootElem.querySelector('.threat-option')!.classList.toggle('hide', visible);
+	}
+
+	private static newSlot(key: string): RotationSlot {
+		return { key, labels: [], timeline: [], hiddenIdsNodes: [], emitter: new TypedEvent<void>(), resetCallbacks: [], plotOptions: null };
+	}
+
+	private takeParkedSlot(key: string): RotationSlot | null {
+		if (this.parkedSlot?.key !== key) return null;
+		const slot = this.parkedSlot;
+		this.parkedSlot = null;
+		return slot;
+	}
+
+	// Parks the on-screen subtree (nodes moved, tooltips kept alive), destroying
+	// the previously parked slot.
+	private stashLiveSlot() {
+		const slot = this.liveSlot;
+		if (!slot) return;
+		slot.labels = Array.from(this.rotationLabels.childNodes);
+		slot.timeline = Array.from(this.rotationTimeline.childNodes);
+		slot.hiddenIdsNodes = Array.from(this.rotationHiddenIdsContainer.childNodes);
+		this.rotationLabels.replaceChildren();
+		this.rotationTimeline.replaceChildren();
+		this.rotationHiddenIdsContainer.replaceChildren();
+		this.liveSlot = null;
+		if (this.parkedSlot) this.destroySlot(this.parkedSlot);
+		this.parkedSlot = slot;
+	}
+
+	private attachSlot(slot: RotationSlot) {
+		this.rotationLabels.replaceChildren(...slot.labels);
+		this.rotationTimeline.replaceChildren(...slot.timeline);
+		this.rotationHiddenIdsContainer.replaceChildren(...slot.hiddenIdsNodes);
+		this.liveSlot = slot;
+		// hiddenIds is global across results: re-apply it to the restored rows.
+		slot.emitter.emit(TypedEvent.nextEventID());
+	}
+
+	private destroySlot(slot: RotationSlot) {
+		slot.resetCallbacks.forEach(callback => callback());
 	}
 
 	render() {
@@ -1411,8 +1487,10 @@ export class Timeline extends ResultComponent {
 	}
 
 	reset() {
-		const previousResultRequestId = this.prevResultData?.result.request.requestId;
-		if (previousResultRequestId && !this.cacheHandler.get(previousResultRequestId)) return;
+		if (this.liveSlot) this.destroySlot(this.liveSlot);
+		if (this.parkedSlot) this.destroySlot(this.parkedSlot);
+		this.liveSlot = null;
+		this.parkedSlot = null;
 		super.reset();
 	}
 }

--- a/ui/core/components/individual_sim_ui/apl/apl_group_editor.tsx
+++ b/ui/core/components/individual_sim_ui/apl/apl_group_editor.tsx
@@ -43,7 +43,7 @@ export class APLGroupEditor extends Input<Player<any>, APLGroup> {
 		nameContainer.querySelector('.apl-name-rename')!.addEventListener('click', () => {
 			const group = this.getSourceValue();
 			if (!group) return;
-			new APLNameModal(this.rootElem.closest('.individual-sim-ui') as HTMLElement ?? document.body, {
+			new APLNameModal((this.rootElem.closest('.individual-sim-ui') as HTMLElement) ?? document.body, {
 				title: i18n.t('rotation_tab.apl.nameModal.rename', { itemName: i18n.t('rotation_tab.apl.actionGroups.name') }),
 				inputLabel: i18n.t('rotation_tab.apl.actionGroups.attributes.name'),
 				confirmButtonLabel: i18n.t('rotation_tab.apl.nameModal.renameConfirm'),
@@ -61,46 +61,47 @@ export class APLGroupEditor extends Input<Player<any>, APLGroup> {
 		this.actionsContainer = container.appendChild(<div className="apl-group-actions-container" />) as HTMLElement;
 
 		// Create the actions picker in the dedicated container with EXACT same styling as Priority List
-		this.actionsPicker = new ListPicker<Player<any>, APLListItem>(this.actionsContainer, this.modObject, {
-			extraCssClasses: ['apl-list-item-picker'], // Use SAME class as Priority List!
-			title: i18n.t('rotation_tab.apl.actionGroups.attributes.actions'),
-			titleTooltip: i18n.t('rotation_tab.apl.actionGroups.tooltips.actions'),
-			itemLabel: i18n.t('rotation_tab.apl.priorityList.name'),
-			actions: {
-				create: {
-					useIcon: true,
-				},
-			},
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
-			getValue: () => this.getSourceValue()?.actions || [],
-			setValue: (eventID: EventID, player: Player<any>, newValue: Array<APLListItem>) => {
-				const group = this.getSourceValue();
-				if (group) {
-					group.actions = newValue;
-					player.rotationChangeEmitter.emit(eventID);
-				}
-			},
-			newItem: () =>
-				APLListItem.create({
-					action: {},
-				}),
-			copyItem: (oldItem: APLListItem) => APLListItem.clone(oldItem),
-			newItemPicker: (parent: HTMLElement, _: ListPicker<Player<any>, APLListItem>, index, config: ListItemPickerConfig<Player<any>, APLListItem>) =>
-				new APLGroupActionPicker(parent, this.modObject, { ...config, groupIndex: this.index, index }),
-			inlineMenuBar: true,
-			allowedActions: ['create', 'copy', 'delete', 'move'],
-			dragGroup: 'action-group-actions',
-			extraActions: [
-				AplHelpers.extractToVariableAction(
-					player,
-					(actionIndex) => this.getSourceValue()?.actions?.[actionIndex]?.action?.condition,
-					(actionIndex, ref) => {
-						this.getSourceValue()!.actions[actionIndex].action!.condition = ref;
+		this.actionsPicker = this.addChild(
+			new ListPicker<Player<any>, APLListItem>(this.actionsContainer, this.modObject, {
+				extraCssClasses: ['apl-list-item-picker'], // Use SAME class as Priority List!
+				title: i18n.t('rotation_tab.apl.actionGroups.attributes.actions'),
+				titleTooltip: i18n.t('rotation_tab.apl.actionGroups.tooltips.actions'),
+				itemLabel: i18n.t('rotation_tab.apl.priorityList.name'),
+				actions: {
+					create: {
+						useIcon: true,
 					},
-					this.rootElem.closest('.individual-sim-ui') as HTMLElement ?? document.body,
-				),
-			],
-		});
+				},
+				getValue: () => this.getSourceValue()?.actions || [],
+				setValue: (eventID: EventID, player: Player<any>, newValue: Array<APLListItem>) => {
+					const group = this.getSourceValue();
+					if (group) {
+						group.actions = newValue;
+						player.rotationChangeEmitter.emit(eventID);
+					}
+				},
+				newItem: () =>
+					APLListItem.create({
+						action: {},
+					}),
+				copyItem: (oldItem: APLListItem) => APLListItem.clone(oldItem),
+				newItemPicker: (parent: HTMLElement, _: ListPicker<Player<any>, APLListItem>, index, config: ListItemPickerConfig<Player<any>, APLListItem>) =>
+					new APLGroupActionPicker(parent, this.modObject, { ...config, groupIndex: this.index, index }),
+				inlineMenuBar: true,
+				allowedActions: ['create', 'copy', 'delete', 'move'],
+				dragGroup: 'action-group-actions',
+				extraActions: [
+					AplHelpers.extractToVariableAction(
+						player,
+						actionIndex => this.getSourceValue()?.actions?.[actionIndex]?.action?.condition,
+						(actionIndex, ref) => {
+							this.getSourceValue()!.actions[actionIndex].action!.condition = ref;
+						},
+						(this.rootElem.closest('.individual-sim-ui') as HTMLElement) ?? document.body,
+					),
+				],
+			}),
+		);
 
 		this.init();
 	}
@@ -171,26 +172,28 @@ class APLGroupActionPicker extends Input<Player<any>, APLListItem> {
 			return validations;
 		});
 
-		this.hidePicker = new APLHidePicker(itemHeaderElem, player, {
-			changedEvent: () => this.player.rotationChangeEmitter,
-			getValue: () => this.getItem().hide,
-			setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
-				this.getItem().hide = newValue;
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+		this.hidePicker = this.addChild(
+			new APLHidePicker(itemHeaderElem, player, {
+				getValue: () => this.getItem().hide,
+				setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
+					this.getItem().hide = newValue;
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 
-		this.actionPicker = new APLActionPicker(this.rootElem, this.modObject, {
-			changedEvent: () => this.modObject.rotationChangeEmitter,
-			getValue: () => this.getItem().action!,
-			setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
-				const item = this.getSourceValue();
-				if (item) {
-					this.getItem().action = newValue;
-					player.rotationChangeEmitter.emit(eventID);
-				}
-			},
-		});
+		this.actionPicker = this.addChild(
+			new APLActionPicker(this.rootElem, this.modObject, {
+				getValue: () => this.getItem().action!,
+				setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
+					const item = this.getSourceValue();
+					if (item) {
+						this.getItem().action = newValue;
+						player.rotationChangeEmitter.emit(eventID);
+					}
+				},
+			}),
+		);
 
 		this.init();
 	}
@@ -209,6 +212,7 @@ class APLGroupActionPicker extends Input<Player<any>, APLListItem> {
 		if (!newValue) {
 			return;
 		}
+		this.hidePicker.setInputValue(newValue.hide);
 		this.actionPicker.setInputValue(newValue.action || APLAction.create());
 		if (newValue.action?.condition) {
 			if (!newValue.action.condition?.uuid?.value || newValue.action.condition.uuid.value == '') {

--- a/ui/core/components/individual_sim_ui/apl/apl_variables_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/apl_variables_list_picker.tsx
@@ -75,7 +75,6 @@ export class APLVariablesListPicker extends Component {
 			value: undefined,
 		});
 	}
-
 }
 
 class APLValueVariablePicker extends Input<Player<any>, APLValueVariable> {
@@ -116,7 +115,7 @@ class APLValueVariablePicker extends Input<Player<any>, APLValueVariable> {
 		nameContainer.querySelector('.apl-name-rename')!.addEventListener('click', () => {
 			const sourceValue = this.getSourceValue();
 			if (!sourceValue) return;
-			new APLNameModal(this.rootElem.closest('.individual-sim-ui') as HTMLElement ?? document.body, {
+			new APLNameModal((this.rootElem.closest('.individual-sim-ui') as HTMLElement) ?? document.body, {
 				title: i18n.t('rotation_tab.apl.nameModal.rename', { itemName: i18n.t('rotation_tab.apl.variables.name') }),
 				inputLabel: i18n.t('rotation_tab.apl.variables.attributes.name'),
 				confirmButtonLabel: i18n.t('rotation_tab.apl.nameModal.renameConfirm'),
@@ -130,18 +129,19 @@ class APLValueVariablePicker extends Input<Player<any>, APLValueVariable> {
 			});
 		});
 
-		this.valuePicker = new APLValuePicker(container, player, {
-			id: randomUUID(),
-			label: i18n.t('rotation_tab.apl.variables.attributes.value'),
-			labelTooltip: i18n.t('rotation_tab.apl.variables.attributes.valueTooltip'),
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
-			getValue: () => this.getSourceValue().value,
-			setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
-				const sourceValue = this.getSourceValue();
-				sourceValue.value = newValue;
-				this.config.setValue(eventID, player, this.config.getValue(player));
-			},
-		});
+		this.valuePicker = this.addChild(
+			new APLValuePicker(container, player, {
+				id: randomUUID(),
+				label: i18n.t('rotation_tab.apl.variables.attributes.value'),
+				labelTooltip: i18n.t('rotation_tab.apl.variables.attributes.valueTooltip'),
+				getValue: () => this.getSourceValue().value,
+				setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
+					const sourceValue = this.getSourceValue();
+					sourceValue.value = newValue;
+					this.config.setValue(eventID, player, this.config.getValue(player));
+				},
+			}),
+		);
 
 		this.init();
 	}

--- a/ui/core/components/individual_sim_ui/apl/pre_pull_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/pre_pull_list_picker.tsx
@@ -61,44 +61,47 @@ class APLPrepullActionPicker extends Input<Player<any>, APLPrepullAction> {
 		const itemHeaderElem = ListPicker.getItemHeaderElem(this);
 		ListPicker.makeListItemValidations(itemHeaderElem, player, player => player.getCurrentStats().rotationStats?.prepullActions[index]?.validations || []);
 
-		this.hidePicker = new APLHidePicker(itemHeaderElem, player, {
-			changedEvent: () => this.player.rotationChangeEmitter,
-			getValue: () => this.getItem().hide,
-			setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
-				this.getItem().hide = newValue;
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+		this.hidePicker = this.addChild(
+			new APLHidePicker(itemHeaderElem, player, {
+				getValue: () => this.getItem().hide,
+				setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
+					this.getItem().hide = newValue;
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 
-		this.doAtPicker = new APLValuePicker(this.rootElem, this.player, {
-			id: randomUUID(),
-			label: i18n.t('rotation_tab.apl.prepull_actions.do_at.label'),
-			labelTooltip: i18n.t('rotation_tab.apl.prepull_actions.do_at.tooltip'),
-			extraCssClasses: ['apl-prepull-actions-doat'],
-			changedEvent: () => this.player.rotationChangeEmitter,
-			getValue: () => this.getItem().doAtValue,
-			setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
-				if (newValue) {
-					this.getItem().doAtValue = newValue;
-				} else {
-					this.getItem().doAtValue = APLValue.create({
-						value: { oneofKind: 'const', const: { val: '-1s' } },
-						uuid: { value: randomUUID() },
-					});
-				}
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-			inline: true,
-		});
+		this.doAtPicker = this.addChild(
+			new APLValuePicker(this.rootElem, this.player, {
+				id: randomUUID(),
+				label: i18n.t('rotation_tab.apl.prepull_actions.do_at.label'),
+				labelTooltip: i18n.t('rotation_tab.apl.prepull_actions.do_at.tooltip'),
+				extraCssClasses: ['apl-prepull-actions-doat'],
+				getValue: () => this.getItem().doAtValue,
+				setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
+					if (newValue) {
+						this.getItem().doAtValue = newValue;
+					} else {
+						this.getItem().doAtValue = APLValue.create({
+							value: { oneofKind: 'const', const: { val: '-1s' } },
+							uuid: { value: randomUUID() },
+						});
+					}
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+				inline: true,
+			}),
+		);
 
-		this.actionPicker = new APLActionPicker(this.rootElem, this.player, {
-			changedEvent: () => this.player.rotationChangeEmitter,
-			getValue: () => this.getItem().action!,
-			setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
-				this.getItem().action = newValue;
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+		this.actionPicker = this.addChild(
+			new APLActionPicker(this.rootElem, this.player, {
+				getValue: () => this.getItem().action!,
+				setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
+					this.getItem().action = newValue;
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 		this.init();
 	}
 

--- a/ui/core/components/individual_sim_ui/apl/priority_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/priority_list_picker.tsx
@@ -39,7 +39,7 @@ export class APLPriorityListPicker extends Component {
 			extraActions: [
 				AplHelpers.extractToVariableAction(
 					simUI.player,
-					(index) => simUI.player.aplRotation.priorityList[index]?.action?.condition,
+					index => simUI.player.aplRotation.priorityList[index]?.action?.condition,
 					(index, ref) => {
 						simUI.player.aplRotation.priorityList[index].action!.condition = ref;
 					},
@@ -80,23 +80,25 @@ class APLListItemPicker extends Input<Player<any>, APLListItem> {
 			return validations;
 		});
 
-		this.hidePicker = new APLHidePicker(itemHeaderElem, player, {
-			changedEvent: () => this.player.rotationChangeEmitter,
-			getValue: () => this.getItem().hide,
-			setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
-				this.getItem().hide = newValue;
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+		this.hidePicker = this.addChild(
+			new APLHidePicker(itemHeaderElem, player, {
+				getValue: () => this.getItem().hide,
+				setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
+					this.getItem().hide = newValue;
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 
-		this.actionPicker = new APLActionPicker(this.rootElem, this.player, {
-			changedEvent: () => this.player.rotationChangeEmitter,
-			getValue: () => this.getItem().action!,
-			setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
-				this.getItem().action = newValue;
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+		this.actionPicker = this.addChild(
+			new APLActionPicker(this.rootElem, this.player, {
+				getValue: () => this.getItem().action!,
+				setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
+					this.getItem().action = newValue;
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 		this.init();
 	}
 

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -1,3 +1,4 @@
+import i18n from '../../../i18n/config';
 import { itemSwapEnabledSpecs } from '../../individual_sim_ui.js';
 import { Player } from '../../player.js';
 import {
@@ -32,14 +33,13 @@ import {
 	APLActionTriggerICD,
 	APLActionWait,
 	APLActionWaitUntil,
-	APLValue,
 	APLActionCastWarlockAssignedCurse,
+	APLValue,
 } from '../../proto/apl.js';
 import { Spec } from '../../proto/common.js';
 import { EventID } from '../../typed_event.js';
 import { randomUUID } from '../../utils';
 import { Input, InputConfig } from '../input.js';
-import i18n from '../../../i18n/config';
 import { TextDropdownPicker } from '../pickers/dropdown_picker.jsx';
 import { ListItemPickerConfig, ListPicker } from '../pickers/list_picker.jsx';
 import * as AplHelpers from './apl_helpers.js';
@@ -67,25 +67,26 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 	constructor(parent: HTMLElement, player: Player<any>, config: APLActionPickerConfig) {
 		super(parent, 'apl-action-picker-root', player, config);
 
-		this.conditionPicker = new AplValues.APLValuePicker(this.rootElem, this.modObject, {
-			label: i18n.t('rotation_tab.apl.priority_list.if_label'),
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
-			getValue: (_player: Player<any>) => this.getSourceValue()?.condition,
-			setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
-				const srcVal = this.getSourceValue();
-				if (srcVal) {
-					srcVal.condition = newValue;
-					player.rotationChangeEmitter.emit(eventID);
-				} else {
-					this.setSourceValue(
-						eventID,
-						APLAction.create({
-							condition: newValue,
-						}),
-					);
-				}
-			},
-		});
+		this.conditionPicker = this.addChild(
+			new AplValues.APLValuePicker(this.rootElem, this.modObject, {
+				label: i18n.t('rotation_tab.apl.priority_list.if_label'),
+				getValue: (_player: Player<any>) => this.getSourceValue()?.condition,
+				setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
+					const srcVal = this.getSourceValue();
+					if (srcVal) {
+						srcVal.condition = newValue;
+						player.rotationChangeEmitter.emit(eventID);
+					} else {
+						this.setSourceValue(
+							eventID,
+							APLAction.create({
+								condition: newValue,
+							}),
+						);
+					}
+				},
+			}),
+		);
 		this.conditionPicker.rootElem.classList.add('apl-action-condition', 'apl-priority-list-only');
 
 		this.actionDiv = document.createElement('div');
@@ -98,74 +99,78 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 			actionKind => actionKindFactories[actionKind].includeIf?.(player, isPrepull) ?? true,
 		);
 
-		this.kindPicker = new TextDropdownPicker(this.actionDiv, player, {
-			id: randomUUID(),
-			defaultLabel: i18n.t('rotation_tab.apl.priority_list.item_label'),
-			values: allActionKinds.map(actionKind => {
-				const factory = actionKindFactories[actionKind];
-				return {
-					value: actionKind,
-					label: factory.label,
-					submenu: factory.submenu,
-					tooltip: factory.fullDescription ? `<p>${factory.shortDescription}</p> ${factory.fullDescription}` : factory.shortDescription,
-				};
-			}),
-			equals: (a, b) => a == b,
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
-			getValue: (_player: Player<any>) => this.getSourceValue()?.action.oneofKind,
-			setValue: (eventID: EventID, player: Player<any>, newKind: APLActionKind) => {
-				const sourceValue = this.getSourceValue();
-				const oldKind = sourceValue?.action.oneofKind;
-				if (oldKind == newKind) {
-					return;
-				}
+		this.kindPicker = this.addChild(
+			new TextDropdownPicker(this.actionDiv, player, {
+				id: randomUUID(),
+				defaultLabel: i18n.t('rotation_tab.apl.priority_list.item_label'),
+				values: allActionKinds.map(actionKind => {
+					const factory = actionKindFactories[actionKind];
+					return {
+						value: actionKind,
+						label: factory.label,
+						submenu: factory.submenu,
+						tooltip: factory.fullDescription ? `<p>${factory.shortDescription}</p> ${factory.fullDescription}` : factory.shortDescription,
+					};
+				}),
+				equals: (a, b) => a == b,
+				getValue: (_player: Player<any>) => this.getSourceValue()?.action.oneofKind,
+				setValue: (eventID: EventID, player: Player<any>, newKind: APLActionKind) => {
+					const sourceValue = this.getSourceValue();
+					const oldKind = sourceValue?.action.oneofKind;
+					if (oldKind == newKind) {
+						return;
+					}
 
-				if (newKind) {
-					const factory = actionKindFactories[newKind];
-					let newSourceValue = this.makeAPLAction(newKind, factory.newValue());
-					if (sourceValue) {
-						// Some pre-fill logic when swapping kinds.
-						if (oldKind && this.actionPicker) {
-							if (newKind == 'sequence') {
-								if (sourceValue.action.oneofKind == 'strictSequence') {
-									(newSourceValue.action as APLActionImplStruct<'sequence'>).sequence.actions = sourceValue.action.strictSequence.actions;
-								} else {
-									(newSourceValue.action as APLActionImplStruct<'sequence'>).sequence.actions = [
-										this.makeAPLAction(oldKind, this.actionPicker.getInputValue()),
-									];
+					if (newKind) {
+						const factory = actionKindFactories[newKind];
+						let newSourceValue = this.makeAPLAction(newKind, factory.newValue());
+						if (sourceValue) {
+							// Some pre-fill logic when swapping kinds.
+							if (oldKind && this.actionPicker) {
+								if (newKind == 'sequence') {
+									if (sourceValue.action.oneofKind == 'strictSequence') {
+										(newSourceValue.action as APLActionImplStruct<'sequence'>).sequence.actions = sourceValue.action.strictSequence.actions;
+									} else {
+										(newSourceValue.action as APLActionImplStruct<'sequence'>).sequence.actions = [
+											this.makeAPLAction(oldKind, this.actionPicker.getInputValue()),
+										];
+									}
+								} else if (newKind == 'strictSequence') {
+									if (sourceValue.action.oneofKind == 'sequence') {
+										(newSourceValue.action as APLActionImplStruct<'strictSequence'>).strictSequence.actions =
+											sourceValue.action.sequence.actions;
+									} else {
+										(newSourceValue.action as APLActionImplStruct<'strictSequence'>).strictSequence.actions = [
+											this.makeAPLAction(oldKind, this.actionPicker.getInputValue()),
+										];
+									}
+								} else if (
+									sourceValue.action.oneofKind == 'sequence' &&
+									sourceValue.action.sequence.actions?.[0]?.action.oneofKind == newKind
+								) {
+									newSourceValue = sourceValue.action.sequence.actions[0];
+								} else if (
+									sourceValue.action.oneofKind == 'strictSequence' &&
+									sourceValue.action.strictSequence.actions?.[0]?.action.oneofKind == newKind
+								) {
+									newSourceValue = sourceValue.action.strictSequence.actions[0];
 								}
-							} else if (newKind == 'strictSequence') {
-								if (sourceValue.action.oneofKind == 'sequence') {
-									(newSourceValue.action as APLActionImplStruct<'strictSequence'>).strictSequence.actions =
-										sourceValue.action.sequence.actions;
-								} else {
-									(newSourceValue.action as APLActionImplStruct<'strictSequence'>).strictSequence.actions = [
-										this.makeAPLAction(oldKind, this.actionPicker.getInputValue()),
-									];
-								}
-							} else if (sourceValue.action.oneofKind == 'sequence' && sourceValue.action.sequence.actions?.[0]?.action.oneofKind == newKind) {
-								newSourceValue = sourceValue.action.sequence.actions[0];
-							} else if (
-								sourceValue.action.oneofKind == 'strictSequence' &&
-								sourceValue.action.strictSequence.actions?.[0]?.action.oneofKind == newKind
-							) {
-								newSourceValue = sourceValue.action.strictSequence.actions[0];
 							}
 						}
-					}
-					if (sourceValue) {
-						sourceValue.action = newSourceValue.action;
+						if (sourceValue) {
+							sourceValue.action = newSourceValue.action;
+						} else {
+							this.setSourceValue(eventID, newSourceValue);
+						}
 					} else {
-						this.setSourceValue(eventID, newSourceValue);
+						sourceValue.action = {
+							oneofKind: newKind,
+						};
 					}
-				} else {
-					sourceValue.action = {
-						oneofKind: newKind,
-					};
-				}
-				player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+					player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 
 		this.currentKind = undefined;
 		this.actionPicker = null;
@@ -229,9 +234,10 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 			return;
 		}
 		this.currentKind = newActionKind;
+		this.kindPicker.setInputValue(newActionKind);
 
 		if (this.actionPicker) {
-			this.actionPicker.rootElem.remove();
+			this.removeChild(this.actionPicker);
 			this.actionPicker = null;
 		}
 
@@ -239,11 +245,8 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 			return;
 		}
 
-		this.kindPicker.setInputValue(newActionKind);
-
 		const factory = actionKindFactories[newActionKind];
 		this.actionPicker = factory.factory(this.actionDiv, this.modObject, {
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
 			getValue: () => (this.getSourceValue()?.action as any)?.[newActionKind] || factory.newValue(),
 			setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
 				const sourceValue = this.getSourceValue();
@@ -253,6 +256,7 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 				player.rotationChangeEmitter.emit(eventID);
 			},
 		});
+		this.addChild(this.actionPicker);
 		this.actionPicker.rootElem.classList.add('apl-action-' + newActionKind);
 	}
 }
@@ -351,17 +355,18 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		submenu: ['casting'],
 		shortDescription: i18n.t('rotation_tab.apl.actions.multi_dot.tooltip'),
 		includeIf: (player: Player<any>, isPrepull: boolean) => !isPrepull,
-		newValue: () => APLActionMultidot.create({
-			maxDots: 3,
-			maxOverlap: {
-				value: {
-					oneofKind: 'const',
-					const: {
-						val: '0ms',
+		newValue: () =>
+			APLActionMultidot.create({
+				maxDots: 3,
+				maxOverlap: {
+					value: {
+						oneofKind: 'const',
+						const: {
+							val: '0ms',
+						},
 					},
 				},
-			},
-		}),
+			}),
 		fields: [
 			AplHelpers.actionIdFieldConfig('spellId', 'castable_dot_spells', ''),
 			AplHelpers.numberFieldConfig('maxDots', false, {
@@ -379,17 +384,18 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		submenu: ['casting'],
 		shortDescription: i18n.t('rotation_tab.apl.actions.strict_multi_dot.tooltip'),
 		includeIf: (player: Player<any>, isPrepull: boolean) => !isPrepull,
-		newValue: () => APLActionStrictMultidot.create({
-			maxDots: 3,
-			maxOverlap: {
-				value: {
-					oneofKind: 'const',
-					const: {
-						val: '0ms',
+		newValue: () =>
+			APLActionStrictMultidot.create({
+				maxDots: 3,
+				maxOverlap: {
+					value: {
+						oneofKind: 'const',
+						const: {
+							val: '0ms',
+						},
 					},
 				},
-			},
-		}),
+			}),
 		fields: [
 			AplHelpers.actionIdFieldConfig('spellId', 'castable_dot_spells', ''),
 			AplHelpers.numberFieldConfig('maxDots', false, {
@@ -407,17 +413,18 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		submenu: ['casting'],
 		shortDescription: i18n.t('rotation_tab.apl.actions.multi_shield.tooltip'),
 		includeIf: (player: Player<any>, isPrepull: boolean) => !isPrepull && player.getSpec().isHealingSpec,
-		newValue: () => APLActionMultishield.create({
-			maxShields: 3,
-			maxOverlap: {
-				value: {
-					oneofKind: 'const',
-					const: {
-						val: '0ms',
+		newValue: () =>
+			APLActionMultishield.create({
+				maxShields: 3,
+				maxOverlap: {
+					value: {
+						oneofKind: 'const',
+						const: {
+							val: '0ms',
+						},
 					},
 				},
-			},
-		}),
+			}),
 		fields: [
 			AplHelpers.actionIdFieldConfig('spellId', 'shield_spells', ''),
 			AplHelpers.numberFieldConfig('maxShields', false, {
@@ -435,14 +442,15 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		submenu: ['casting'],
 		shortDescription: i18n.t('rotation_tab.apl.actions.channel.tooltip'),
 		// fullDescription: i18n.t('rotation_tab.apl.actions.channel.full'),
-		newValue: () => APLActionChannelSpell.create({
-			interruptIf: {
-				value: {
-					oneofKind: 'gcdIsReady',
-					gcdIsReady: {},
+		newValue: () =>
+			APLActionChannelSpell.create({
+				interruptIf: {
+					value: {
+						oneofKind: 'gcdIsReady',
+						gcdIsReady: {},
+					},
 				},
-			},
-		}),
+			}),
 		fields: [
 			AplHelpers.actionIdFieldConfig('spellId', 'channel_spells', ''),
 			AplHelpers.unitFieldConfig('target', 'targets'),
@@ -460,11 +468,12 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		submenu: ['casting'],
 		shortDescription: i18n.t('rotation_tab.apl.actions.cast_all_stat_buff_cooldowns.tooltip'),
 		// fullDescription: i18n.t('rotation_tab.apl.actions.cast_all_stat_buff_cooldowns.full'),
-		newValue: () => APLActionCastAllStatBuffCooldowns.create({
-			statType1: -1,
-			statType2: -1,
-			statType3: -1,
-		}),
+		newValue: () =>
+			APLActionCastAllStatBuffCooldowns.create({
+				statType1: -1,
+				statType2: -1,
+				statType3: -1,
+			}),
 		fields: [AplHelpers.statTypeFieldConfig('statType1'), AplHelpers.statTypeFieldConfig('statType2'), AplHelpers.statTypeFieldConfig('statType3')],
 	}),
 	['autocastOtherCooldowns']: inputBuilder({
@@ -481,16 +490,17 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		submenu: ['timing'],
 		shortDescription: i18n.t('rotation_tab.apl.actions.wait.tooltip'),
 		includeIf: (player: Player<any>, isPrepull: boolean) => !isPrepull,
-		newValue: () => APLActionWait.create({
-			duration: {
-				value: {
-					oneofKind: 'const',
-					const: {
-						val: '1000ms',
+		newValue: () =>
+			APLActionWait.create({
+				duration: {
+					value: {
+						oneofKind: 'const',
+						const: {
+							val: '1000ms',
+						},
 					},
 				},
-			},
-		}),
+			}),
 		fields: [AplValues.valueFieldConfig('duration')],
 	}),
 	['waitUntil']: inputBuilder({
@@ -506,12 +516,13 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		submenu: ['timing'],
 		shortDescription: i18n.t('rotation_tab.apl.actions.scheduled_action.tooltip'),
 		includeIf: (player: Player<any>, isPrepull: boolean) => !isPrepull,
-		newValue: () => APLActionSchedule.create({
-			schedule: '0s, 60s',
-			innerAction: {
-				action: { oneofKind: 'castSpell', castSpell: {} },
-			},
-		}),
+		newValue: () =>
+			APLActionSchedule.create({
+				schedule: '0s, 60s',
+				innerAction: {
+					action: { oneofKind: 'castSpell', castSpell: {} },
+				},
+			}),
 		fields: [
 			AplHelpers.stringFieldConfig('schedule', {
 				label: i18n.t('rotation_tab.apl.actions.scheduled_action.do_at.label'),
@@ -567,9 +578,10 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		submenu: ['misc'],
 		shortDescription: i18n.t('rotation_tab.apl.actions.activate_aura_with_stacks.tooltip'),
 		includeIf: (_, isPrepull: boolean) => isPrepull,
-		newValue: () => APLActionActivateAuraWithStacks.create({
-			numStacks: 1,
-		}),
+		newValue: () =>
+			APLActionActivateAuraWithStacks.create({
+				numStacks: 1,
+			}),
 		fields: [
 			AplHelpers.actionIdFieldConfig('auraId', 'stackable_auras'),
 			AplHelpers.numberFieldConfig('numStacks', false, {
@@ -583,12 +595,13 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		submenu: ['misc'],
 		shortDescription: i18n.t('rotation_tab.apl.actions.activate_all_stat_buff_proc_auras.tooltip'),
 		includeIf: (_, isPrepull: boolean) => isPrepull,
-		newValue: () => APLActionActivateAllStatBuffProcAuras.create({
-			swapSet: ItemSwapSet.Main,
-			statType1: -1,
-			statType2: -1,
-			statType3: -1,
-		}),
+		newValue: () =>
+			APLActionActivateAllStatBuffProcAuras.create({
+				swapSet: ItemSwapSet.Main,
+				statType1: -1,
+				statType2: -1,
+				statType3: -1,
+			}),
 		fields: [
 			itemSwapSetFieldConfig('swapSet'),
 			AplHelpers.statTypeFieldConfig('statType1'),
@@ -660,10 +673,11 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 			<p>Example: If you have a group named "careful_aim" with actions [serpent_sting, chimera_shot, steady_shot],
 			referencing this group will execute those three actions in sequence.</p>
 		`,
-		newValue: () => APLActionGroupReference.create({
-			groupName: '',
-			variables: [],
-		}),
+		newValue: () =>
+			APLActionGroupReference.create({
+				groupName: '',
+				variables: [],
+			}),
 		fields: [
 			AplHelpers.groupNameFieldConfig('groupName', {
 				labelTooltip: 'Name of the group to reference (must match a group defined in the Groups section)',
@@ -683,9 +697,13 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		newValue: function (): APLActionBearOptimalRotationAction {
 			throw new Error('Function not implemented.');
 		},
-		factory: function (parent: HTMLElement, player: Player<any>, config: InputConfig<Player<any>, APLActionBearOptimalRotationAction, APLActionBearOptimalRotationAction>): Input<Player<any>, APLActionBearOptimalRotationAction, APLActionBearOptimalRotationAction> {
+		factory: function (
+			parent: HTMLElement,
+			player: Player<any>,
+			config: InputConfig<Player<any>, APLActionBearOptimalRotationAction, APLActionBearOptimalRotationAction>,
+		): Input<Player<any>, APLActionBearOptimalRotationAction, APLActionBearOptimalRotationAction> {
 			throw new Error('Function not implemented.');
-		}
+		},
 	},
 	catOptimalRotationAction: {
 		label: '',
@@ -696,9 +714,13 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		newValue: function (): APLActionCatOptimalRotationAction {
 			throw new Error('Function not implemented.');
 		},
-		factory: function (parent: HTMLElement, player: Player<any>, config: InputConfig<Player<any>, APLActionCatOptimalRotationAction, APLActionCatOptimalRotationAction>): Input<Player<any>, APLActionCatOptimalRotationAction, APLActionCatOptimalRotationAction> {
+		factory: function (
+			parent: HTMLElement,
+			player: Player<any>,
+			config: InputConfig<Player<any>, APLActionCatOptimalRotationAction, APLActionCatOptimalRotationAction>,
+		): Input<Player<any>, APLActionCatOptimalRotationAction, APLActionCatOptimalRotationAction> {
 			throw new Error('Function not implemented.');
-		}
+		},
 	},
 	guardianHotwDpsRotation: {
 		label: '',
@@ -709,9 +731,13 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		newValue: function (): APLActionGuardianHotwDpsRotation {
 			throw new Error('Function not implemented.');
 		},
-		factory: function (parent: HTMLElement, player: Player<any>, config: InputConfig<Player<any>, APLActionGuardianHotwDpsRotation, APLActionGuardianHotwDpsRotation>): Input<Player<any>, APLActionGuardianHotwDpsRotation, APLActionGuardianHotwDpsRotation> {
+		factory: function (
+			parent: HTMLElement,
+			player: Player<any>,
+			config: InputConfig<Player<any>, APLActionGuardianHotwDpsRotation, APLActionGuardianHotwDpsRotation>,
+		): Input<Player<any>, APLActionGuardianHotwDpsRotation, APLActionGuardianHotwDpsRotation> {
 			throw new Error('Function not implemented.');
-		}
+		},
 	},
 	castWarlockAssignedCurse: inputBuilder({
 		label: i18n.t('rotation_tab.apl.actions.warlock_cast_assigned_curse.label'),

--- a/ui/core/components/individual_sim_ui/apl_helpers.tsx
+++ b/ui/core/components/individual_sim_ui/apl_helpers.tsx
@@ -1,7 +1,8 @@
 import { ref } from 'tsx-vanilla';
 
-import { CacheHandler } from '../../cache_handler';
 import i18n from '../../../i18n/config';
+import { translateStat } from '../../../i18n/localization.js';
+import { CacheHandler } from '../../cache_handler';
 import { AuraStats, Player, SpellStats, UnitMetadata } from '../../player.js';
 import {
 	APLActionGuardianHotwDpsRotation_Strategy as HotwStrategy,
@@ -16,7 +17,6 @@ import { ActionID, OtherAction, Stat, UnitReference, UnitReference_Type as UnitT
 import { ActionId, defaultTargetIcon, getPetIconFromName } from '../../proto_utils/action_id.js';
 import { renameAPLReference } from '../../proto_utils/apl_utils.js';
 import { getStatName } from '../../proto_utils/names.js';
-import { translateStat } from '../../../i18n/localization.js';
 import { EventID, TypedEvent } from '../../typed_event.js';
 import { bucket, getEnumValues, randomUUID } from '../../utils.js';
 import { Input, InputConfig } from '../input.jsx';
@@ -365,8 +365,10 @@ const createSpellSubmenu = (actionId: ActionId, spells: AuraStats[] | SpellStats
 
 export type DEFAULT_UNIT_REF = 'self' | 'currentTarget';
 
-export interface APLActionIDPickerConfig<ModObject>
-	extends Omit<DropdownPickerConfig<ModObject, ActionID, ActionId>, 'defaultLabel' | 'equals' | 'setOptionContent' | 'values' | 'getValue' | 'setValue'> {
+export interface APLActionIDPickerConfig<ModObject> extends Omit<
+	DropdownPickerConfig<ModObject, ActionID, ActionId>,
+	'defaultLabel' | 'equals' | 'setOptionContent' | 'values' | 'getValue' | 'setValue'
+> {
 	actionIdSet: ACTION_ID_SET;
 	getUnitRef: (player: Player<any>) => UnitReference;
 	defaultUnitRef: DEFAULT_UNIT_REF;
@@ -433,17 +435,25 @@ export class APLActionIDPicker extends DropdownPicker<Player<any>, ActionID, Act
 		const defaultRef =
 			config.defaultUnitRef == 'self' ? UnitReference.create({ type: UnitType.Self }) : UnitReference.create({ type: UnitType.CurrentTarget });
 		const getActionIDs = actionIdSet.getActionIDs;
-		const updateValues = async () => {
+		let updateSeq = 0;
+		let lastMetadata: UnitMetadata | undefined;
+		const updateValues = async (force: boolean) => {
+			const seq = ++updateSeq;
 			const unitRef = getUnitRef(player);
 			const metadata = player.sim.getUnitMetadata(unitRef, player, defaultRef);
-			if (metadata) {
-				const values = await getActionIDs(metadata);
-				this.setOptions(values);
-			}
+			if (!metadata) return;
+			// The option list depends only on which metadata instance backs the
+			// unit; a rotation edit that leaves the unit alone has nothing to do.
+			if (!force && metadata === lastMetadata) return;
+			lastMetadata = metadata;
+			const values = await getActionIDs(metadata);
+			// A newer update (or disposal) happened while awaiting: drop this one.
+			if (seq !== updateSeq || this.isDisposed) return;
+			this.setOptions(values);
 		};
-		updateValues();
-		const unitMetaEvent = player.sim.unitMetadataEmitter.on(updateValues);
-		const rotationChangeEvent = player.rotationChangeEmitter.on(updateValues);
+		updateValues(true);
+		const unitMetaEvent = player.sim.unitMetadataEmitter.on(() => updateValues(true));
+		const rotationChangeEvent = player.rotationChangeEmitter.on(() => updateValues(false));
 		this.addOnDisposeCallback(() => {
 			unitMetaEvent.dispose();
 			rotationChangeEvent.dispose();
@@ -680,27 +690,28 @@ export class APLPickerBuilder<T> extends Input<Player<any>, T> {
 		fieldConfig: APLPickerBuilderFieldConfig<T, F>,
 	): APLPickerBuilderField<T, F> {
 		const field: F = fieldConfig.field;
-		const picker = fieldConfig.factory(
-			builder.rootElem,
-			builder.modObject,
-			{
-				label: fieldConfig.label,
-				labelTooltip: fieldConfig.labelTooltip,
-				id: randomUUID(),
-				changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
-				getValue: () => {
-					const source = builder.getSourceValue();
-					if (!source[field]) {
-						source[field] = fieldConfig.newValue();
-					}
-					return source[field];
+		const picker = builder.addChild(
+			fieldConfig.factory(
+				builder.rootElem,
+				builder.modObject,
+				{
+					label: fieldConfig.label,
+					labelTooltip: fieldConfig.labelTooltip,
+					id: randomUUID(),
+					getValue: () => {
+						const source = builder.getSourceValue();
+						if (!source[field]) {
+							source[field] = fieldConfig.newValue();
+						}
+						return source[field];
+					},
+					setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
+						builder.getSourceValue()[field] = newValue;
+						player.rotationChangeEmitter.emit(eventID);
+					},
 				},
-				setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
-					builder.getSourceValue()[field] = newValue;
-					player.rotationChangeEmitter.emit(eventID);
-				},
-			},
-			() => builder.getSourceValue(),
+				() => builder.getSourceValue(),
+			),
 		);
 
 		if (field === 'vals' || field === 'actions') {
@@ -830,7 +841,6 @@ export function variableNameFieldConfig(field: string, options?: Partial<APLPick
 				defaultLabel: i18n.t('rotation_tab.apl.helpers.select_variable'),
 				equals: (a, b) => a === b,
 				values: [],
-				changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
 			});
 
 			const updateValues = () => {
@@ -853,7 +863,8 @@ export function variableNameFieldConfig(field: string, options?: Partial<APLPick
 
 			// Update values initially and when rotation changes
 			updateValues();
-			player.rotationChangeEmitter.on(updateValues);
+			const rotationEvent = player.rotationChangeEmitter.on(updateValues);
+			picker.addOnDisposeCallback(() => rotationEvent.dispose());
 
 			return picker;
 		},
@@ -950,7 +961,7 @@ class APLPlaceholderNamePicker extends Input<Player<any>, string> {
 	private openNameModal(player: Player<any>, getParentValue: () => any, isNew = false) {
 		const currentName = this.getSourceValue();
 		const group = this.findContainingGroup(player, getParentValue());
-		new APLNameModal(this.rootElem.closest('.individual-sim-ui') as HTMLElement ?? document.body, {
+		new APLNameModal((this.rootElem.closest('.individual-sim-ui') as HTMLElement) ?? document.body, {
 			title: currentName
 				? i18n.t('rotation_tab.apl.nameModal.rename', { itemName: i18n.t('rotation_tab.apl.variablePlaceholder.name') })
 				: i18n.t('rotation_tab.apl.floatingActionBar.new', { itemName: i18n.t('rotation_tab.apl.variablePlaceholder.name') }),
@@ -1023,7 +1034,6 @@ export function groupNameFieldConfig(field: string, options?: Partial<APLPickerB
 				defaultLabel: i18n.t('rotation_tab.apl.helpers.select_group'),
 				equals: (a, b) => a === b,
 				values: [],
-				changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
 			});
 
 			const updateValues = () => {
@@ -1046,7 +1056,8 @@ export function groupNameFieldConfig(field: string, options?: Partial<APLPickerB
 
 			// Update values initially and when rotation changes
 			updateValues();
-			player.rotationChangeEmitter.on(updateValues);
+			const rotationEvent = player.rotationChangeEmitter.on(updateValues);
+			picker.addOnDisposeCallback(() => rotationEvent.dispose());
 
 			return picker;
 		},
@@ -1062,25 +1073,37 @@ export function groupReferenceVariablesFieldConfig(
 	return {
 		field: field,
 		newValue: () => [],
-		factory: (parent, player, config, getParentValue) => {
-			// Create a simple container
-			const container = document.createElement('div');
-			container.classList.add('group-reference-variables-container');
-			parent.appendChild(container);
+		factory: (parent, player, config, getParentValue) => new APLGroupVariablesPicker(parent, player, config, getParentValue, groupNameField),
+		...(options || {}),
+	};
+}
 
-			// Create a ListPicker for the variables
-			const listPicker = new ListPicker(container, player, {
+// Auto-populated list of the variables a group reference passes to its group.
+class APLGroupVariablesPicker extends Input<Player<any>, any[]> {
+	private readonly listPicker: ListPicker<Player<any>, any>;
+	private readonly getParentValue: () => any;
+	private readonly groupNameField: string;
+
+	constructor(parent: HTMLElement, player: Player<any>, config: any, getParentValue: () => any, groupNameField: string) {
+		// The inner ListPicker renders the title; don't let Input render a second label.
+		const { label: _label, labelTooltip: _labelTooltip, ...inputConfig } = config;
+		super(parent, 'group-reference-variables-container', player, inputConfig);
+		this.getParentValue = getParentValue;
+		this.groupNameField = groupNameField;
+
+		// Reconcile once up front so the ListPicker's init() builds the final item set.
+		this.reconcile();
+
+		this.listPicker = this.addChild(
+			new ListPicker(this.rootElem, player, {
 				title: 'Group Variables',
 				titleTooltip: "Variables to pass to the group. These will override the group's internal variables.",
 				itemLabel: 'Variable',
-				changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
-				getValue: () => {
-					const parentValue = getParentValue();
-					return parentValue?.variables || [];
-				},
+				// Copy: ListPicker splices its input in place before calling setValue.
+				getValue: () => this.getInputValue(),
 				setValue: (eventID: EventID, player: Player<any>, newValue: any[]) => {
-					const parentValue = getParentValue();
-					parentValue.variables = newValue;
+					const parentValue = this.getParentValue();
+					if (parentValue) parentValue.variables = newValue;
 					config.setValue(eventID, player, newValue);
 				},
 				newItem: () => {
@@ -1092,115 +1115,95 @@ export function groupReferenceVariablesFieldConfig(
 				}),
 				newItemPicker: (
 					parent: HTMLElement,
-					listPicker: ListPicker<Player<any>, any>,
+					_listPicker: ListPicker<Player<any>, any>,
 					index: number,
 					itemConfig: ListItemPickerConfig<Player<any>, any>,
 				) => {
-					const currentVariables = getParentValue()?.variables || [];
+					const currentVariables = this.getParentValue()?.variables || [];
 					const variableName = currentVariables[index]?.__uiVarName || currentVariables[index]?.name || '';
-					return new APLGroupVariablePicker(parent, player, itemConfig, getParentValue, groupNameField, variableName);
+					return new APLGroupVariablePicker(parent, player, itemConfig, this.getParentValue, this.groupNameField, variableName);
 				},
 				inlineMenuBar: false, // Hide the add/remove buttons since we auto-populate
 				allowedActions: ['delete', 'copy'], // Only allow delete and copy, not create
-			});
+			}),
+		);
+	}
 
-			// Function to update the list based on the selected group
-			const updateVariableList = () => {
-				const parentValue = getParentValue();
-				const selectedGroupName = parentValue[groupNameField];
+	// Scans the selected group for variable placeholders and syncs
+	// parentValue.variables to that set (keeping existing assignments). Returns
+	// the parent value, or null when there is nothing to show.
+	private reconcile(): any | null {
+		const parentValue = this.getParentValue();
+		const selectedGroupName = parentValue?.[this.groupNameField];
+		if (!selectedGroupName) {
+			this.rootElem.classList.add('d-none');
+			return null;
+		}
+		const groups = this.modObject.aplRotation?.groups || [];
+		const selectedGroup = groups.find((group: any) => group.name === selectedGroupName);
+		if (!selectedGroup) {
+			this.rootElem.classList.add('d-none');
+			return null;
+		}
 
-				if (!selectedGroupName) {
-					listPicker.setInputValue([]);
-					container.classList.add('d-none');
-					return;
-				}
+		const placeholderVariables = new Set<string>();
+		const scanForPlaceholders = (obj: any) => {
+			if (!obj || typeof obj !== 'object') return;
+			if (obj?.value?.oneofKind === 'variablePlaceholder') {
+				const name = obj.value.variablePlaceholder?.name;
+				if (name) placeholderVariables.add(name);
+			}
+			if (Array.isArray(obj)) {
+				obj.forEach(child => scanForPlaceholders(child));
+			} else {
+				Object.values(obj).forEach(child => scanForPlaceholders(child));
+			}
+		};
+		selectedGroup.actions?.forEach((actionItem: any) => scanForPlaceholders(actionItem));
 
-				// Find the selected group
-				const groups = player.aplRotation?.groups || [];
-				const selectedGroup = groups.find((group: any) => group.name === selectedGroupName);
+		if (placeholderVariables.size === 0) {
+			this.rootElem.classList.add('d-none');
+			return null;
+		}
+		this.rootElem.classList.remove('d-none');
 
-				if (!selectedGroup) {
-					listPicker.setInputValue([]);
-					container.classList.add('d-none');
-					return;
-				}
-
-				// Prepare a set and recursive scanner for VariablePlaceholder values.
-				const placeholderVariables = new Set<string>();
-				const scanForPlaceholders = (obj: any) => {
-					if (!obj || typeof obj !== 'object') return;
-					// Detect a variable placeholder APLValue.
-					if (obj?.value?.oneofKind === 'variablePlaceholder') {
-						const name = obj.value.variablePlaceholder?.name;
-						if (name) placeholderVariables.add(name);
-					}
-					// Recurse through arrays and object properties.
-					if (Array.isArray(obj)) {
-						obj.forEach(child => scanForPlaceholders(child));
-					} else {
-						Object.values(obj).forEach(child => scanForPlaceholders(child));
-					}
+		const existing: any[] = parentValue.variables || [];
+		const reconciled = Array.from(placeholderVariables).map(varName => {
+			let variableItem = existing.find((v: any) => v.name === varName);
+			if (!variableItem) {
+				variableItem = {
+					name: varName,
+					value: {
+						uuid: { value: randomUUID() },
+						value: {
+							oneofKind: 'variableRef',
+							variableRef: { name: '' },
+						},
+					},
 				};
+			}
+			variableItem.__uiVarName = varName;
+			return variableItem;
+		});
+		parentValue.variables = reconciled;
+		return parentValue;
+	}
 
-				// Perform a full recursive scan on every action in the group.
-				selectedGroup.actions?.forEach((actionItem: any) => {
-					scanForPlaceholders(actionItem);
-				});
+	getInputElem(): HTMLElement | null {
+		return this.rootElem;
+	}
 
-				// Hide the container if no placeholder variables found
-				if (placeholderVariables.size === 0) {
-					container.classList.add('d-none');
-					listPicker.setInputValue([]);
-					return;
-				}
+	getInputValue(): any[] {
+		return (this.getParentValue()?.variables || []).slice();
+	}
 
-				// Show the container and populate variables
-				container.classList.remove('d-none');
-
-				parentValue.variables = Array.from(placeholderVariables).map(varName => {
-					// Find existing variable or create new one
-					let variableItem = parentValue?.variables.find((v: any) => v.name === varName);
-					if (!variableItem) {
-						variableItem = {
-							name: varName,
-							value: {
-								uuid: { value: randomUUID() },
-								value: {
-									oneofKind: 'variableRef',
-									variableRef: { name: '' },
-								},
-							},
-						};
-					}
-					// Attach UI variable name for label
-					variableItem.__uiVarName = varName;
-					return variableItem;
-				});
-
-				// Clear first to force picker recreation — labels are set in
-				// the constructor and won't update on reuse.
-				listPicker.setInputValue([]);
-				listPicker.setInputValue(parentValue.variables);
-			};
-
-			// Listen for group name changes and rotation changes
-			player.rotationChangeEmitter.on(updateVariableList);
-			updateVariableList();
-
-			return {
-				rootElem: container,
-				getInputValue: () => {
-					const parentValue = getParentValue();
-					return parentValue?.variables || [];
-				},
-				setInputValue: (newValue: any[]) => {
-					const parentValue = getParentValue();
-					parentValue.variables = newValue;
-				},
-			} as any;
-		},
-		...(options || {}),
-	};
+	setInputValue(newValue: any[]) {
+		const parentValue = this.getParentValue();
+		if (parentValue) parentValue.variables = newValue;
+		this.reconcile();
+		// Cascade to the nested list (its items no longer self-subscribe).
+		this.listPicker.setInputValue(this.getInputValue());
+	}
 }
 
 // Simple picker for individual group variables
@@ -1208,7 +1211,8 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 	private readonly valuePicker: TextDropdownPicker<Player<any>, string>;
 	private readonly getParentValue: () => any;
 	private readonly groupNameField: string;
-	private readonly variableName: string;
+	private readonly nameLabel: HTMLElement;
+	private variableName: string;
 
 	constructor(
 		parent: HTMLElement,
@@ -1223,42 +1227,42 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 		this.groupNameField = groupNameField;
 		this.variableName = variableName;
 
-		// Create label for the variable name
-		const label = document.createElement('label');
-		label.textContent = `${this.variableName}:`;
-		label.classList.add('group-variable-label', 'fw-bold', 'd-block');
-		this.rootElem.appendChild(label);
+		// Label for the variable name (kept current by setInputValue when the row is reused).
+		this.nameLabel = document.createElement('label');
+		this.nameLabel.classList.add('group-variable-label', 'fw-bold', 'd-block');
+		this.rootElem.appendChild(this.nameLabel);
 
 		// Variable value picker
-		this.valuePicker = new TextDropdownPicker(this.rootElem, this.modObject, {
-			id: randomUUID(),
-			label: '',
-			labelTooltip: i18n.t('rotation_tab.apl.helpers.field_configs.variable_assignment_tooltip', { variableName: this.variableName }),
-			defaultLabel: i18n.t('rotation_tab.apl.helpers.select_variable'),
-			equals: (a, b) => a === b,
-			values: [],
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
-			getValue: () => {
-				const item = this.getSourceValue();
-				if (item?.value?.value?.variableRef?.name) {
-					return item.value.value.variableRef.name;
-				}
-				return '';
-			},
-			setValue: (eventID: EventID, player: Player<any>, newValue: string) => {
-				const item = this.getSourceValue();
-				if (item && newValue) {
-					item.value = {
-						uuid: { value: randomUUID() },
-						value: {
-							oneofKind: 'variableRef',
-							variableRef: { name: newValue },
-						},
-					};
-					player.rotationChangeEmitter.emit(eventID);
-				}
-			},
-		});
+		this.valuePicker = this.addChild(
+			new TextDropdownPicker(this.rootElem, this.modObject, {
+				id: randomUUID(),
+				label: '',
+				labelTooltip: i18n.t('rotation_tab.apl.helpers.field_configs.variable_assignment_tooltip', { variableName: this.variableName }),
+				defaultLabel: i18n.t('rotation_tab.apl.helpers.select_variable'),
+				equals: (a, b) => a === b,
+				values: [],
+				getValue: () => {
+					const item = this.getSourceValue();
+					if (item?.value?.value?.variableRef?.name) {
+						return item.value.value.variableRef.name;
+					}
+					return '';
+				},
+				setValue: (eventID: EventID, player: Player<any>, newValue: string) => {
+					const item = this.getSourceValue();
+					if (item && newValue) {
+						item.value = {
+							uuid: { value: randomUUID() },
+							value: {
+								oneofKind: 'variableRef',
+								variableRef: { name: newValue },
+							},
+						};
+						player.rotationChangeEmitter.emit(eventID);
+					}
+				},
+			}),
+		);
 
 		// Update available variables when group changes
 		const updateAvailableVariables = () => {
@@ -1281,7 +1285,8 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 		};
 
 		// Listen for group name changes
-		this.modObject.rotationChangeEmitter.on(updateAvailableVariables);
+		const rotationEvent = this.modObject.rotationChangeEmitter.on(updateAvailableVariables);
+		this.addOnDisposeCallback(() => rotationEvent.dispose());
 		updateAvailableVariables();
 
 		this.init();
@@ -1300,7 +1305,9 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 
 	setInputValue(newValue: any) {
 		if (!newValue) return;
-		// The value picker will be updated via the change event
+		this.variableName = newValue.__uiVarName || newValue.name || this.variableName;
+		this.nameLabel.textContent = `${this.variableName}:`;
+		this.valuePicker.setInputValue(newValue.value?.value?.variableRef?.name || '');
 	}
 }
 
@@ -1324,7 +1331,6 @@ export function eclipseTypeFieldConfig(field: string): APLPickerBuilderFieldConf
 			}),
 	};
 }
-
 
 export function hotwStrategyFieldConfig(field: string): APLPickerBuilderFieldConfig<any, any> {
 	const values = [

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -159,102 +159,105 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 			);
 		}
 
-		this.kindPicker = new TextDropdownPicker(this.rootElem, player, {
-			defaultLabel: i18n.t('rotation_tab.apl.values.no_condition'),
-			id: randomUUID(),
-			values: [
-				{
-					value: undefined,
-					label: i18n.t('rotation_tab.apl.values.none'),
-				} as TextDropdownValueConfig<APLValueKind>,
-			].concat(
-				allValueKinds.map(kind => {
-					const factory = valueKindFactories[kind];
-					const resolveString = factory.dynamicStringResolver || ((value: string) => value);
-					return {
-						value: kind,
-						label: resolveString(factory.label, player),
-						submenu: factory.submenu,
-						tooltip: factory.fullDescription
-							? `<p>${resolveString(factory.shortDescription, player)}</p> ${resolveString(factory.fullDescription, player)}`
-							: resolveString(factory.shortDescription, player),
-					};
-				}),
-			),
-			equals: (a, b) => a == b,
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
-			getValue: (_player: Player<any>) => this.getSourceValue()?.value.oneofKind,
-			setValue: (eventID: EventID, player: Player<any>, newKind: APLValueKind) => {
-				const sourceValue = this.getSourceValue();
-				const oldKind = sourceValue?.value.oneofKind;
-				if (oldKind == newKind) {
-					return;
-				}
+		this.kindPicker = this.addChild(
+			new TextDropdownPicker(this.rootElem, player, {
+				defaultLabel: i18n.t('rotation_tab.apl.values.no_condition'),
+				id: randomUUID(),
+				values: [
+					{
+						value: undefined,
+						label: i18n.t('rotation_tab.apl.values.none'),
+					} as TextDropdownValueConfig<APLValueKind>,
+				].concat(
+					allValueKinds.map(kind => {
+						const factory = valueKindFactories[kind];
+						const resolveString = factory.dynamicStringResolver || ((value: string) => value);
+						return {
+							value: kind,
+							label: resolveString(factory.label, player),
+							submenu: factory.submenu,
+							tooltip: factory.fullDescription
+								? `<p>${resolveString(factory.shortDescription, player)}</p> ${resolveString(factory.fullDescription, player)}`
+								: resolveString(factory.shortDescription, player),
+						};
+					}),
+				),
+				equals: (a, b) => a == b,
+				getValue: (_player: Player<any>) => this.getSourceValue()?.value.oneofKind,
+				setValue: (eventID: EventID, player: Player<any>, newKind: APLValueKind) => {
+					const sourceValue = this.getSourceValue();
+					const oldKind = sourceValue?.value.oneofKind;
+					if (oldKind == newKind) {
+						return;
+					}
 
-				if (newKind) {
-					const factory = valueKindFactories[newKind];
-					let newSourceValue = this.makeAPLValue(newKind, factory.newValue());
-					if (sourceValue) {
-						// Some pre-fill logic when swapping kinds.
-						if (oldKind && this.valuePicker) {
-							if (newKind == 'not') {
-								(newSourceValue.value as APLValueImplStruct<'not'>).not.val = this.makeAPLValue(oldKind, this.valuePicker.getInputValue());
-							} else if (sourceValue.value.oneofKind == 'not' && sourceValue.value.not.val?.value.oneofKind == newKind) {
-								newSourceValue = sourceValue.value.not.val;
-							} else if (newKind == 'and') {
-								if (sourceValue.value.oneofKind == 'or') {
-									(newSourceValue.value as APLValueImplStruct<'and'>).and.vals = sourceValue.value.or.vals;
-								} else {
-									(newSourceValue.value as APLValueImplStruct<'and'>).and.vals = [
-										this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
-									];
+					if (newKind) {
+						const factory = valueKindFactories[newKind];
+						let newSourceValue = this.makeAPLValue(newKind, factory.newValue());
+						if (sourceValue) {
+							// Some pre-fill logic when swapping kinds.
+							if (oldKind && this.valuePicker) {
+								if (newKind == 'not') {
+									(newSourceValue.value as APLValueImplStruct<'not'>).not.val = this.makeAPLValue(oldKind, this.valuePicker.getInputValue());
+								} else if (sourceValue.value.oneofKind == 'not' && sourceValue.value.not.val?.value.oneofKind == newKind) {
+									newSourceValue = sourceValue.value.not.val;
+								} else if (newKind == 'and') {
+									if (sourceValue.value.oneofKind == 'or') {
+										(newSourceValue.value as APLValueImplStruct<'and'>).and.vals = sourceValue.value.or.vals;
+									} else {
+										(newSourceValue.value as APLValueImplStruct<'and'>).and.vals = [
+											this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
+										];
+									}
+								} else if (newKind == 'or') {
+									if (sourceValue.value.oneofKind == 'and') {
+										(newSourceValue.value as APLValueImplStruct<'or'>).or.vals = sourceValue.value.and.vals;
+									} else {
+										(newSourceValue.value as APLValueImplStruct<'or'>).or.vals = [
+											this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
+										];
+									}
+								} else if (newKind == 'min') {
+									if (sourceValue.value.oneofKind == 'max') {
+										(newSourceValue.value as APLValueImplStruct<'min'>).min.vals = sourceValue.value.max.vals;
+									} else {
+										(newSourceValue.value as APLValueImplStruct<'min'>).min.vals = [
+											this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
+										];
+									}
+								} else if (newKind == 'max') {
+									if (sourceValue.value.oneofKind == 'min') {
+										(newSourceValue.value as APLValueImplStruct<'max'>).max.vals = sourceValue.value.min.vals;
+									} else {
+										(newSourceValue.value as APLValueImplStruct<'max'>).max.vals = [
+											this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
+										];
+									}
+								} else if (sourceValue.value.oneofKind == 'and' && sourceValue.value.and.vals?.[0]?.value.oneofKind == newKind) {
+									newSourceValue = sourceValue.value.and.vals[0];
+								} else if (sourceValue.value.oneofKind == 'or' && sourceValue.value.or.vals?.[0]?.value.oneofKind == newKind) {
+									newSourceValue = sourceValue.value.or.vals[0];
+								} else if (sourceValue.value.oneofKind == 'min' && sourceValue.value.min.vals?.[0]?.value.oneofKind == newKind) {
+									newSourceValue = sourceValue.value.min.vals[0];
+								} else if (sourceValue.value.oneofKind == 'max' && sourceValue.value.max.vals?.[0]?.value.oneofKind == newKind) {
+									newSourceValue = sourceValue.value.max.vals[0];
+								} else if (newKind == 'cmp') {
+									(newSourceValue.value as APLValueImplStruct<'cmp'>).cmp.lhs = this.makeAPLValue(oldKind, this.valuePicker.getInputValue());
 								}
-							} else if (newKind == 'or') {
-								if (sourceValue.value.oneofKind == 'and') {
-									(newSourceValue.value as APLValueImplStruct<'or'>).or.vals = sourceValue.value.and.vals;
-								} else {
-									(newSourceValue.value as APLValueImplStruct<'or'>).or.vals = [this.makeAPLValue(oldKind, this.valuePicker.getInputValue())];
-								}
-							} else if (newKind == 'min') {
-								if (sourceValue.value.oneofKind == 'max') {
-									(newSourceValue.value as APLValueImplStruct<'min'>).min.vals = sourceValue.value.max.vals;
-								} else {
-									(newSourceValue.value as APLValueImplStruct<'min'>).min.vals = [
-										this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
-									];
-								}
-							} else if (newKind == 'max') {
-								if (sourceValue.value.oneofKind == 'min') {
-									(newSourceValue.value as APLValueImplStruct<'max'>).max.vals = sourceValue.value.min.vals;
-								} else {
-									(newSourceValue.value as APLValueImplStruct<'max'>).max.vals = [
-										this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
-									];
-								}
-							} else if (sourceValue.value.oneofKind == 'and' && sourceValue.value.and.vals?.[0]?.value.oneofKind == newKind) {
-								newSourceValue = sourceValue.value.and.vals[0];
-							} else if (sourceValue.value.oneofKind == 'or' && sourceValue.value.or.vals?.[0]?.value.oneofKind == newKind) {
-								newSourceValue = sourceValue.value.or.vals[0];
-							} else if (sourceValue.value.oneofKind == 'min' && sourceValue.value.min.vals?.[0]?.value.oneofKind == newKind) {
-								newSourceValue = sourceValue.value.min.vals[0];
-							} else if (sourceValue.value.oneofKind == 'max' && sourceValue.value.max.vals?.[0]?.value.oneofKind == newKind) {
-								newSourceValue = sourceValue.value.max.vals[0];
-							} else if (newKind == 'cmp') {
-								(newSourceValue.value as APLValueImplStruct<'cmp'>).cmp.lhs = this.makeAPLValue(oldKind, this.valuePicker.getInputValue());
 							}
 						}
-					}
-					if (sourceValue) {
-						sourceValue.value = newSourceValue.value;
+						if (sourceValue) {
+							sourceValue.value = newSourceValue.value;
+						} else {
+							this.setSourceValue(eventID, newSourceValue);
+						}
 					} else {
-						this.setSourceValue(eventID, newSourceValue);
+						this.setSourceValue(eventID, undefined);
 					}
-				} else {
-					this.setSourceValue(eventID, undefined);
-				}
-				player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+					player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 
 		this.currentKind = undefined;
 		this.valuePicker = null;
@@ -325,9 +328,10 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 			return;
 		}
 		this.currentKind = newKind;
+		this.kindPicker.setInputValue(newKind);
 
 		if (this.valuePicker) {
-			this.valuePicker.rootElem.remove();
+			this.removeChild(this.valuePicker);
 			this.valuePicker = null;
 		}
 
@@ -335,12 +339,9 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 			return;
 		}
 
-		this.kindPicker.setInputValue(newKind);
-
 		const factory = valueKindFactories[newKind];
 		this.valuePicker = factory.factory(this.rootElem, this.modObject, {
 			id: randomUUID(),
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
 			getValue: () => {
 				const sourceVal = this.getSourceValue();
 				return sourceVal ? (sourceVal.value as any)[newKind] || factory.newValue() : factory.newValue();
@@ -353,6 +354,7 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 				player.rotationChangeEmitter.emit(eventID);
 			},
 		});
+		this.addChild(this.valuePicker);
 	}
 }
 

--- a/ui/core/components/individual_sim_ui/gear_tab.ts
+++ b/ui/core/components/individual_sim_ui/gear_tab.ts
@@ -60,11 +60,7 @@ export class GearTab extends SimTab {
 		});
 
 		const builds = (this.simUI.individualConfig.presets.builds ?? []).filter(build =>
-			Object.keys(build).some(
-				category =>
-					[PresetConfigurationCategory.Gear as string].includes(category) &&
-					!!build[category as keyof PresetBuild],
-			),
+			Object.keys(build).some(category => [PresetConfigurationCategory.Gear as string].includes(category) && !!build[category as keyof PresetBuild]),
 		);
 
 		this.simUI.sim.waitForInit().then(() => {
@@ -112,9 +108,7 @@ export class GearTab extends SimTab {
 
 		// Active state tracking
 		const checkActive = () => {
-			const isActive = build.gear
-				? EquipmentSpec.equals(build.gear.gear, this.simUI.player.getGear().asSpec())
-				: false;
+			const isActive = build.gear ? EquipmentSpec.equals(build.gear.gear, this.simUI.player.getGear().asSpec()) : false;
 			dataElem.classList[isActive ? 'add' : 'remove']('active');
 		};
 		checkActive();
@@ -192,7 +186,6 @@ export class GearTab extends SimTab {
 				});
 			},
 			changeEmitters: [this.simUI.player.changeEmitter],
-			equals: (a: SavedGearSet, b: SavedGearSet) => SavedGearSet.equals(a, b),
 			toJson: (a: SavedGearSet) => SavedGearSet.toJson(a),
 			fromJson: (obj: any) => SavedGearSet.fromJson(obj),
 		});
@@ -235,7 +228,6 @@ export class GearTab extends SimTab {
 				});
 			},
 			changeEmitters: [this.simUI.player.changeEmitter],
-			equals: (a: SavedGearSet, b: SavedGearSet) => SavedGearSet.equals(a, b),
 			toJson: (a: SavedGearSet) => SavedGearSet.toJson(a),
 			fromJson: (obj: any) => SavedGearSet.fromJson(obj),
 		});

--- a/ui/core/components/individual_sim_ui/rotation_tab.tsx
+++ b/ui/core/components/individual_sim_ui/rotation_tab.tsx
@@ -1,15 +1,18 @@
+import { isEqualAPLRotation } from '../../proto_utils/apl_utils';
+import clsx from 'clsx';
+
 import i18n from '../../../i18n/config';
 import { IndividualSimUI, InputSection } from '../../individual_sim_ui';
 import { Player } from '../../player';
 import { APLRotation, APLRotation_Type as APLRotationType } from '../../proto/apl';
 import { SavedRotation } from '../../proto/ui';
-import { isEqualAPLRotation } from '../../proto_utils/apl_utils';
 import { EventID, TypedEvent } from '../../typed_event';
 import { omitDeep } from '../../utils';
 import { ContentBlock } from '../content_block';
 import * as IconInputs from '../icon_inputs';
 import { Input } from '../input';
 import { BooleanPicker } from '../pickers/boolean_picker';
+import { TextDropdownPicker } from '../pickers/dropdown_picker';
 import { EnumPicker } from '../pickers/enum_picker';
 import { IconEnumPicker } from '../pickers/icon_enum_picker';
 import { NumberPicker } from '../pickers/number_picker';
@@ -22,8 +25,6 @@ import { APLPrePullListPicker } from './apl/pre_pull_list_picker';
 import { APLPriorityListPicker } from './apl/priority_list_picker';
 import { CooldownsPicker } from './cooldowns_picker';
 import { PresetConfigurationCategory, PresetConfigurationPicker } from './preset_configuration_picker';
-import { TextDropdownPicker } from '../pickers/dropdown_picker';
-import clsx from 'clsx';
 
 export class RotationTab extends SimTab {
 	protected simUI: IndividualSimUI<any>;
@@ -265,11 +266,8 @@ export class RotationTab extends SimTab {
 					player.setAplRotation(eventID, newRotation.rotation || APLRotation.create());
 				}),
 			changeEmitters: [this.simUI.player.rotationChangeEmitter, this.simUI.player.talentsChangeEmitter],
-			equals: (a: SavedRotation, b: SavedRotation) => {
-				// Uncomment this to debug equivalence checks with preset rotations (e.g. the chip doesn't highlight)
-				// console.log(`Rot A: ${SavedRotation.toJsonString(a, { prettySpaces: 2 })}\n\nRot B: ${SavedRotation.toJsonString(b, { prettySpaces: 2 })}`);
-				return isEqualAPLRotation(this.simUI.player, a.rotation, b.rotation);
-			},
+			// Semantic: Auto and APL types match, simple rotations compare by content.
+			equals: (a: SavedRotation, b: SavedRotation) => isEqualAPLRotation(this.simUI.player, a.rotation, b.rotation),
 			toJson: (a: SavedRotation) => SavedRotation.toJson(a),
 			fromJson: (obj: any) => omitDeep(SavedRotation.fromJson(obj), ['uuid']),
 			nameLabel: i18n.t('rotation_tab.saved_rotations.name_label'),
@@ -281,6 +279,7 @@ export class RotationTab extends SimTab {
 		});
 
 		this.simUI.sim.waitForInit().then(() => {
+			if (this.isDisposed) return;
 			savedRotationsManager.loadUserData();
 			(this.simUI.individualConfig.presets.rotations || []).forEach(presetRotation => {
 				const rotData = presetRotation.rotation;

--- a/ui/core/components/individual_sim_ui/settings_tab.tsx
+++ b/ui/core/components/individual_sim_ui/settings_tab.tsx
@@ -267,7 +267,6 @@ export class SettingsTab extends SimTab {
 			getData: (encounter: Encounter) => SavedEncounter.create({ encounter: encounter.toProto() }),
 			setData: (eventID: EventID, encounter: Encounter, newEncounter: SavedEncounter) => encounter.fromProto(eventID, newEncounter.encounter!),
 			changeEmitters: [this.simUI.sim.encounter.changeEmitter],
-			equals: (a: SavedEncounter, b: SavedEncounter) => SavedEncounter.equals(a, b),
 			toJson: (a: SavedEncounter) => SavedEncounter.toJson(a),
 			fromJson: (obj: any) => SavedEncounter.fromJson(obj),
 		});
@@ -322,7 +321,6 @@ export class SettingsTab extends SimTab {
 				this.simUI.player.distanceFromTargetChangeEmitter,
 				this.simUI.player.healingModelChangeEmitter,
 			],
-			equals: (a: SavedSettings, b: SavedSettings) => SavedSettings.equals(a, b),
 			toJson: (a: SavedSettings) => SavedSettings.toJson(a),
 			fromJson: (obj: any) => {
 				SettingsTab.updateSavedSettings(obj);

--- a/ui/core/components/individual_sim_ui/talents_tab.tsx
+++ b/ui/core/components/individual_sim_ui/talents_tab.tsx
@@ -67,7 +67,6 @@ export class TalentsTab<SpecType extends Spec> extends SimTab {
 				});
 			},
 			changeEmitters: [this.simUI.player.talentsChangeEmitter],
-			equals: (a: SavedTalents, b: SavedTalents) => SavedTalents.equals(a, b),
 			toJson: (a: SavedTalents) => SavedTalents.toJson(a),
 			fromJson: (obj: any) => SavedTalents.fromJson(obj),
 			nameLabel: i18n.t('talents_tab.saved_talents.name_label'),

--- a/ui/core/components/input.tsx
+++ b/ui/core/components/input.tsx
@@ -18,8 +18,9 @@ export interface InputConfig<ModObject, T, V = T> {
 
 	defaultValue?: T;
 
-	// Returns the event indicating the mapped value has changed.
-	changedEvent: (obj: ModObject) => TypedEvent<any>;
+	// Returns the event indicating the mapped value has changed. Omit for inputs
+	// whose parent keeps them in sync via refresh() (e.g. nested APL pickers).
+	changedEvent?: (obj: ModObject) => TypedEvent<any>;
 
 	// Get and set the mapped value.
 	getValue: (obj: ModObject) => T;
@@ -65,19 +66,18 @@ export abstract class Input<ModObject, T, V = T> extends Component {
 		if (config.label) this.rootElem.appendChild(this.buildLabel(config));
 		if (config.description) this.rootElem.appendChild(this.buildDescription(config));
 
-		const event = config.changedEvent(this.modObject).on(() => {
+		const event = config.changedEvent?.(this.modObject).on(() => {
 			const element = this.getInputElem();
 			if (!existsInDOM(element) || !existsInDOM(this.rootElem)) {
 				this.dispose();
 				return;
 			}
-			this.setInputValue(this.getSourceValue());
-			this.update();
+			this.refresh();
 		});
 
 		this.addOnDisposeCallback(() => {
 			this.abortController?.abort();
-			event.dispose();
+			event?.dispose();
 		});
 	}
 
@@ -120,6 +120,12 @@ export abstract class Input<ModObject, T, V = T> extends Component {
 		} else {
 			this.rootElem.classList.add('hide');
 		}
+	}
+
+	// Re-reads the mapped value from the source and re-applies enable/show state.
+	refresh() {
+		this.setInputValue(this.getSourceValue());
+		this.update();
 	}
 
 	// Can't call abstract functions in constructor, so need an init() call.

--- a/ui/core/components/input_helpers.ts
+++ b/ui/core/components/input_helpers.ts
@@ -54,7 +54,7 @@ export function makeWrappedBooleanInput<SpecType extends Spec, ModObject>(
 		label: config.label,
 		labelTooltip: config.labelTooltip,
 		description: config.description,
-		changedEvent: (player: Player<SpecType>) => config.changedEvent(getModObject(player)),
+		changedEvent: (player: Player<SpecType>) => config.changedEvent!(getModObject(player)),
 		getValue: (player: Player<SpecType>) => config.getValue(getModObject(player)),
 		setValue: (eventID: EventID, player: Player<SpecType>, newValue: boolean) => config.setValue(eventID, getModObject(player), newValue),
 		enableWhen: config.enableWhen ? (player: Player<SpecType>) => config.enableWhen!(getModObject(player)) : undefined,
@@ -165,7 +165,7 @@ function makeWrappedNumberInput<SpecType extends Spec, ModObject>(
 		showZeroes: config.showZeroes,
 		maxDecimalDigits: config.maxDecimalDigits,
 		positive: config.positive,
-		changedEvent: (player: Player<SpecType>) => config.changedEvent(getModObject(player)),
+		changedEvent: (player: Player<SpecType>) => config.changedEvent!(getModObject(player)),
 		getValue: (player: Player<SpecType>) => config.getValue(getModObject(player)),
 		setValue: (eventID: EventID, player: Player<SpecType>, newValue: number) => config.setValue(eventID, getModObject(player), newValue),
 		enableWhen: config.enableWhen ? (player: Player<SpecType>) => config.enableWhen!(getModObject(player)) : undefined,
@@ -174,7 +174,8 @@ function makeWrappedNumberInput<SpecType extends Spec, ModObject>(
 	};
 }
 export interface PlayerNumberInputConfig<SpecType extends Spec, Message>
-	extends BasePlayerConfig<SpecType, number>,
+	extends
+		BasePlayerConfig<SpecType, number>,
 		Pick<NumberPickerConfig<Player<SpecType>>, 'labelTooltip' | 'description' | 'showZeroes' | 'maxDecimalDigits' | 'float' | 'positive'> {
 	fieldName: keyof Message;
 	label: string;
@@ -325,7 +326,7 @@ function makeWrappedEnumInput<SpecType extends Spec, ModObject>(config: WrappedE
 		labelTooltip: config.labelTooltip,
 		description: config.description,
 		values: config.values,
-		changedEvent: (player: Player<SpecType>) => config.changedEvent(getModObject(player)),
+		changedEvent: (player: Player<SpecType>) => config.changedEvent!(getModObject(player)),
 		getValue: (player: Player<SpecType>) => config.getValue(getModObject(player)),
 		setValue: (eventID: EventID, player: Player<SpecType>, newValue: number) => config.setValue(eventID, getModObject(player), newValue),
 		enableWhen: config.enableWhen ? (player: Player<SpecType>) => config.enableWhen!(getModObject(player)) : undefined,
@@ -437,7 +438,7 @@ function makeWrappedIconInput<SpecType extends Spec, ModObject, T>(
 		actionId: (player: Player<SpecType>) => config.actionId(getModObject(player)),
 		label: config.label,
 		states: config.states,
-		changedEvent: (player: Player<SpecType>) => config.changedEvent(getModObject(player)),
+		changedEvent: (player: Player<SpecType>) => config.changedEvent!(getModObject(player)),
 		showWhen: (player: Player<SpecType>) => !config.showWhen || (config.showWhen(getModObject(player)) as any),
 		enableWhen: (player: Player<SpecType>) => !config.enableWhen || (config.enableWhen(getModObject(player)) as any),
 		getValue: (player: Player<SpecType>) => config.getValue(getModObject(player)),
@@ -652,7 +653,7 @@ function makeWrappedEnumIconInput<SpecType extends Spec, ModObject, T>(
 		equals: config.equals,
 		showWhen: (player: Player<SpecType>): boolean => !config.showWhen || (config.showWhen(getModObject(player)) as any),
 		zeroValue: config.zeroValue,
-		changedEvent: (player: Player<SpecType>) => config.changedEvent(getModObject(player)),
+		changedEvent: (player: Player<SpecType>) => config.changedEvent!(getModObject(player)),
 		getValue: (player: Player<SpecType>) => config.getValue(getModObject(player)),
 		setValue: (eventID: EventID, player: Player<SpecType>, newValue: T) => config.setValue(eventID, getModObject(player), newValue),
 		extraCssClasses: config.extraCssClasses,
@@ -662,8 +663,7 @@ function makeWrappedEnumIconInput<SpecType extends Spec, ModObject, T>(
 }
 
 export interface PlayerEnumIconInputConfig<SpecType extends Spec, Message, T>
-	extends BasePlayerConfig<SpecType, T>,
-		Pick<IconPickerConfig<Message, T>, 'label' | 'labelTooltip'> {
+	extends BasePlayerConfig<SpecType, T>, Pick<IconPickerConfig<Message, T>, 'label' | 'labelTooltip'> {
 	fieldName: keyof Message;
 	values: Array<IconEnumValueConfig<Player<SpecType>, T>>;
 	numColumns?: number;

--- a/ui/core/components/pickers/dropdown_picker.tsx
+++ b/ui/core/components/pickers/dropdown_picker.tsx
@@ -1,10 +1,11 @@
 import { Dropdown } from 'bootstrap';
 import clsx from 'clsx';
+import { shallowEqualArrays, shallowEqualObjects } from 'shallow-equal';
 import tippy from 'tippy.js';
 import { ref } from 'tsx-vanilla';
 
 import { TypedEvent } from '../../typed_event.js';
-import { existsInDOM } from '../../utils.js';
+import { arrayEquals, existsInDOM } from '../../utils.js';
 import { Input, InputConfig } from '../input.js';
 import i18n from '../../../i18n/config';
 
@@ -106,9 +107,29 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 			return;
 		}
 
-		this.valueConfigs = newValueConfigs.filter(vc => !vc.headerText);
+		const filtered = newValueConfigs.filter(vc => !vc.headerText);
+		// Keep the existing config objects when nothing changed: every APL
+		// action-id picker refreshes its options on each rotation change, and a
+		// fresh-but-equal list would force a button re-render per picker.
+		if (arrayEquals(filtered, this.valueConfigs, (a, b) => this.isSameOption(a, b))) {
+			return;
+		}
+		this.valueConfigs = filtered;
 		this.setInputValue(this.getSourceValue());
 		return;
+	}
+
+	// True when two option configs would render identically: equal values plus
+	// identical display fields, including those of an object value (e.g. a
+	// UnitValue's text/icon/color, which `equals` deliberately ignores).
+	private isSameOption(a: DropdownValueConfig<V>, b: DropdownValueConfig<V>): boolean {
+		const { value: aValue, submenu: aSubmenu, extraCssClasses: aClasses, ...aRest } = a;
+		const { value: bValue, submenu: bSubmenu, extraCssClasses: bClasses, ...bRest } = b;
+		if (!this.config.equals(aValue, bValue)) return false;
+		// The array fields are rebuilt per refresh, so compare them by content.
+		if (!shallowEqualObjects(aRest, bRest) || !shallowEqualArrays(aSubmenu, bSubmenu) || !shallowEqualArrays(aClasses, bClasses)) return false;
+		if (aValue === bValue || typeof aValue !== 'object' || aValue === null || typeof bValue !== 'object' || bValue === null) return true;
+		return shallowEqualObjects(aValue as Record<string, unknown>, bValue as Record<string, unknown>);
 	}
 
 	resetDropdown() {
@@ -243,7 +264,10 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 		return this.valueToSource(this.currentSelection?.value as V);
 	}
 
+	private setValueSeq = 0;
+
 	setInputValue(newSrcValue: T) {
+		const seq = ++this.setValueSeq;
 		const newValue = this.sourceToValue(newSrcValue);
 		const newSelection = this.valueConfigs.find(v => this.config.equals(v.value, newValue))!;
 		if (newSelection) {
@@ -251,13 +275,22 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 		} else if (newValue == null) {
 			this.updateValue(null);
 		} else if (this.config.createMissingValue) {
-			this.config.createMissingValue(newValue).then(newSelection => this.updateValue(newSelection));
+			this.config.createMissingValue(newValue).then(newSelection => {
+				// A newer setInputValue (or disposal) happened while awaiting.
+				if (seq !== this.setValueSeq || this.isDisposed) return;
+				this.updateValue(newSelection);
+			});
 		} else {
 			this.updateValue(null);
 		}
 	}
 
 	private updateValue(newValue: DropdownValueConfig<V> | null) {
+		// Same selection object as already rendered: nothing to do. This is the
+		// hot path when a rotation edit re-syncs every dropdown in the APL editor.
+		if (newValue && newValue === this.currentSelection) {
+			return;
+		}
 		this.currentSelection = newValue;
 
 		// Update button

--- a/ui/core/components/pickers/icon_enum_picker.tsx
+++ b/ui/core/components/pickers/icon_enum_picker.tsx
@@ -28,6 +28,7 @@ export interface IconEnumValueConfig<ModObject, T> {
 }
 
 export interface IconEnumPickerConfig<ModObject, T> extends InputConfig<ModObject, T> {
+	changedEvent: (obj: ModObject) => TypedEvent<any>;
 	numColumns?: number;
 	values: Array<IconEnumValueConfig<ModObject, T>>;
 	// Value that will be considered inactive.

--- a/ui/core/components/pickers/icon_picker.tsx
+++ b/ui/core/components/pickers/icon_picker.tsx
@@ -11,6 +11,7 @@ import { Input, InputConfig } from '../input.js';
 // ModObject is the object being modified (Sim, Player, or Target).
 // ValueType is either number or boolean.
 export interface IconPickerConfig<ModObject, ValueType> extends InputConfig<ModObject, ValueType> {
+	changedEvent: (obj: ModObject) => TypedEvent<any>;
 	actionId: (modObj: ModObject) => ActionId | null;
 
 	// The number of possible 'states' this icon can have. Most inputs will use 2

--- a/ui/core/components/pickers/list_picker.tsx
+++ b/ui/core/components/pickers/list_picker.tsx
@@ -30,36 +30,34 @@ export interface ListPickerExtraAction {
 	shouldShow?: (index: number) => boolean;
 }
 
-type CopyItemConfig<ItemType> =
-	| { copyItem: (oldItem: ItemType) => ItemType; onCopyItem?: never }
-	| { copyItem?: never; onCopyItem: (index: number) => void };
+type CopyItemConfig<ItemType> = { copyItem: (oldItem: ItemType) => ItemType; onCopyItem?: never } | { copyItem?: never; onCopyItem: (index: number) => void };
 
 export type ListPickerConfig<ModObject, ItemType> = Omit<InputConfig<ModObject, Array<ItemType>>, 'id'> &
 	CopyItemConfig<ItemType> & {
-	itemLabel: string;
-	newItem: () => ItemType;
-	newItemPicker: (
-		parent: HTMLElement,
-		listPicker: ListPicker<ModObject, ItemType>,
-		index: number,
-		config: ListItemPickerConfig<ModObject, ItemType>,
-	) => Input<ModObject, ItemType>;
-	actions?: ListPickerActionsConfig;
-	title?: string;
-	titleTooltip?: string;
-	inlineMenuBar?: boolean;
-	hideUi?: boolean;
-	horizontalLayout?: boolean;
-	// if set, will remove the border and padding of the list items
-	isCompact?: boolean;
-	// If set, will disable the delete button if the list is at the minimum.
-	minimumItems?: number;
-	// If set, only actions included in the list are allowed. Otherwise, all actions are allowed.
-	allowedActions?: Array<ListItemAction>;
-	dragGroup?: string;
-	// Additional custom action buttons to add to the popover menu
-	extraActions?: Array<ListPickerExtraAction>;
-}
+		itemLabel: string;
+		newItem: () => ItemType;
+		newItemPicker: (
+			parent: HTMLElement,
+			listPicker: ListPicker<ModObject, ItemType>,
+			index: number,
+			config: ListItemPickerConfig<ModObject, ItemType>,
+		) => Input<ModObject, ItemType>;
+		actions?: ListPickerActionsConfig;
+		title?: string;
+		titleTooltip?: string;
+		inlineMenuBar?: boolean;
+		hideUi?: boolean;
+		horizontalLayout?: boolean;
+		// if set, will remove the border and padding of the list items
+		isCompact?: boolean;
+		// If set, will disable the delete button if the list is at the minimum.
+		minimumItems?: number;
+		// If set, only actions included in the list are allowed. Otherwise, all actions are allowed.
+		allowedActions?: Array<ListItemAction>;
+		dragGroup?: string;
+		// Additional custom action buttons to add to the popover menu
+		extraActions?: Array<ListPickerExtraAction>;
+	};
 
 const DEFAULT_CONFIG = {
 	actions: {
@@ -163,7 +161,10 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 	setInputValue(newValue: Array<ItemType>): void {
 		// Add/remove pickers to make the lengths match.
 		if (newValue.length < this.itemPickerPairs.length) {
-			this.itemPickerPairs.slice(newValue.length).forEach(ipp => ipp.elem.remove());
+			this.itemPickerPairs.slice(newValue.length).forEach(ipp => {
+				this.disposeChild(ipp.picker);
+				ipp.elem.remove();
+			});
 			this.itemPickerPairs = this.itemPickerPairs.slice(0, newValue.length);
 		} else if (newValue.length > this.itemPickerPairs.length) {
 			const numToAdd = newValue.length - this.itemPickerPairs.length;
@@ -179,7 +180,8 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 		}
 
 		// Set all the values.
-		newValue.forEach((val, i) => this.itemPickerPairs[i].picker.setInputValue(val));
+		// Items without their own changedEvent (APL pickers) are kept in sync from here.
+		newValue.forEach((_val, i) => this.itemPickerPairs[i].picker.refresh());
 	}
 
 	private actionEnabled(action: ListItemAction): boolean {
@@ -250,6 +252,9 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 		});
 
 		const item: ItemPickerPair<ItemType> = { elem: itemContainer, picker: itemPicker, idx: index };
+		this.addChild(itemPicker);
+		// Per-item resources (tooltips, document-level listeners) are released
+		// with the item picker (its dispose callbacks / signal), not with the whole list.
 
 		if (this.actionEnabled('delete')) {
 			if (!this.config.minimumItems || index + 1 > this.config.minimumItems) {
@@ -266,14 +271,15 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 				deleteButton.addEventListener(
 					'click',
 					() => {
+						// Hide before setValue: the shrink below may dispose this item (and its tooltip) synchronously.
+						deleteButtonTooltip.hide();
 						const newList = this.config.getValue(this.modObject);
 						newList.splice(index, 1);
 						this.config.setValue(TypedEvent.nextEventID(), this.modObject, newList);
-						deleteButtonTooltip.hide();
 					},
 					{ signal: this.signal },
 				);
-				this.addOnDisposeCallback(() => deleteButtonTooltip?.destroy());
+				itemPicker.addOnDisposeCallback(() => deleteButtonTooltip?.destroy());
 				this.addHoverListeners(deleteButton);
 			}
 		}
@@ -301,7 +307,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 					},
 					{ signal: this.signal },
 				);
-				this.addOnDisposeCallback(() => extraTooltip?.destroy());
+				itemPicker.addOnDisposeCallback(() => extraTooltip?.destroy());
 				this.addHoverListeners(extraButton);
 				if (extraAction.shouldShow) {
 					extraActionButtons.push({ elem: extraButton, shouldShow: extraAction.shouldShow });
@@ -332,7 +338,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 				},
 				{ signal: this.signal },
 			);
-			this.addOnDisposeCallback(() => copyButtonTooltip?.destroy());
+			itemPicker.addOnDisposeCallback(() => copyButtonTooltip?.destroy());
 			this.addHoverListeners(copyButton);
 		}
 
@@ -394,7 +400,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 						itemContainer.removeAttribute('draggable');
 					}
 				},
-				{ signal: this.signal },
+				{ signal: itemPicker.signal },
 			);
 
 			const droppingActionOnOtherList = () => {

--- a/ui/core/components/raid_sim_action.tsx
+++ b/ui/core/components/raid_sim_action.tsx
@@ -142,6 +142,8 @@ export class RaidSimResultsManager {
 	}
 
 	setSimProgress(progress: ProgressMetrics) {
+		// Content is replaced below; release the previous content's tooltips/listeners.
+		this.reset();
 		if (progress.finalRaidResult && progress.finalRaidResult.error) {
 			this.simUI.resultsViewer.hideAll();
 			return;
@@ -168,6 +170,7 @@ export class RaidSimResultsManager {
 	}
 
 	setSimResult(eventID: EventID, simResult: SimResult) {
+		this.reset();
 		this.currentData = {
 			simResult: simResult,
 			settings: {
@@ -466,7 +469,7 @@ export class RaidSimResultsManager {
 
 		if (players.length === 1) {
 			const playerMetrics = players[0];
-			const spec = players[0].spec?.specID
+			const spec = players[0].spec?.specID;
 			const isTank = [Spec.SpecFeralBearDruid, Spec.SpecProtectionPaladin].includes(spec);
 			if (playerMetrics.getTargetIndex(filter) === null) {
 				const { chanceOfDeath, dps: dpsMetrics, tps: tpsMetrics, dtps: dtpsMetrics, tmi: tmiMetrics } = playerMetrics;

--- a/ui/core/components/saved_data_manager.tsx
+++ b/ui/core/components/saved_data_manager.tsx
@@ -15,7 +15,9 @@ export type SavedDataManagerConfig<ModObject, T> = {
 	loadOnly?: boolean;
 	storageKey: string;
 	changeEmitters: TypedEvent<any>[];
-	equals: (a: T, b: T) => boolean;
+	// Optional semantic equality (e.g. rotations, where the type/uuids may differ);
+	// without it entries compare by their `toJson` string.
+	equals?: (a: T, b: T) => boolean;
 	getData: (modObject: ModObject) => T;
 	setData: (eventID: EventID, modObject: ModObject, data: T) => void;
 	toJson: (a: T) => any;
@@ -42,6 +44,10 @@ export type SavedDataConfig<ModObject, T> = {
 type SavedData<ModObject, T> = {
 	name: string;
 	data: T;
+	// Serialized form of `data` (only when the manager has no semantic `equals`),
+	// compared against the current value by string so an active-check costs one
+	// serialization per manager, not one deep proto equals per entry.
+	dataJson?: string;
 	elem: HTMLElement;
 } & Pick<SavedDataConfig<ModObject, T>, 'enableWhen' | 'onLoad'>;
 
@@ -58,6 +64,7 @@ export class SavedDataManager<ModObject, T> extends Component {
 	private saveInput?: HTMLInputElement;
 
 	private frozen: boolean;
+	private pendingCheckFrame: number | null = null;
 
 	constructor(parent: HTMLElement | null, modObject: ModObject, config: SavedDataManagerConfig<ModObject, T>) {
 		super(parent, 'saved-data-manager-root');
@@ -67,6 +74,12 @@ export class SavedDataManager<ModObject, T> extends Component {
 		this.userData = [];
 		this.presets = [];
 		this.frozen = false;
+
+		// One coalesced active-check per manager per change burst, deferred to
+		// the next frame: the old per-entry deep equals on every change was the
+		// dominant cost of an APL edit (~166 ms on a large rotation).
+		const emitters = this.config.changeEmitters.map(emitter => emitter.on(() => this.scheduleChecks()));
+		this.addOnDisposeCallback(() => emitters.forEach(emitter => emitter.dispose()));
 
 		if (config.extraCssClasses) this.rootElem.classList.add(...config.extraCssClasses);
 
@@ -109,6 +122,7 @@ export class SavedDataManager<ModObject, T> extends Component {
 			dataArr[oldIdx].elem.replaceWith(newData.elem);
 			dataArr[oldIdx] = newData;
 		}
+		this.scheduleChecks();
 	}
 
 	private makeSavedData(config: SavedDataConfig<ModObject, T>): SavedData<ModObject, T> {
@@ -127,6 +141,8 @@ export class SavedDataManager<ModObject, T> extends Component {
 		dataElem?.addEventListener('click', () => {
 			this.config.setData(TypedEvent.nextEventID(), this.modObject, config.data);
 			config.onLoad?.(this.modObject);
+			// Run the deferred check now so the clicked entry's name is the one left in the input.
+			this.flushChecks();
 			if (this.saveInput) this.saveInput.value = config.name;
 			trackEvent({
 				action: 'settings',
@@ -168,32 +184,59 @@ export class SavedDataManager<ModObject, T> extends Component {
 			});
 		}
 
-		const checkActive = () => {
-			if (this.config.equals(config.data, this.config.getData(this.modObject))) {
-				dataElem.classList.add('active');
-				if (this.saveInput) this.saveInput.value = config.name;
-			} else {
-				dataElem.classList.remove('active');
-			}
-
-			if (config.enableWhen && !config.enableWhen(this.modObject)) {
-				dataElem.classList.add('disabled');
-			} else {
-				dataElem.classList.remove('disabled');
-			}
-		};
-
-		checkActive();
-		const emitters = this.config.changeEmitters.map(emitter => emitter.on(checkActive));
-		this.addOnDisposeCallback(() => emitters.map(emitter => emitter.dispose()));
-
-		return {
+		const savedData: SavedData<ModObject, T> = {
 			name: config.name,
 			data: config.data,
+			dataJson: this.serialize(config.data),
 			elem: dataElem,
 			enableWhen: config.enableWhen,
 			onLoad: config.onLoad,
 		};
+		return savedData;
+	}
+
+	private serialize(data: T): string | undefined {
+		return this.config.equals ? undefined : JSON.stringify(this.config.toJson(data));
+	}
+
+	private scheduleChecks() {
+		if (this.pendingCheckFrame != null) return;
+		this.pendingCheckFrame = requestAnimationFrame(() => {
+			this.pendingCheckFrame = null;
+			this.runChecks();
+		});
+	}
+
+	private flushChecks() {
+		if (this.pendingCheckFrame == null) return;
+		cancelAnimationFrame(this.pendingCheckFrame);
+		this.pendingCheckFrame = null;
+		this.runChecks();
+	}
+
+	private runChecks() {
+		if (!this.presets.length && !this.userData.length) return;
+		const current = this.config.getData(this.modObject);
+		const currentJson = this.serialize(current);
+		// Presets last so, with identical data, the preset's name wins in the save input (as before).
+		this.userData.forEach(entry => this.checkEntry(entry, current, currentJson));
+		this.presets.forEach(entry => this.checkEntry(entry, current, currentJson));
+	}
+
+	private checkEntry(entry: SavedData<ModObject, T>, current: T, currentJson: string | undefined) {
+		const isActive = this.config.equals ? this.config.equals(entry.data, current) : entry.dataJson === currentJson;
+		if (isActive) {
+			entry.elem.classList.add('active');
+			if (this.saveInput) this.saveInput.value = entry.name;
+		} else {
+			entry.elem.classList.remove('active');
+		}
+
+		if (entry.enableWhen && !entry.enableWhen(this.modObject)) {
+			entry.elem.classList.add('disabled');
+		} else {
+			entry.elem.classList.remove('disabled');
+		}
 	}
 
 	// Save data to window.localStorage.

--- a/ui/core/components/saved_data_managers/ep_weights.ts
+++ b/ui/core/components/saved_data_managers/ep_weights.ts
@@ -26,7 +26,6 @@ export const renderSavedEPWeights = (
 			});
 		},
 		changeEmitters: [simUI.player.epWeightsChangeEmitter],
-		equals: (a, b) => SavedEPWeights.equals(a, b),
 		toJson: a => SavedEPWeights.toJson(a),
 		fromJson: obj => SavedEPWeights.fromJson(obj),
 		...options,

--- a/ui/core/encounter.ts
+++ b/ui/core/encounter.ts
@@ -160,7 +160,7 @@ export class Encounter {
 			this.setExecuteProportion45(eventID, proto.executeProportion45);
 			this.setExecuteProportion90(eventID, proto.executeProportion90);
 			this.setUseHealth(eventID, proto.useHealth);
-			this.targets = proto.targets;
+			this.targets = proto.targets.map(t => TargetProto.clone(t));
 			this.targetsChangeEmitter.emit(eventID);
 		});
 	}

--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -404,9 +404,22 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 			// This needs to go last so it doesn't re-store things as they are initialized.
 			const events = [this.changeEmitter];
 			if (this.reforger?.changeEmitter) events.push(this.reforger.changeEmitter);
-			TypedEvent.onAny(events).on(_eventID => {
+			// Debounced: serializing + storing the full settings on every keystroke
+			// cost ~50 ms per APL edit. A pending write is flushed on page hide.
+			let persistTimer: ReturnType<typeof setTimeout> | null = null;
+			const persist = () => {
+				persistTimer = null;
 				const jsonStr = IndividualSimSettings.toJsonString(this.toProto());
 				window.localStorage.setItem(this.getSettingsStorageKey(), jsonStr);
+			};
+			window.addEventListener('pagehide', () => {
+				if (persistTimer == null) return;
+				clearTimeout(persistTimer);
+				persist();
+			});
+			TypedEvent.onAny(events).on(() => {
+				if (persistTimer != null) clearTimeout(persistTimer);
+				persistTimer = setTimeout(persist, 300);
 			});
 
 			this.statWeightActionSettings.load(initEventID);
@@ -481,10 +494,7 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 			const defaultRotationType = this.individualConfig.defaults.rotationType || APLRotationType.TypeAuto;
 
 			if (defaultRotationType === APLRotationType.TypeAPL && this.individualConfig.defaults.aplRotation) {
-				this.player.setAplRotation(
-					eventID,
-					APLRotation.create(this.individualConfig.defaults.aplRotation),
-				);
+				this.player.setAplRotation(eventID, APLRotation.create(this.individualConfig.defaults.aplRotation));
 				return;
 			}
 

--- a/ui/core/typed_event.ts
+++ b/ui/core/typed_event.ts
@@ -98,7 +98,9 @@ export class TypedEvent<T> {
 	}
 
 	private fireEventInternal(eventID: EventID, event: T) {
-		this.listeners.forEach(listener => listener(eventID, event));
+		// Iterate a copy: a listener may off() itself (lazy self-dispose in Input),
+		// which would otherwise skip the next listener in the live array.
+		this.listeners.slice().forEach(listener => listener(eventID, event));
 	}
 
 	// Executes the provided callback while all TypedEvents are frozen.

--- a/ui/raid/raid_tab.ts
+++ b/ui/raid/raid_tab.ts
@@ -55,9 +55,6 @@ export class RaidTab extends SimTab {
 				});
 			},
 			changeEmitters: [this.simUI.changeEmitter, this.simUI.sim.changeEmitter],
-			equals: (a: SavedRaid, b: SavedRaid) => {
-				return SavedRaid.equals(a, b);
-			},
 			toJson: (a: SavedRaid) => SavedRaid.toJson(a),
 			fromJson: (obj: any) => SavedRaid.fromJson(obj),
 		});

--- a/ui/raid/settings_tab.ts
+++ b/ui/raid/settings_tab.ts
@@ -134,7 +134,6 @@ export class SettingsTab extends SimTab {
 			getData: (encounter: Encounter) => SavedEncounter.create({ encounter: encounter.toProto() }),
 			setData: (eventID: EventID, encounter: Encounter, newEncounter: SavedEncounter) => encounter.fromProto(eventID, newEncounter.encounter!),
 			changeEmitters: [this.simUI.sim.encounter.changeEmitter],
-			equals: (a: SavedEncounter, b: SavedEncounter) => SavedEncounter.equals(a, b),
 			toJson: (a: SavedEncounter) => SavedEncounter.toJson(a),
 			fromJson: (obj: any) => SavedEncounter.fromJson(obj),
 		});

--- a/ui/scss/core/components/detailed_results/_timeline.scss
+++ b/ui/scss/core/components/detailed_results/_timeline.scss
@@ -232,6 +232,12 @@
 	display: inline-flex;
 	border: 1px solid var(--bs-white);
 	margin: 3px;
+	padding: 0 0.375rem 0 0.25rem;
+	cursor: pointer;
+
+	&:hover .fas {
+		color: var(--bs-link-danger);
+	}
 }
 
 .rotation-label-icon {

--- a/ui/scss/core/components/detailed_results/_timeline.scss
+++ b/ui/scss/core/components/detailed_results/_timeline.scss
@@ -232,7 +232,8 @@
 	display: inline-flex;
 	border: 1px solid var(--bs-white);
 	margin: 3px;
-	padding: 0 0.375rem 0 0.25rem;
+	padding: 0 0.5rem;
+	gap: 0.25rem;
 	cursor: pointer;
 
 	&:hover .fas {


### PR DESCRIPTION
## Summary

Parity port of wowsims/mop#1555 (APL editor + detailed-results timeline cleanup). See that PR for the full change list and the measured DOM impact; the mechanics are identical here:

- `TypedEvent` dispatches over a snapshot; `Component` child registry (`addChild` / `disposeChild` / `removeChild`).
- `InputConfig.changedEvent` is optional and `Input.refresh()` re-syncs children from their parent's cascade; nested APL pickers no longer subscribe to the rotation themselves.
- `DropdownPicker` skips redundant re-renders (`shallow-equal` is a new direct dependency).
- Timeline keeps the rotation subtree live across current ↔ reference swaps (one parked slot); pet/target header rows are never hidden; hidden rows are keyed by section + action; hidden chips are clickable as a whole.
- `SavedDataManager` runs one coalesced check per frame and compares by JSON unless a semantic `equals` is configured.
- Settings autosave is debounced and flushed on `pagehide`.

**Differences from the MoP change set** (TBC lacks the feature): no `damageAmplifier` / `cancelSpellCast` action inputs, no `secondaryResource` on the Timeline. TBC-only call site handled: the second gear `SavedDataManager` in `gear_tab.ts` also dropped its `equals`.

## Verification

`tsc --noEmit` clean; `oxlint` unchanged versus master on every touched file; `vite build` ok. Browser checks against a local `wowsimtbc --usefs` host: 14-spec sweep (load, Simulate, real result, console/page errors) clean; eye-icon hide sweep over every row on Warlock (pets) with no label/row drift; hidden-chip click un-hides; current ↔ reference swap keeps ~2.4k live tooltips; APL numeric edits on the Warrior Arms rotation (154 list items) at 7–10 ms sync.

Ported by a Sonnet agent and validated hunk-by-hunk against the MoP tree by an Opus agent (15 of 27 files byte-identical in their delta; the rest differ only by formatter reflow or the two TBC-lacks-feature items above).

https://claude.ai/code/session_016y947FgNKyqFWiApSLYbJe
