### PR TITLE
Stack percent damage modifiers per DBC aura type

### DIFF
--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -220,6 +220,7 @@ func (druid *Druid) Initialize() {
 
 func (druid *Druid) RegisterBaselineSpells() {
 	druid.registerInnervateCD()
+	druid.registerThornsSpell()
 	druid.registerFormBreakingConsumes()
 }
 

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -18,7 +18,7 @@ func (druid *Druid) ApplyTalents() {
 	druid.applyStarlightWrath()
 	druid.applyFocusedStarlight()
 	druid.applyImprovedMoonfire()
-	druid.applyBrambles()
+	// Brambles: applied as Thorns aura points in thorns.go
 	druid.applyInsectSwarm()
 	druid.applyNaturesReach()
 	druid.applyVengeance()
@@ -258,18 +258,6 @@ func (druid *Druid) applyInsectSwarm() {
 	}
 
 	druid.registerInsectSwarmSpell()
-}
-
-func (druid *Druid) applyBrambles() {
-	if druid.Talents.Brambles == 0 {
-		return
-	}
-
-	druid.AddStaticMod(core.SpellModConfig{
-		ClassMask:  DruidSpellThorns | DruidSpellEntanglingRoots,
-		Kind:       core.SpellMod_DamageDone_Flat,
-		FloatValue: 0.25 * float64(druid.Talents.Brambles),
-	})
 }
 
 func (druid *Druid) applyStarlightWrath() {

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -267,7 +267,7 @@ func (druid *Druid) applyBrambles() {
 
 	druid.AddStaticMod(core.SpellModConfig{
 		ClassMask:  DruidSpellThorns | DruidSpellEntanglingRoots,
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.25 * float64(druid.Talents.Brambles),
 	})
 }

--- a/sim/druid/thorns.go
+++ b/sim/druid/thorns.go
@@ -1,0 +1,39 @@
+package druid
+
+import (
+	"github.com/wowsims/tbc/sim/core"
+)
+
+// Self-cast Thorns (rank 7). Reuses the core raid-buff aura, passing the
+// druid's own Brambles talent points. If the Thorns raid buff is selected it
+// is already registered (buffs apply before Initialize) and wins; otherwise
+// the self-cast version uses the druid's actual talent.
+func (druid *Druid) registerThornsSpell() {
+	thornsAura := druid.GetAura("Thorns")
+	if thornsAura == nil {
+		thornsAura = core.ThornsAura(druid.GetCharacter(), druid.Talents.Brambles)
+	}
+
+	druid.RegisterSpell(Humanoid, core.SpellConfig{
+		ActionID:       core.ActionID{SpellID: 26992},
+		SpellSchool:    core.SpellSchoolNature,
+		Flags:          core.SpellFlagAPL | core.SpellFlagHelpful,
+		ClassSpellMask: DruidSpellThorns,
+		ProcMask:       core.ProcMaskEmpty,
+
+		ManaCost: core.ManaCostOptions{
+			FlatCost: 400,
+		},
+		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				GCD: core.GCDDefault,
+			},
+		},
+
+		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
+			thornsAura.Activate(sim)
+		},
+
+		RelatedSelfBuff: thornsAura,
+	})
+}

