### PR TITLE
Stack druid percent cost modifiers per DBC aura type

### DIFF
--- a/sim/druid/feralcat/TestFeralCat.results
+++ b/sim/druid/feralcat/TestFeralCat.results
@@ -1198,10 +1198,10 @@ dps_results: {
 dps_results: {
  key: "TestFeralCat-AllItems-MoongladeRaiment"
  value: {
-  dps: 1954.87733
-  tps: 999.87805
+  dps: 1955.17543
+  tps: 999.87601
   dtps: 12.00914
-  hps: 64.34071
+  hps: 64.46787
  }
 }
 dps_results: {

--- a/sim/druid/item_sets.go
+++ b/sim/druid/item_sets.go
@@ -66,7 +66,7 @@ var ItemSetMoongladeRaiment = core.NewItemSet(core.ItemSet{
 		4: func(agent core.Agent, setBonusAura *core.Aura) {
 			setBonusAura.AttachSpellMod(core.SpellModConfig{
 				ClassMask:  DruidSpellCatForm | DruidSpellBearForm,
-				Kind:       core.SpellMod_PowerCost_Pct,
+				Kind:       core.SpellMod_PowerCost_Pct_Add,
 				FloatValue: -0.25,
 			})
 		},

--- a/sim/druid/omen_of_clarity.go
+++ b/sim/druid/omen_of_clarity.go
@@ -45,9 +45,9 @@ func (druid *Druid) applyOmenOfClarity() {
 			}
 		},
 	}).AttachSpellMod(core.SpellModConfig{
-		Kind:       core.SpellMod_PowerCost_Pct,
+		Kind:       core.SpellMod_PowerCost_Pct_Add,
 		ClassMask:  clearcastingSpells,
-		FloatValue: -2,
+		FloatValue: -1,
 	})
 
 	druid.MakeProcTriggerAura(core.ProcTrigger{

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -159,7 +159,7 @@ func (druid *Druid) applyMoonglow() {
 	druid.AddStaticMod(core.SpellModConfig{
 		ClassMask:  DruidSpellMoonfire | DruidSpellStarfire | DruidSpellWrath | DruidSpellHealingTouch | DruidSpellRegrowth | DruidSpellRejuvenation,
 		FloatValue: -0.03 * float64(druid.Talents.Moonglow),
-		Kind:       core.SpellMod_PowerCost_Pct,
+		Kind:       core.SpellMod_PowerCost_Pct_Add,
 	})
 }
 
@@ -336,7 +336,7 @@ func (druid *Druid) applyNaturalShapeshifter() {
 
 	druid.AddStaticMod(core.SpellModConfig{
 		ClassMask:  DruidSpellCatForm | DruidSpellBearForm,
-		Kind:       core.SpellMod_PowerCost_Pct,
+		Kind:       core.SpellMod_PowerCost_Pct_Add,
 		FloatValue: -0.1 * float64(druid.Talents.NaturalShapeshifter),
 	})
 }


### PR DESCRIPTION
## Druid percent cost-mod stacking (validated; re-lands after #498 merged without it)

Replaces #500 — that PR was closed while #498 merged in parallel, so these changes never reached master.

Same DBC rule as #498: aura 108 + MiscValue 14 (SPELLMOD_COST) mods sum (`SpellMod_PowerCost_Pct_Add`); aura 72 school mods multiply.

| Effect | Spell ID | Value | DBC | Kind |
|---|---|---|---|---|
| Moonglow | 16845 | −3%/pt | 108/14 | Add |
| Natural Shapeshifter | 16833 | −10%/pt | 108/14 | Add ✅ confirmed in-game |
| Moonglade Raiment 4pc | 37287 | −25% | 108/14 | Add ✅ confirmed in-game |
| Clearcasting (Omen of Clarity) | 16870 | −100% | 108/14 | Add (value fixed −2 → −1) |

✅ **Validated in-game** (Cat Form, Staff of Natural Fury −200 flat, Moonglade 4pc equipped):

| Setup | Measured | Additive prediction | Multiplicative |
|---|---|---|---|
| Staff + Moonglade 4pc | **472** | 629.5×0.75 = 472 ✓ | 472 (also proves flat applies before pct; 422 would mean flat-after) |
| Staff + Moonglade 4pc + NS 3/3 | **283** | 629.5×(1−0.55) = 283 ✓ | 330 ✗ |

NS + Moonglade sum — same aura 108 / SPELLMOD_COST behavior as every other confirmed pair. The earlier multiplicative read is refuted.

Feral cat fixtures regenerated (Moonglade row only); all druid suites green under `--tags=with_db`.

https://claude.ai/code/session_01RpP28aqeHjhfGrRoayEDoS
