### PR TITLE
Fix quick-swap writing back stale gear, and inactive meta gems dropping the socket bonus

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -730,6 +730,9 @@ message ItemSpec {
 	int32 random_suffix = 2;
 	int32 enchant = 3;
 	repeated int32 gems = 4;
+	// Set by the UI when the socketed meta gem's requirements are not met. The gem stays in its
+	// socket so the item's socket bonus still applies, but contributes no stats and no effect.
+	bool meta_gem_disabled = 5;
 }
 
 

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -536,7 +536,7 @@ func (character *Character) HasRingEquipped(itemID int32) bool {
 
 func (character *Character) HasMetaGemEquipped(gemID int32) bool {
 	for _, gem := range character.Head().Gems {
-		if gem.ID == gemID {
+		if gem.ID == gemID && !gem.Disabled {
 			return true
 		}
 	}

--- a/sim/core/database.go
+++ b/sim/core/database.go
@@ -178,6 +178,9 @@ func (item *Item) ToItemSpecProto() *proto.ItemSpec {
 		RandomSuffix: item.RandomSuffix.ID,
 		Enchant:      item.Enchant.EffectID,
 		Gems:         MapSlice(item.Gems, func(gem Gem) int32 { return gem.ID }),
+		MetaGemDisabled: slices.ContainsFunc(item.Gems, func(gem Gem) bool {
+			return gem.Disabled && gem.Color == proto.GemColor_GemColorMeta
+		}),
 	}
 
 	return itemSpec
@@ -220,6 +223,9 @@ type Gem struct {
 	Name  string
 	Stats stats.Stats
 	Color proto.GemColor
+	// Set per equipped instance, not from the DB: a meta gem whose requirements are not met stays
+	// socketed (so the item's socket bonus still applies) but grants no stats and no effect.
+	Disabled bool
 }
 
 func GemFromProto(pData *proto.SimGem) Gem {
@@ -232,10 +238,11 @@ func GemFromProto(pData *proto.SimGem) Gem {
 }
 
 type ItemSpec struct {
-	ID           int32
-	RandomSuffix int32
-	Enchant      int32
-	Gems         []int32
+	ID              int32
+	RandomSuffix    int32
+	Enchant         int32
+	Gems            []int32
+	MetaGemDisabled bool
 }
 
 type Equipment [NumItemSlots]Item
@@ -402,10 +409,11 @@ func ProtoToEquipmentSpec(es *proto.EquipmentSpec) EquipmentSpec {
 	var coreEquip EquipmentSpec
 	for i, item := range es.Items {
 		coreEquip[i] = ItemSpec{
-			ID:           item.Id,
-			RandomSuffix: item.RandomSuffix,
-			Enchant:      item.Enchant,
-			Gems:         item.Gems,
+			ID:              item.Id,
+			RandomSuffix:    item.RandomSuffix,
+			Enchant:         item.Enchant,
+			Gems:            item.Gems,
+			MetaGemDisabled: item.MetaGemDisabled,
 		}
 	}
 	return coreEquip
@@ -453,6 +461,7 @@ func NewItem(itemSpec ItemSpec) Item {
 		item.Gems = make([]Gem, numGems)
 		for gemIdx, gemID := range itemSpec.Gems {
 			if gem, ok := GemsByID[gemID]; ok {
+				gem.Disabled = itemSpec.MetaGemDisabled && gem.Color == proto.GemColor_GemColorMeta
 				item.Gems[gemIdx] = gem
 			} else {
 				if gemID != 0 {
@@ -543,6 +552,11 @@ func ItemEquipmentGemAndEnchantStats(item Item) stats.Stats {
 	equipStats = equipStats.Add(item.Enchant.Stats)
 
 	for _, gem := range item.Gems {
+		// A disabled meta gem keeps its color below so the socket bonus still matches.
+		if gem.Disabled {
+			continue
+		}
+
 		equipStats = equipStats.Add(gem.Stats)
 	}
 

--- a/sim/core/gem_test.go
+++ b/sim/core/gem_test.go
@@ -1,0 +1,299 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/wowsims/tbc/sim/core/proto"
+	"github.com/wowsims/tbc/sim/core/stats"
+)
+
+var allGemColors = []proto.GemColor{
+	proto.GemColor_GemColorMeta,
+	proto.GemColor_GemColorRed,
+	proto.GemColor_GemColorBlue,
+	proto.GemColor_GemColorYellow,
+	proto.GemColor_GemColorGreen,
+	proto.GemColor_GemColorOrange,
+	proto.GemColor_GemColorPurple,
+	proto.GemColor_GemColorPrismatic,
+}
+
+// Which gem colors count towards a socket bonus, written out by hand rather than derived from
+// ColorIntersects so that this stays an independent statement of the rules: a socket accepts its own
+// color plus the two hybrids that contain it, a meta socket accepts only meta, and prismatic matches
+// everything in both directions.
+var socketBonusMatches = map[proto.GemColor][]proto.GemColor{
+	proto.GemColor_GemColorMeta: {proto.GemColor_GemColorMeta, proto.GemColor_GemColorPrismatic},
+	proto.GemColor_GemColorRed: {
+		proto.GemColor_GemColorRed, proto.GemColor_GemColorOrange, proto.GemColor_GemColorPurple, proto.GemColor_GemColorPrismatic,
+	},
+	proto.GemColor_GemColorBlue: {
+		proto.GemColor_GemColorBlue, proto.GemColor_GemColorGreen, proto.GemColor_GemColorPurple, proto.GemColor_GemColorPrismatic,
+	},
+	proto.GemColor_GemColorYellow: {
+		proto.GemColor_GemColorYellow, proto.GemColor_GemColorGreen, proto.GemColor_GemColorOrange, proto.GemColor_GemColorPrismatic,
+	},
+	proto.GemColor_GemColorGreen: {
+		proto.GemColor_GemColorGreen, proto.GemColor_GemColorBlue, proto.GemColor_GemColorYellow, proto.GemColor_GemColorPrismatic,
+	},
+	proto.GemColor_GemColorOrange: {
+		proto.GemColor_GemColorOrange, proto.GemColor_GemColorRed, proto.GemColor_GemColorYellow, proto.GemColor_GemColorPrismatic,
+	},
+	proto.GemColor_GemColorPurple: {
+		proto.GemColor_GemColorPurple, proto.GemColor_GemColorRed, proto.GemColor_GemColorBlue, proto.GemColor_GemColorPrismatic,
+	},
+	proto.GemColor_GemColorPrismatic: allGemColors,
+}
+
+func socketBonusExpected(socketColor, gemColor proto.GemColor) bool {
+	for _, c := range socketBonusMatches[socketColor] {
+		if c == gemColor {
+			return true
+		}
+	}
+	return false
+}
+
+// One socket, one gem, a socket bonus on the item. Returns the total of the one stat everything
+// contributes to, so callers can decode which parts were counted.
+const (
+	gemStatValue    = 160.0
+	socketBonusStat = 120.0
+)
+
+func itemWithOneSocket(socketColor, gemColor proto.GemColor, disabled bool) Item {
+	gemStats := stats.Stats{}
+	gemStats[stats.Agility] = gemStatValue
+	bonus := stats.Stats{}
+	bonus[stats.Agility] = socketBonusStat
+
+	return Item{
+		ID:          1,
+		GemSockets:  []proto.GemColor{socketColor},
+		Gems:        []Gem{{ID: 1, Color: gemColor, Stats: gemStats, Disabled: disabled}},
+		SocketBonus: bonus,
+	}
+}
+
+// Every socket colour against every gem colour, so a change to the matching rules cannot slip past
+// on the colours nobody happens to have written a case for.
+func TestSocketBonusForEveryColorCombination(t *testing.T) {
+	for _, socketColor := range allGemColors {
+		for _, gemColor := range allGemColors {
+			got := ItemEquipmentGemAndEnchantStats(itemWithOneSocket(socketColor, gemColor, false))[stats.Agility]
+
+			want := gemStatValue
+			if socketBonusExpected(socketColor, gemColor) {
+				want += socketBonusStat
+			}
+
+			if got != want {
+				t.Errorf("%v socket with a %v gem: expected %v agility, got %v", socketColor, gemColor, want, got)
+			}
+		}
+	}
+}
+
+// An empty socket earns no bonus. The one exception is a prismatic socket: ColorIntersects treats
+// prismatic as matching anything on either side, so an empty one still counts. That is pre-existing
+// behaviour and is left alone here -- no TBC item has a prismatic socket, so it cannot be reached.
+func TestEmptySocketNeverEarnsSocketBonus(t *testing.T) {
+	for _, socketColor := range allGemColors {
+		item := itemWithOneSocket(socketColor, proto.GemColor_GemColorUnknown, false)
+		item.Gems = []Gem{{}}
+
+		want := 0.0
+		if socketColor == proto.GemColor_GemColorPrismatic {
+			want = socketBonusStat
+		}
+
+		if got := ItemEquipmentGemAndEnchantStats(item)[stats.Agility]; got != want {
+			t.Errorf("%v socket left empty: expected %v agility, got %v", socketColor, want, got)
+		}
+	}
+}
+
+// Guards the claim made above, so that if a prismatic socket ever appears on a TBC item the exception
+// in TestEmptySocketNeverEarnsSocketBonus has to be revisited rather than silently mattering.
+func TestNoTBCItemHasAPrismaticSocket(t *testing.T) {
+	if len(ItemsByID) == 0 {
+		t.Skip("no item database loaded; run with -tags with_db")
+	}
+
+	for _, item := range ItemsByID {
+		for _, socketColor := range item.GemSockets {
+			if socketColor == proto.GemColor_GemColorPrismatic {
+				t.Fatalf("%q has a prismatic socket; empty-prismatic-socket handling now matters", item.Name)
+			}
+		}
+	}
+}
+
+// A disabled gem contributes no stats but keeps its colour, so the socket bonus is unaffected. Only
+// meta gems are disabled today (when their requirements are not met), but the rule is colour-agnostic
+// and is checked that way.
+func TestDisabledGemKeepsSocketBonusButLosesItsStats(t *testing.T) {
+	for _, socketColor := range allGemColors {
+		for _, gemColor := range allGemColors {
+			got := ItemEquipmentGemAndEnchantStats(itemWithOneSocket(socketColor, gemColor, true))[stats.Agility]
+
+			want := 0.0
+			if socketBonusExpected(socketColor, gemColor) {
+				want = socketBonusStat
+			}
+
+			if got != want {
+				t.Errorf("%v socket with a disabled %v gem: expected %v agility, got %v", socketColor, gemColor, want, got)
+			}
+		}
+	}
+}
+
+// The colour rules above are synthetic. This runs the same invariant over every gem actually in the
+// database, so a gem whose colour is mis-parsed on import is caught too.
+func TestSocketBonusForEveryGemInDatabase(t *testing.T) {
+	if len(GemsByID) == 0 {
+		t.Skip("no gem database loaded; run with -tags with_db")
+	}
+
+	for _, gem := range GemsByID {
+		for _, socketColor := range allGemColors {
+			item := Item{
+				ID:          1,
+				GemSockets:  []proto.GemColor{socketColor},
+				Gems:        []Gem{gem},
+				SocketBonus: stats.Stats{},
+			}
+			item.SocketBonus[stats.Agility] = socketBonusStat
+
+			want := gem.Stats[stats.Agility]
+			if socketBonusExpected(socketColor, gem.Color) {
+				want += socketBonusStat
+			}
+
+			if got := ItemEquipmentGemAndEnchantStats(item)[stats.Agility]; got != want {
+				t.Fatalf("%q (%v) in a %v socket: expected %v agility, got %v", gem.Name, gem.Color, socketColor, want, got)
+			}
+		}
+	}
+}
+
+// Every meta gem in the database, disabled: no stats of its own, but the head socket bonus survives.
+// This is the bug this change exists to fix.
+func TestEveryDisabledMetaGemInDatabaseKeepsSocketBonus(t *testing.T) {
+	if len(GemsByID) == 0 {
+		t.Skip("no gem database loaded; run with -tags with_db")
+	}
+
+	checked := 0
+	for _, gem := range GemsByID {
+		if gem.Color != proto.GemColor_GemColorMeta {
+			continue
+		}
+		checked++
+
+		disabled := gem
+		disabled.Disabled = true
+		item := Item{
+			ID:          1,
+			GemSockets:  []proto.GemColor{proto.GemColor_GemColorMeta},
+			Gems:        []Gem{disabled},
+			SocketBonus: stats.Stats{},
+		}
+		item.SocketBonus[stats.Agility] = socketBonusStat
+
+		if got := ItemEquipmentGemAndEnchantStats(item)[stats.Agility]; got != socketBonusStat {
+			t.Fatalf("disabled %q: expected the %v socket bonus and nothing else, got %v", gem.Name, socketBonusStat, got)
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no meta gems found in the database")
+	}
+	t.Logf("checked %d meta gems", checked)
+}
+
+// Equipment is round-tripped back through NewItem in places, so the disabled flag has to survive
+// Item -> ItemSpec proto -> Item or the meta gem silently reactivates mid-run.
+func TestDisabledMetaGemSurvivesProtoRoundTrip(t *testing.T) {
+	const testItemID, testMetaGemID, testRedGemID = 990001, 990002, 990003
+
+	addToDatabase(&proto.SimDatabase{
+		Items: []*proto.SimItem{{
+			Id:             testItemID,
+			Name:           "Test Helm",
+			GemSockets:     []proto.GemColor{proto.GemColor_GemColorMeta, proto.GemColor_GemColorRed},
+			ScalingOptions: map[int32]*proto.ScalingItemProperties{0: {}},
+		}},
+		Gems: []*proto.SimGem{
+			{Id: testMetaGemID, Name: "Test Meta", Color: proto.GemColor_GemColorMeta},
+			{Id: testRedGemID, Name: "Test Red", Color: proto.GemColor_GemColorRed},
+		},
+	})
+
+	item := NewItem(ItemSpec{ID: testItemID, Gems: []int32{testMetaGemID, testRedGemID}, MetaGemDisabled: true})
+	if !item.Gems[0].Disabled {
+		t.Fatal("meta gem should be disabled after NewItem")
+	}
+	if item.Gems[0].Color != proto.GemColor_GemColorMeta {
+		t.Fatal("disabled meta gem must keep its color so the socket bonus still matches")
+	}
+	if item.Gems[1].Disabled {
+		t.Fatal("only the meta gem should be disabled")
+	}
+
+	roundTripped := NewItem(ProtoToEquipmentSpec(&proto.EquipmentSpec{Items: []*proto.ItemSpec{item.ToItemSpecProto()}})[0])
+	if !roundTripped.Gems[0].Disabled {
+		t.Fatal("meta gem reactivated after a proto round-trip")
+	}
+}
+
+// The request path is *proto.EquipmentSpec -> ProtoToEquipment -> Character.Equipment, so check the
+// flag survives that seam and that the head item really does keep its socket bonus.
+func TestDisabledMetaGemFromRequestKeepsSocketBonus(t *testing.T) {
+	const testItemID, testMetaGemID, testRedGemID = 990011, 990012, 990013
+
+	socketBonus := make([]float64, len(stats.Stats{}))
+	socketBonus[stats.Agility] = socketBonusStat
+	metaStats := make([]float64, len(stats.Stats{}))
+	metaStats[stats.Agility] = 216
+	redStats := make([]float64, len(stats.Stats{}))
+	redStats[stats.Agility] = gemStatValue
+
+	addToDatabase(&proto.SimDatabase{
+		Items: []*proto.SimItem{{
+			Id:             testItemID,
+			Name:           "Test Helm 2",
+			Type:           proto.ItemType_ItemTypeHead,
+			GemSockets:     []proto.GemColor{proto.GemColor_GemColorMeta, proto.GemColor_GemColorRed},
+			SocketBonus:    socketBonus,
+			ScalingOptions: map[int32]*proto.ScalingItemProperties{0: {}},
+		}},
+		Gems: []*proto.SimGem{
+			{Id: testMetaGemID, Name: "Test Meta 2", Color: proto.GemColor_GemColorMeta, Stats: metaStats},
+			{Id: testRedGemID, Name: "Test Red 2", Color: proto.GemColor_GemColorRed, Stats: redStats},
+		},
+	})
+
+	equipmentFor := func(metaDisabled bool) Equipment {
+		return ProtoToEquipment(&proto.EquipmentSpec{Items: []*proto.ItemSpec{{
+			Id:              testItemID,
+			Gems:            []int32{testMetaGemID, testRedGemID},
+			MetaGemDisabled: metaDisabled,
+		}}})
+	}
+
+	active := equipmentFor(false)
+	if got := ItemEquipmentGemAndEnchantStats(*active.Head())[stats.Agility]; got != 216+gemStatValue+socketBonusStat {
+		t.Fatalf("active meta gem: expected %v agility, got %v", 216+gemStatValue+socketBonusStat, got)
+	}
+
+	inactive := equipmentFor(true)
+	if !inactive.Head().Gems[0].Disabled {
+		t.Fatal("meta_gem_disabled did not survive the proto -> Equipment conversion")
+	}
+	// Meta gem stats gone, head socket bonus intact -- the bug this whole change is about.
+	if got := ItemEquipmentGemAndEnchantStats(*inactive.Head())[stats.Agility]; got != gemStatValue+socketBonusStat {
+		t.Fatalf("disabled meta gem: expected %v agility, got %v", gemStatValue+socketBonusStat, got)
+	}
+}

--- a/sim/core/item_effects.go
+++ b/sim/core/item_effects.go
@@ -81,6 +81,9 @@ func (equipment *Equipment) applyItemEffects(agent Agent, registeredItemEffects 
 
 		if includeGemEffects {
 			for _, g := range eq.Gems {
+				if g.Disabled {
+					continue
+				}
 				if applyGemEffect, ok := itemEffects[g.ID]; ok {
 					applyGemEffect(agent)
 				}

--- a/ui/core/components/gear_picker/gear_picker.tsx
+++ b/ui/core/components/gear_picker/gear_picker.tsx
@@ -77,6 +77,7 @@ export class ItemPicker extends Component {
 
 	private quickSwapEnchantPopover: QuickSwapList<Enchant> | null = null;
 	private quickSwapGemPopover: QuickSwapList<Gem>[] = [];
+	private simInitialized = false;
 
 	constructor(parent: HTMLElement, gearPicker: GearPicker, simUI: SimUI, player: Player<any>, slot: ItemSlot) {
 		super(parent, 'item-picker-root');
@@ -97,12 +98,15 @@ export class ItemPicker extends Component {
 
 			this.itemElem.iconElem.addEventListener('click', openGearSelector);
 			this.itemElem.nameElem.addEventListener('click', openGearSelector);
+			this.simInitialized = true;
 			this.addQuickEnchantHelpers();
 		});
 
 		player.gearChangeEmitter.on(() => {
 			this.item = this.player.getEquippedItem(this.slot);
 			if (this._equippedItem) {
+				// The slot may have been empty at sim init, in which case the popover is built here.
+				this.addQuickEnchantHelpers();
 				if (this._equippedItem !== this.quickSwapEnchantPopover?.item) {
 					this.quickSwapEnchantPopover?.update({ item: this._equippedItem });
 				}
@@ -176,7 +180,7 @@ export class ItemPicker extends Component {
 	}
 
 	private addQuickEnchantHelpers() {
-		if (!this._equippedItem) return;
+		if (!this.simInitialized || this.quickSwapEnchantPopover || !this._equippedItem) return;
 		const openEnchantSelector = () => this.openSelectorModal(SelectorModalTabs.Enchants);
 		this.itemElem.enchantElem.addEventListener('click', event => {
 			event?.preventDefault();

--- a/ui/core/components/gear_picker/quick_enchant_popover.tsx
+++ b/ui/core/components/gear_picker/quick_enchant_popover.tsx
@@ -1,5 +1,5 @@
-import { Player } from '../../player';
 import i18n from '../../../i18n/config';
+import { Player } from '../../player';
 import { ItemSlot } from '../../proto/common';
 import { UIEnchant as Enchant } from '../../proto/ui.js';
 import { EquippedItem } from '../../proto_utils/equipped_item';
@@ -31,8 +31,6 @@ export const addQuickEnchantPopover = (player: Player<any>, tooltipElement: HTML
 			}));
 		},
 		onItemClick: clickedItem => {
-			// Read the equipped item at click time. The one captured when this popover was built
-			// goes stale as soon as the slot changes, and writing it back would revert the item.
 			const currentItem = player.getEquippedItem(itemSlot);
 			if (!currentItem) return;
 			player.equipItem(TypedEvent.nextEventID(), itemSlot, currentItem.withEnchant(clickedItem));

--- a/ui/core/components/gear_picker/quick_enchant_popover.tsx
+++ b/ui/core/components/gear_picker/quick_enchant_popover.tsx
@@ -16,7 +16,7 @@ export const addQuickEnchantPopover = (player: Player<any>, tooltipElement: HTML
 		},
 		item,
 		getItems: (currentItem: EquippedItem) => {
-			const eligibleEnchants = player.sim.db.getEnchants(itemSlot);
+			const eligibleEnchants = player.getEnchants(itemSlot);
 			const favoriteEnchants = player.sim.getFilters().favoriteEnchants;
 			const eligibleFavoriteEnchants = favoriteEnchants
 				?.map(favoriteId => {
@@ -31,7 +31,11 @@ export const addQuickEnchantPopover = (player: Player<any>, tooltipElement: HTML
 			}));
 		},
 		onItemClick: clickedItem => {
-			player.equipItem(TypedEvent.nextEventID(), itemSlot, item.withEnchant(clickedItem));
+			// Read the equipped item at click time. The one captured when this popover was built
+			// goes stale as soon as the slot changes, and writing it back would revert the item.
+			const currentItem = player.getEquippedItem(itemSlot);
+			if (!currentItem) return;
+			player.equipItem(TypedEvent.nextEventID(), itemSlot, currentItem.withEnchant(clickedItem));
 		},
 		footerButton: {
 			label: i18n.t('gear_tab.gear_picker.quick_popovers.favorite_enchants.open_enchants'),

--- a/ui/core/components/gear_picker/quick_gem_popover.tsx
+++ b/ui/core/components/gear_picker/quick_gem_popover.tsx
@@ -35,7 +35,11 @@ export const addQuickGemPopover = (
 			}));
 		},
 		onItemClick: clickedItem => {
-			player.equipItem(TypedEvent.nextEventID(), itemSlot, item.withGem(clickedItem, socketIdx));
+			// Read the equipped item at click time. The one captured when this popover was built
+			// goes stale as soon as the slot changes, and writing it back would revert the item.
+			const currentItem = player.getEquippedItem(itemSlot);
+			if (!currentItem) return;
+			player.equipItem(TypedEvent.nextEventID(), itemSlot, currentItem.withGem(clickedItem, socketIdx));
 		},
 		footerButton: {
 			label: i18n.t('gear_tab.gear_picker.quick_popovers.favorite_gems.open_gems'),

--- a/ui/core/components/gear_picker/quick_gem_popover.tsx
+++ b/ui/core/components/gear_picker/quick_gem_popover.tsx
@@ -1,5 +1,5 @@
-import { Player } from '../../player';
 import i18n from '../../../i18n/config';
+import { Player } from '../../player';
 import { ItemSlot } from '../../proto/common';
 import { EquippedItem } from '../../proto_utils/equipped_item';
 import { TypedEvent } from '../../typed_event';
@@ -35,8 +35,6 @@ export const addQuickGemPopover = (
 			}));
 		},
 		onItemClick: clickedItem => {
-			// Read the equipped item at click time. The one captured when this popover was built
-			// goes stale as soon as the slot changes, and writing it back would revert the item.
 			const currentItem = player.getEquippedItem(itemSlot);
 			if (!currentItem) return;
 			player.equipItem(TypedEvent.nextEventID(), itemSlot, currentItem.withGem(clickedItem, socketIdx));

--- a/ui/core/proto_utils/gear.ts
+++ b/ui/core/proto_utils/gear.ts
@@ -326,16 +326,6 @@ export class Gear extends BaseGear {
 		return this;
 	}
 
-	withoutMetaGem(): Gear {
-		const headItem = this.getEquippedItem(ItemSlot.ItemSlotHead);
-		const metaGem = this.getMetaGem();
-		if (headItem && metaGem) {
-			return this.withEquippedItem(ItemSlot.ItemSlotHead, headItem.removeGemsWithId(metaGem.id));
-		} else {
-			return this;
-		}
-	}
-
 	withoutGems(ignoreSlots?: Set<ItemSlot>, ignoreMeta?: boolean): Gear {
 		let curGear: Gear = this;
 		const metaGem = this.getMetaGem();

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -19,7 +19,9 @@ import {
 } from './proto/api.js';
 import {
 	ArmorType,
+	EquipmentSpec,
 	Faction,
+	ItemSlot,
 	Profession,
 	PseudoStat,
 	RangedWeaponType,
@@ -57,6 +59,18 @@ export type RunSimOptions = {
 const WASM_CONCURRENCY_STORAGE_KEY = `${LOCAL_STORAGE_PREFIX}_wasmconcurrency`;
 
 // Core Sim module which deals only with api types, no UI-related stuff.
+// The backend needs an inactive meta gem left in its socket so the item's socket bonus still
+// applies, while ignoring the gem's own stats and effect. Gear.asSpec() is deliberately left
+// alone so this derived flag never reaches saved settings or shared gear links.
+const gearAsBackendSpec = (gear: Gear): EquipmentSpec => {
+	const spec = gear.asSpec();
+	const headIdx = gear.getItemSlots().indexOf(ItemSlot.ItemSlotHead);
+	if (headIdx >= 0 && gear.hasInactiveMetaGem()) {
+		spec.items[headIdx].metaGemDisabled = true;
+	}
+	return spec;
+};
+
 export class Sim {
 	private readonly workerPool: WorkerPool;
 
@@ -215,20 +229,16 @@ export class Sim {
 
 				const isEnchanter = [player.profession1, player.profession2].includes(Profession.Enchanting);
 
-				// Disable meta gem if inactive.
-				if (gear.hasInactiveMetaGem()) {
-					gear = gear.withoutMetaGem();
-					gearChanged = true;
-				}
-
 				// Remove Ring Enchants if not enchanter
 				if (!isEnchanter) {
 					gear = gear.withoutEnchanting();
 					gearChanged = true;
 				}
 
-				if (gearChanged) {
-					player.equipment = gear.asSpec();
+				// An inactive meta gem is flagged rather than removed, so that flag still has to
+				// reach the backend even when nothing else about the gear changed.
+				if (gearChanged || gear.hasInactiveMetaGem()) {
+					player.equipment = gearAsBackendSpec(gear);
 				}
 
 				extendPlayerProtoWithMissingEffects(player, this.db);
@@ -316,14 +326,8 @@ export class Sim {
 			const request = this.makeRaidSimRequest(false);
 			const player = request.raid!.parties[0].players[0];
 
-			// Remove any inactive meta gems, since the backend doesn't have its own validation.
-			// Disable meta gem if inactive.
-			if (gear.hasInactiveMetaGem()) {
-				gear = gear.withoutMetaGem();
-			}
-
 			player.database = gear.toDatabase(this.db);
-			player.equipment = gear.asSpec();
+			player.equipment = gearAsBackendSpec(gear);
 			if (player.consumables) player.consumables = gear.adjustImbues(player.consumables);
 
 			request.raid!.parties[0].players[0] = player;
@@ -439,14 +443,8 @@ export class Sim {
 
 		const player = raidProto.parties[0].players[0];
 
-		// Remove any inactive meta gems, since the backend doesn't have its own validation.
-		// Disable meta gem if inactive.
-		if (gear.hasInactiveMetaGem()) {
-			gear = gear.withoutMetaGem();
-		}
-
 		player.database = gear.toDatabase(this.db);
-		player.equipment = gear.asSpec();
+		player.equipment = gearAsBackendSpec(gear);
 
 		extendPlayerProtoWithMissingEffects(player, this.db);
 		raidProto.parties[0].players[0] = player;


### PR DESCRIPTION
Fixes two bugs reported by a user, plus two related defects found while tracing them. The MoP half is wowsims/mop#1560 — note that it *deletes* the meta gem condition logic rather than fixing it, because MoP meta gems have no colour requirements and the code there was dead Cata leftovers. TBC meta gems do have requirements (18 conditions are registered and I confirmed they fire), so here it is fixed.

## 1. Selecting a favourite enchant also swapped the item and its gems

`addQuickEnchantPopover` passed the currently equipped item in at construction, and `onItemClick` closed over it. `ItemPicker.addQuickEnchantHelpers()` runs **exactly once** per slot (from `player.sim.waitForInit()`), and its tippy target is a stable element, so the popover is never rebuilt. `QuickSwapList.update()` merges a fresh `config.item` — which is why the rendered list and the "active" highlight always looked right — but it never replaces `config.onItemClick`.

So clicking a favourite enchant equipped `<item as it was at sim init>.withEnchant(new)`, reverting the item id, gems and random suffix.

Repro (deterministic):
1. Load a spec page and let the sim finish initialising.
2. Change an item, or re-gem it.
3. Hover its enchant row and click a favourited enchant.
4. The item and gems snap back to their page-load state.

Both popovers now read `player.getEquippedItem(slot)` at click time. `quick_gem_popover.tsx` had the identical defect; it is currently masked because `addQuickGemHelpers()` is re-run on every `gearChangeEmitter`, but it is fixed the same way.

## 2. An inactive meta gem also removed the head item's socket bonus

The UI removed the meta gem from its socket before sending the request. That left an empty meta socket, so `ColorIntersects(Meta, Unknown)` returned false and `ItemEquipmentGemAndEnchantStats` skipped the head item's **entire** `SocketBonus`, not just the meta gem's stats. In-game the socket bonus depends only on gem colours, and a meta gem stays meta-coloured whether or not its requirements are met.

The gem now stays socketed and is flagged with `ItemSpec.meta_gem_disabled`. The backend skips its stats, its item effect and `HasMetaGemEquipped`, while the socket-bonus check still sees its colour.

Verified live in the dev UI with Relentless Earthstorm Diamond (needs 2 red / 2 yellow / 2 blue). With the coloured gems stripped so the condition cannot be met, the head item's spec goes from `gems: [0, 0]` before this change — meta gem gone, socket bonus lost — to `gems: [32409, 0]` with `metaGemDisabled: true` after it.

Two details worth review:
- `Item.ToItemSpecProto()` emits the flag, so anything that round-trips equipment back through `NewItem` does not silently reactivate the gem.
- `Gear.asSpec()` is left untouched, so the derived flag never reaches saved settings or shared gear links. A module-private `gearAsBackendSpec()` in `sim.ts` wraps the backend-facing spec builds instead.

## Also fixed

- A slot that was **empty at sim init** never got an enchant quick-swap popover for the rest of the session (`addQuickEnchantHelpers` early-returned and was never retried). It is now built on the first gear change, gated on init so "Show Quick Swap" is still respected.
- The enchant quick-swap listed favourites straight from `sim.db.getEnchants(slot)`, without the `canEquipEnchant` filter that the selector modal applies. It now uses `player.getEnchants(slot)`, so an enchant this character cannot use — a ring enchant on a non-enchanter, for instance — no longer appears there. Flagging this one explicitly since it changes which favourites show up.

## Testing

New `sim/core/gem_test.go` covers socket bonuses for gems generally rather than just the meta case:

| test | what it covers |
|---|---|
| `TestSocketBonusForEveryColorCombination` | all 8 socket colours x all 8 gem colours, checked against a hand-written table of the matching rules rather than against `ColorIntersects` itself, so it is an independent statement of the rules |
| `TestSocketBonusForEveryGemInDatabase` | the same invariant over **every one of the 214 gems** in the database, using each gem's real colour and stats — so a gem whose colour is mis-parsed on import is caught too |
| `TestDisabledGemKeepsSocketBonusButLosesItsStats` | the disabled-gem rule across every colour combination, not just meta |
| `TestEveryDisabledMetaGemInDatabaseKeepsSocketBonus` | all 18 database meta gems: disabled, they contribute nothing but the socket bonus survives — the bug this PR fixes |
| `TestEmptySocketNeverEarnsSocketBonus` | empty sockets of every colour |
| `TestDisabledMetaGemSurvivesProtoRoundTrip` / `...FromRequestKeepsSocketBonus` | the flag survives `Item -> ItemSpec proto -> Item` and the real request path `proto.EquipmentSpec -> ProtoToEquipment -> Equipment` |

The database-backed tests skip cleanly without `-tags with_db`. Coverage was checked by breaking `ColorIntersects` (dropping purple from the red socket's matches): the colour matrix fails, and the database sweep fails naming a real gem ("Purified Jaggal Pearl").

**One pre-existing quirk surfaced, documented rather than changed:** `ColorIntersects` treats prismatic as matching anything on either side, so an *empty* prismatic socket still earns the socket bonus. No TBC item has a prismatic socket, so it cannot be reached here, and `TestNoTBCItemHasAPrismaticSocket` asserts that stays true. Worth knowing that MoP has 1275 items with prismatic sockets, where the same code path is reachable — out of scope for this PR.
- `go test -tags with_db ./sim/...` — 8789 pass, no fixture movement. No fixtures regenerated. (`sim/web` does not build in a fresh worktree because the generated `binary_dist` package is gitignored; unrelated to this change.)
- `npm run type-check` and `npm run lint:js` clean (lint warnings on the touched files are pre-existing import-sort ones).
- The UI defects were additionally browser-verified against pre-fix code on the MoP side, where the two repos share these files byte-for-byte.

Generated protos are gitignored, so `make proto` adds nothing to the diff.
