### PR TITLE
Blizzard and Hurricane ticks cannot crit

### DIFF
--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -1477,8 +1477,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p1_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2380.37217
-  tps: 1893.60562
+  dps: 2221.49007
+  tps: 1785.47148
  }
 }
 dps_results: {
@@ -1498,8 +1498,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p1_a-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 768.50767
-  tps: 739.35456
+  dps: 739.07519
+  tps: 709.99541
  }
 }
 dps_results: {
@@ -1519,8 +1519,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p2_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3023.50466
-  tps: 2323.56756
+  dps: 2777.77161
+  tps: 2151.34887
  }
 }
 dps_results: {
@@ -1540,8 +1540,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p2_a-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 870.52861
-  tps: 825.58972
+  dps: 832.12686
+  tps: 787.29797
  }
 }
 dps_results: {
@@ -1561,8 +1561,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p3-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3710.16561
-  tps: 2836.85182
+  dps: 3368.58295
+  tps: 2595.89396
  }
 }
 dps_results: {
@@ -1582,8 +1582,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p3-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1344.96329
-  tps: 1299.76249
+  dps: 1264.30363
+  tps: 1219.06616
  }
 }
 dps_results: {
@@ -1603,8 +1603,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p4-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3793.49775
-  tps: 2894.86431
+  dps: 3459.29605
+  tps: 2660.51201
  }
 }
 dps_results: {
@@ -1624,8 +1624,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p4-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1275.88872
-  tps: 1230.73655
+  dps: 1204.92959
+  tps: 1159.85076
  }
 }
 dps_results: {
@@ -1645,8 +1645,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p5-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4219.09985
-  tps: 3205.81492
+  dps: 3819.31502
+  tps: 2925.34887
  }
 }
 dps_results: {
@@ -1666,8 +1666,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-p5-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1334.8413
-  tps: 1289.58984
+  dps: 1329.16263
+  tps: 1283.54451
  }
 }
 dps_results: {
@@ -1687,8 +1687,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p1_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2337.53669
-  tps: 1861.87977
+  dps: 2176.71326
+  tps: 1749.58671
  }
 }
 dps_results: {
@@ -1708,8 +1708,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p1_a-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 767.78799
-  tps: 738.86161
+  dps: 736.50774
+  tps: 706.84136
  }
 }
 dps_results: {
@@ -1729,8 +1729,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p2_a-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2937.48009
-  tps: 2261.93565
+  dps: 2735.86055
+  tps: 2119.36309
  }
 }
 dps_results: {
@@ -1750,8 +1750,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p2_a-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 867.11794
-  tps: 822.25504
+  dps: 829.62732
+  tps: 784.76442
  }
 }
 dps_results: {
@@ -1771,8 +1771,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p3-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3657.89499
-  tps: 2796.38102
+  dps: 3324.04728
+  tps: 2562.68762
  }
 }
 dps_results: {
@@ -1792,8 +1792,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p3-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1143.02499
-  tps: 1097.97351
+  dps: 1092.78721
+  tps: 1047.84573
  }
 }
 dps_results: {
@@ -1813,8 +1813,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p4-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3755.12029
-  tps: 2867.82489
+  dps: 3429.99777
+  tps: 2638.59468
  }
 }
 dps_results: {
@@ -1834,8 +1834,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p4-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1257.65187
-  tps: 1212.42902
+  dps: 1200.16793
+  tps: 1154.94508
  }
 }
 dps_results: {
@@ -1855,8 +1855,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p5-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4148.06877
-  tps: 3152.41735
+  dps: 3776.26267
+  tps: 2890.71419
  }
 }
 dps_results: {
@@ -1876,8 +1876,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-Tauren-p5-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1271.33437
-  tps: 1225.93889
+  dps: 1182.14568
+  tps: 1136.89687
  }
 }
 dps_results: {

--- a/sim/druid/hurricane.go
+++ b/sim/druid/hurricane.go
@@ -56,8 +56,6 @@ func (druid *Druid) registerHurricaneSpell() {
 		BonusCoefficient: 0.129,
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
-			// Cannot crit, the same way Blizzard cannot. 1472 Hurricane ticks across TBC logs
-			// land as plain hits.
 			spell.CalcAndDealAoeDamage(sim, 206, spell.OutcomeMagicHit)
 		},
 	})

