### PR TITLE
fix(logs): restore wowhead tooltip data on repeated spells

### DIFF
--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -1273,8 +1273,8 @@ export class Timeline extends ResultComponent {
 				<div className="timeline-tooltip-header">
 					{showPlayerLabel ? (
 						<>
-							<img className="timeline-tooltip-icon" src="${player.iconUrl}" />
-							<span className="" style="color: ${colorOverride}">
+							<img className="timeline-tooltip-icon" src={player.iconUrl} />
+							<span className="" style={{ color: colorOverride }}>
 								{player.label}
 							</span>
 							<span> - </span>

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -242,13 +242,11 @@ export class ActionId {
 		elem: HTMLElement | HTMLElement[],
 		params?: Omit<WowheadTooltipItemParams, 'itemId'> | Omit<WowheadTooltipSpellParams, 'spellId'>,
 	) {
-		(this.itemId
+		const url = await (this.itemId
 			? ActionId.makeItemTooltipData(this.itemId, params)
-			: ActionId.makeSpellTooltipData(this.spellIdTooltipOverride || this.spellId, params)
-		).then(url => {
-			(Array.isArray(elem) ? elem : [elem]).forEach(e => {
-				if (e) e.dataset.wowhead = url;
-			});
+			: ActionId.makeSpellTooltipData(this.spellIdTooltipOverride || this.spellId, params));
+		(Array.isArray(elem) ? elem : [elem]).forEach(e => {
+			if (e) e.dataset.wowhead = url;
 		});
 	}
 

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -238,10 +238,7 @@ export class ActionId {
 		}
 	}
 
-	async setWowheadDataset(
-		elem: HTMLElement | HTMLElement[],
-		params?: Omit<WowheadTooltipItemParams, 'itemId'> | Omit<WowheadTooltipSpellParams, 'spellId'>,
-	) {
+	async setWowheadDataset(elem: HTMLElement | HTMLElement[], params?: Omit<WowheadTooltipItemParams, 'itemId'> | Omit<WowheadTooltipSpellParams, 'spellId'>) {
 		const url = await (this.itemId
 			? ActionId.makeItemTooltipData(this.itemId, params)
 			: ActionId.makeSpellTooltipData(this.spellIdTooltipOverride || this.spellId, params));

--- a/ui/core/proto_utils/logs_parser.tsx
+++ b/ui/core/proto_utils/logs_parser.tsx
@@ -202,8 +202,10 @@ export class SimLog {
 		) as HTMLAnchorElement;
 		this.actionId?.setBackground(iconElem);
 		this.actionId?.setWowheadHref(actionAnchor);
-		this.actionId?.setWowheadDataset(actionAnchor, { useBuffAura: isAura });
-		if (cacheKey) cachedActionIdLink.set(cacheKey, actionAnchor.cloneNode(true) as HTMLAnchorElement);
+		const datasetSet = this.actionId?.setWowheadDataset(actionAnchor, { useBuffAura: isAura }) ?? Promise.resolve();
+		if (cacheKey) {
+			datasetSet.then(() => cachedActionIdLink.set(cacheKey, actionAnchor.cloneNode(true) as HTMLAnchorElement)).catch(() => {});
+		}
 		return actionAnchor;
 	}
 

--- a/ui/core/proto_utils/logs_parser.tsx
+++ b/ui/core/proto_utils/logs_parser.tsx
@@ -405,24 +405,24 @@ export class DamageDealtLog extends SimLog {
 						{this.miss
 							? 'Miss'
 							: this.dodge
-							? 'Dodge'
-							: this.parry
-							? 'Parry'
-							: this.block
-							? this.crit
-								? 'Critical Block'
-								: this.glance
-								? 'Blocked Glance'
-								: 'Block'
-							: this.glance
-							? 'Glance'
-							: this.crit
-							? 'Crit'
-							: this.crush
-							? 'Crush'
-							: this.tick
-							? 'Tick'
-							: 'Hit'}
+								? 'Dodge'
+								: this.parry
+									? 'Parry'
+									: this.block
+										? this.crit
+											? 'Critical Block'
+											: this.glance
+												? 'Blocked Glance'
+												: 'Block'
+										: this.glance
+											? 'Glance'
+											: this.crit
+												? 'Crit'
+												: this.crush
+													? 'Crush'
+													: this.tick
+														? 'Tick'
+														: 'Hit'}
 					</>
 				)}
 				{` `}
@@ -803,14 +803,7 @@ export class ResourceChangedLog extends SimLog {
 	readonly isSpend: boolean;
 	readonly total: number;
 
-	constructor(
-		params: SimLogParams,
-		resourceType: ResourceType,
-		valueBefore: number,
-		valueAfter: number,
-		isSpend: boolean,
-		total: number,
-	) {
+	constructor(params: SimLogParams, resourceType: ResourceType, valueBefore: number, valueAfter: number, isSpend: boolean, total: number) {
 		super(params);
 		this.resourceType = resourceType;
 		this.valueBefore = valueBefore;


### PR DESCRIPTION
Ported from the review round on [wowsims/mop#1563](https://github.com/wowsims/mop/pull/1563). That review found 15 issues, but most of them cover the virtualised log list and windowed timeline that PR introduces — code this repo does not have. Three findings apply here, and I checked each against the actual files rather than assuming from the MoP diff.

## The real bug: tooltips missing on repeated spells

`ActionId.setWowheadDataset()` is declared `async`, but wrote `data-wowhead` inside a `.then()` on a promise it never awaited — so the promise it handed back resolved *before* its own write. `SimLog.newActionIdLink()` then cloned the anchor into `cachedActionIdLink` synchronously, capturing it before the attribute landed.

The effect, given `cachedHTML` memoizes each log's rendered element:

- the **first** log naming a spell keeps the live anchor, which eventually receives the attribute — tooltip works
- **every later** log naming that spell is built from `cachedLink.cloneNode(true)`, a frozen copy with no tooltip parameters at all — no tooltip

That includes `useBuffAura`, which is what makes an aura link show the buff rather than the spell.

`setWowheadDataset()` now awaits the URL before writing, and the link is cloned into the cache once that resolves. In the window before it lands, a second log for the same spell simply misses the cache and builds its own anchor — correct, if marginally more work.

## Latent: `dpsTooltip` built its header from literal strings

```jsx
<img className="timeline-tooltip-icon" src="${player.iconUrl}" />
<span className="" style="color: ${colorOverride}">
```

Double quotes, so neither a template literal nor a JSX expression: the icon requests a relative URL literally named `${player.iconUrl}`, and the class colour never applies. `threatTooltip` immediately below already does it correctly with `src={player.iconUrl}` / `style={{ color: colorOverride }}`.

This only renders when `colorOverride` is non-empty, which is the multi-player chart path — not reachable from the individual sim UI today. Fixed as a latent bug, matching the MoP change.

## Deliberately not ported

The same review made `CacheHandler.get()` refresh recency (true LRU). Here `cachedActionIdLink` is uncapped and `simResultsCache` keeps 2 entries, so recency-vs-insertion eviction has no beneficiary in this repo. Left alone.

Everything else in that review — the tab-deferral latch, the row-window collapse at zero width, the `VirtualList` clamp and striping fixes, the log export scope and content width — is against code that does not exist here.

## Verification

`npm run type-check` passes (the one reported error is in `ui/core/wasm/`, an untracked local directory, and predates this branch).

`oxfmt` is applied to the touched files, in a separate commit so the fix stays readable on its own. This tree is not oxfmt-clean on master — 77 files fail `--check` — so the formatter also reflows a ternary chain in `DamageDealtLog` and two signatures that this branch does not otherwise touch.

The equivalent fix **is** verified in the browser on MoP — 25/25 log links carry `data-wowhead` after a full scroll round-trip, with `buff=1` intact on aura links. I could not re-run that here: port 3333 was occupied and vite serves a prebuilt worker bundle, so the sim would not run. Worth a manual check of the log tab before merging — open a log and confirm the second and later occurrences of a spell still show a tooltip.

https://claude.ai/code/session_01NKWyHhMwE3ZtZLvzm8rF3K