--- a/sim/hunter/item_sets.go
+++ b/sim/hunter/item_sets.go
@@ -173,7 +173,7 @@ var ItemSetGronnstalkersArmor = core.NewItemSet(core.ItemSet{
 		},
 		4: func(agent core.Agent, setBonusAura *core.Aura) {
 			setBonusAura.AttachSpellMod(core.SpellModConfig{
-				Kind:       core.SpellMod_DamageDone_Pct,
+				Kind:       core.SpellMod_DamageDone_Flat,
 				ClassMask:  HunterSpellSteadyShot,
 				FloatValue: 0.1,
 			}).ExposeToAPL(38392)
@@ -347,7 +347,7 @@ func (hunter *Hunter) addPvpGloves() {
 	hunter.RegisterPvPGloveMod(
 		pvpGloveItemIDs,
 		core.SpellModConfig{
-			Kind:       core.SpellMod_DamageDone_Pct,
+			Kind:       core.SpellMod_DamageDone_Flat,
 			ClassMask:  HunterSpellMultiShot,
 			FloatValue: 0.05,
 		})

--- a/sim/hunter/talents.go
+++ b/sim/hunter/talents.go
@@ -371,7 +371,7 @@ func (hunter *Hunter) registerImprovedStings() {
 	}
 
 	hunter.AddStaticMod(core.SpellModConfig{
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		ClassMask:  HunterSpellSerpentSting,
 		FloatValue: 0.06 * float64(hunter.Talents.ImprovedStings),
 	})
@@ -395,7 +395,7 @@ func (hunter *Hunter) registerBarrage() {
 	}
 
 	hunter.AddStaticMod(core.SpellModConfig{
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		ClassMask:  HunterSpellMultiShot | HunterSpellVolley,
 		FloatValue: 0.04 * float64(hunter.Talents.Barrage),
 	})

--- a/sim/paladin/item_sets.go
+++ b/sim/paladin/item_sets.go
@@ -115,7 +115,7 @@ var ItemSetJusticarArmor = core.NewItemSet(core.ItemSet{
 	Bonuses: map[int32]core.ApplySetBonus{
 		2: func(agent core.Agent, setBonusAura *core.Aura) {
 			setBonusAura.AttachSpellMod(core.SpellModConfig{
-				Kind:       core.SpellMod_DamageDone_Pct,
+				Kind:       core.SpellMod_DamageDone_Flat,
 				FloatValue: 0.10,
 				ClassMask:  SpellMaskSealOfRighteousness | SpellMaskSealOfVengeance | SpellMaskSealOfBlood,
 			}).ExposeToAPL(37184)
@@ -189,7 +189,7 @@ var ItemSetLightbringerArmor = core.NewItemSet(core.ItemSet{
 		},
 		4: func(agent core.Agent, setBonusAura *core.Aura) {
 			setBonusAura.AttachSpellMod(core.SpellModConfig{
-				Kind:       core.SpellMod_DamageDone_Pct,
+				Kind:       core.SpellMod_DamageDone_Flat,
 				FloatValue: 0.10,
 				ClassMask:  SpellMaskConsecration,
 			}).ExposeToAPL(38422)

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -316,7 +316,7 @@ func (paladin *Paladin) applyDivineIntellect() {
 // Improved Seal of Righteousness - Increases the damage done by your Seal of Righteousness and its Judgement by 3/6/9/12/15%
 func (paladin *Paladin) applyImprovedSealOfRighteousness() {
 	paladin.AddStaticMod(core.SpellModConfig{
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.03 * float64(paladin.Talents.ImprovedSealOfRighteousness),
 		ClassMask:  SpellMaskSealOfRighteousness | SpellMaskJudgementOfRighteousness,
 	})
@@ -325,7 +325,7 @@ func (paladin *Paladin) applyImprovedSealOfRighteousness() {
 // Healing Light - Increases the amount healed by your Holy Light and Flash of Light spells by 4/8/12%
 func (paladin *Paladin) applyHealingLight() {
 	paladin.AddStaticMod(core.SpellModConfig{
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.04 * float64(paladin.Talents.HealingLight),
 		ClassMask:  SpellMaskHolyLight | SpellMaskFlashOfLight,
 	})
@@ -562,7 +562,7 @@ func (paladin *Paladin) applyOneHandedWeaponSpecialization() {
 func (paladin *Paladin) applyImprovedHolyShield() {
 	// Number of charges handled in holy_shield.go
 	paladin.AddStaticMod(core.SpellModConfig{
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		ClassMask:  SpellMaskHolyShieldProc,
 		FloatValue: 0.1 * float64(paladin.Talents.ImprovedHolyShield),
 	})

--- a/sim/warlock/talents.go
+++ b/sim/warlock/talents.go
@@ -259,7 +259,7 @@ func (warlock *Warlock) appyImprovedImp() {
 	}
 
 	warlock.Imp.AddStaticMod(core.SpellModConfig{
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.1 * float64(warlock.Talents.ImprovedImp),
 		ClassMask:  WarlockSpellImpFireBolt,
 	})
@@ -293,7 +293,7 @@ func (warlock *Warlock) applyImprovedSayaad() {
 
 	//This might not actually increase the damage, find a source to prove this
 	warlock.Succubus.AddStaticMod(core.SpellModConfig{
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.1 * float64(warlock.Talents.ImprovedSayaad),
 		ClassMask:  WarlockSpellSuccubusLashOfPain,
 	})
@@ -323,7 +323,7 @@ func (warlock *Warlock) applyUnholyPower() {
 	}
 
 	warlock.Imp.AddStaticMod(core.SpellModConfig{
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.04 * float64(warlock.Talents.UnholyPower),
 		ClassMask:  WarlockSpellImpFireBolt,
 	})


### PR DESCRIPTION
## Percent damage-modifier stacking (follow-up to #498)

Same DBC discriminator as the cost PR, applied to damage mods. Draft for validation — needs in-game confirmation of at least one overlap before merging.

```
damage = base × (1 + Σ aura-108 spellmods) × Π (1 + each school/special aura)
```

- **aura 108** (`ADD_PCT_MODIFIER`, family-masked): sums → `SpellMod_DamageDone_Flat` (additive bucket)
- **aura 79** (`MOD_DAMAGE_PERCENT_DONE`, school-wide): multiplies → `SpellMod_DamageDone_Pct`

### Moved to the additive bucket (aura 108 confirmed or family-masked by construction)

| Effect | Spell ID | DBC |
|---|---|---|
| Improved Seal of Righteousness (paladin) | 20224 | 108 |
| Healing Light (paladin) | 20237 | 108 |
| Improved Holy Shield (paladin) | family-masked | 108 by construction |
| T6 2pc seals + Consecration 10% (paladin sets) | family-masked | 108 by construction |
| Improved Stings (hunter) | 19464 | 108 |
| Barrage (hunter) | 19461 | 108 |
| T5 2pc Steady Shot / PvP gloves Multi-Shot (hunter) | family-masked | 108 by construction |
| Improved Imp (warlock) | 18694 | 108 |
| Improved Sayaad (warlock) | 18754 | 108 |
| Unholy Power (warlock) | 18769 | 107 (flat spellmod — also sums) |

### Verified correct as multiplicative (unchanged)

| Effect | Spell ID | DBC |
|---|---|---|
| Arcane Instability (mage) | 15058 | 79, all magic |
| Playing with Fire (mage) | 31638 | 79, all magic |
| Arctic Winds (mage) | 31674 | 79, frost |
| Molten Fury (mage) | 31679 | **112** (execute-range special) |
| 2H Weapon Spec (warrior) | 12163 | 79, physical |
| 1H Weapon Spec (paladin) | 20196 | 79, all |
| Weapon Mastery (shaman) | 29082 | 79, physical |
| Ranged Weapon Spec (hunter) | 19507 | 79, all |
| Dual Wield Spec (warrior fury) | 23584 | **122** (offhand pct) |
| Enrage / Vengeance (proc buffs) | 12317 / 20049 | triggered buffs, assumed 79 |
| Fire Power (mage) | 11124 | 108 — already in additive bucket ✓ |

### Druid self-cast Thorns

Brambles turned out to have no target at all — nothing registered `DruidSpellThorns`. Instead of a spell mod, the druid now registers a castable Thorns (rank 7, 400 mana, Humanoid form only) that reuses the core raid-buff aura with the druid's own Brambles points (Battle Shout pattern). The dead Brambles mod is deleted. If the Thorns raid buff is selected it wins — don't select both.

### Validation status

- Zero fixture drift: no current test build stacks two 108 damage spellmods on one spell, so this is future-proofing plus correctness for user gear/talent combos the fixtures miss (e.g. Improved SoR + T6 2pc seal bonus would now sum: 1.25 instead of 1.15×1.10).
- Suggested in-game check: Seal of Righteousness tick with 5/5 Improved SoR + T6 2pc — additive predicts base×1.25, multiplicative base×1.265.
- All 20 suites green under `--tags=with_db`.

Based on #498 (`fix/power-cost-pct-stacking`).

https://claude.ai/code/session_01RpP28aqeHjhfGrRoayEDoS
