### PR TITLE
build(wasm): optimize module output, add opt-in wasm dev server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,9 @@ jobs:
             - name: Install npm dependencies
               run: npm ci
 
+            - name: Install binaryen
+              run: sudo apt-get update && sudo apt-get install -y binaryen
+
             - name: Build 🔧
               run: |
                   make dist/tbc/.dirstamp

--- a/makefile
+++ b/makefile
@@ -89,13 +89,20 @@ host_%: $(OUT_DIR) node_modules
 wasm: $(OUT_DIR)/lib.wasm
 
 # Builds the generic .wasm, with all items included.
+WASM_FEATURES := --enable-sign-ext --enable-nontrapping-float-to-int --enable-mutable-globals --enable-bulk-memory
 $(OUT_DIR)/lib.wasm: sim/wasm/* sim/core/proto/api.pb.go $(filter-out sim/core/items/all_items.go, $(call rwildcard,sim,*.go))
 	@echo "Starting webassembly compile now..."
-	@if GOOS=js GOARCH=wasm go build -o ./$(OUT_DIR)/lib.wasm ./sim/wasm/; then \
+	@if GOWASM=satconv,signext GOOS=js GOARCH=wasm go build -o ./$(OUT_DIR)/lib.wasm ./sim/wasm/; then \
 		printf "\033[1;32mWASM compile successful.\033[0m\n"; \
 	else \
 		printf "\033[1;31mWASM COMPILE FAILED\033[0m\n"; \
 		exit 1; \
+	fi
+	@if command -v wasm-opt >/dev/null 2>&1; then \
+		echo "Optimizing wasm with wasm-opt..."; \
+		wasm-opt -O3 $(WASM_FEATURES) $(OUT_DIR)/lib.wasm -o $(OUT_DIR)/lib.wasm.tmp && mv -f $(OUT_DIR)/lib.wasm.tmp $(OUT_DIR)/lib.wasm; \
+	else \
+		printf "\033[1;33mwasm-opt not found -- skipping optimization (install binaryen to enable).\033[0m\n"; \
 	fi
 
 $(OUT_DIR)/assets/%: assets/%

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -18,8 +18,9 @@ export const BASE_PATH = path.resolve(__dirname, 'ui');
 export const OUT_DIR = path.join(__dirname, 'dist', 'tbc');
 
 function serveExternalAssets() {
+	const simWorker = process.env.WASM_WORKER ? '/tbc/sim_worker.js' : '/tbc/local_worker.js';
 	const workerMappings = {
-		'/tbc/sim_worker.js': '/tbc/local_worker.js',
+		'/tbc/sim_worker.js': simWorker,
 		'/tbc/net_worker.js': '/tbc/net_worker.js',
 		'/tbc/lib.wasm': '/tbc/lib.wasm',
 		'/tbc/reforge_worker.js': '/tbc/reforge_worker.js',


### PR DESCRIPTION
Port of wowsims/mop#1561. No sim code touched.

## `GOWASM=satconv,signext`

Lets the Go compiler emit the non-trapping float→int and sign-extension opcodes instead of emulating them. Both are baseline in every browser the sim supports (Chrome 75+, Firefox 64+, Safari 15+).

## Optional `wasm-opt -O3`

Go's toolchain never runs its wasm output through a wasm optimizer. This adds that step, guarded by `command -v` — a checkout without binaryen builds exactly as before, just unoptimized, so it is not a new hard build dependency. CI installs binaryen so the deployed module gets it.

`WASM_FEATURES` is pinned to the opcodes Go actually emits rather than `--all-features`, so binaryen cannot introduce instructions outside that browser baseline. It has to stay in step with `GOWASM`.

**Size:** TBC serves `lib.wasm` uncompressed, so this lands directly — **20.46 MB → 18.61 MB (−9.0%)**. (On MoP the module is gzipped before shipping and gzip closed almost all of the same reduction.)

## `WASM_WORKER=1` for the dev server

`vite.config.mts` hard-mapped `/tbc/sim_worker.js` → `/tbc/local_worker.js`, which is the HTTP worker. So the dev server always routed sims to the Go backend and the in-browser wasm path could not be exercised locally at all. `WASM_WORKER=1 npx vite serve` now serves the real wasm worker. Default behaviour unchanged.

## On performance

I measured this on the MoP side, carefully, and found **no throughput gain**: a paired A/B (8 alternating runs, same commit) gives **+0.79%, 95% CI −3.6% to +5.2%**, and a sweep across 1–18 workers is likewise inside the noise. An earlier +7% figure turned out to be measurement error from comparing against a baseline captured under different machine load.

So this is proposed as **build hygiene**, not a performance fix, and the makefile makes no perf claim.

## Verification

- Both build paths exercised: with `wasm-opt` on `PATH` (optimizes) and without (warns, still produces a valid `lib.wasm`). No temp file left behind.
- Optimized module boot-tested under Node with `wasm_exec.js`: the Go runtime starts, `main()` runs, exports register, and it reaches `wasmready`.