--- a/sim/druid/hurricane.go
+++ b/sim/druid/hurricane.go
@@ -56,7 +56,9 @@ func (druid *Druid) registerHurricaneSpell() {
 		BonusCoefficient: 0.129,
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
-			spell.CalcAndDealAoeDamage(sim, 206, spell.OutcomeMagicHitAndCrit)
+			// Cannot crit, the same way Blizzard cannot. 1472 Hurricane ticks across TBC logs
+			// land as plain hits.
+			spell.CalcAndDealAoeDamage(sim, 206, spell.OutcomeMagicHit)
 		},
 	})
 }

--- a/sim/mage/blizzard.go
+++ b/sim/mage/blizzard.go
@@ -25,9 +25,6 @@ func (mage *Mage) registerBlizzardSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
-			// Cannot crit. The tick spell carries SPELL_ATTR2_CANT_CRIT while the channel that
-			// casts it does not, and 384 Blizzard ticks across TBC logs land as plain hits in
-			// fights where every other AoE, Flamestrike included, crits normally.
 			spell.CalcAndDealAoeDamage(sim, 184, spell.OutcomeMagicHit)
 		},
 	})

--- a/sim/mage/blizzard.go
+++ b/sim/mage/blizzard.go
@@ -25,7 +25,10 @@ func (mage *Mage) registerBlizzardSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
-			spell.CalcAndDealAoeDamage(sim, 184, spell.OutcomeMagicHitAndCrit)
+			// Cannot crit. The tick spell carries SPELL_ATTR2_CANT_CRIT while the channel that
+			// casts it does not, and 384 Blizzard ticks across TBC logs land as plain hits in
+			// fights where every other AoE, Flamestrike included, crits normally.
+			spell.CalcAndDealAoeDamage(sim, 184, spell.OutcomeMagicHit)
 		},
 	})
 


### PR DESCRIPTION
Blizzard and Hurricane resolved their ticks through `OutcomeMagicHitAndCrit`. Neither should crit. This came out of following up the DBC work in #332 on the `SPELL_ATTR2_CANT_CRIT` attribute, and unlike most of that follow-up it survived checking.

## Spell data

The split is clean — the attribute sits on the tick spell, never on the channel that casts it:

| spell | channel | `CANT_CRIT` | tick | `CANT_CRIT` |
|---|---|---|---|---|
| Blizzard | 27085 | no | 42198, 42208 | **yes** |
| Hurricane | 27012 | no | 42230, 42231 | **yes** |
| Rain of Fire | 27212 | no | 42223, 42224 | **yes** |

Flamestrike (27086) is the control: a direct AoE, no attribute, and it crits.

I initially wrote these 42xxx ids off as a later expansion's, since the dump has 17 attribute columns. That was wrong twice over — `blizzard.go` already cites `wago.tools/db2/SpellEffect?build=2.5.5.65295&filter[SpellID]=42208` in a comment, and the ids show up directly in TBC Anniversary combat logs.

## Logs

Warcraft Logs, TBC Anniversary Hyjal trash:

| ability | landed hits | crits |
|---|---|---|
| Hurricane 42230 | 1472 | **0** |
| Blizzard 42198 | 378 | **0** |

Samples are 13 pulls from `RdNfCVH8XrATMtmb` and 2 from `cjBp8JNWFPm13ndC`. Controls in the same fights: 513 and 627 crits logged overall, with Flamestrike at 16 crits in 107 hits, Seed of Corruption 100 in 311, and Magma Totem 10 in 148. At any realistic crit rate a run of 1472 without one is not chance.

Rain of Fire carries the same attribute but is not implemented here beyond a spell-mask constant, so nothing changes for it. That also explains its absence from the logs — TBC destruction warlocks AoE with Seed of Corruption.

## Impact

Balance druid multi-target loses roughly 30 to 400 dps depending on phase. Single target is untouched, and no other spec moves — Blizzard is not in any tested mage APL, so the mage fixtures do not shift even though the code path changed.

Happy to drop the Blizzard half if you would rather land these separately, though the evidence is the same shape for both.
