### PR TITLE
fix(sim): cap armor damage reduction at 75%

### DIFF
--- a/sim/core/armor_test.go
+++ b/sim/core/armor_test.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/wowsims/tbc/sim/core/stats"
+)
+
+func TestArmorDamageReductionCap(t *testing.T) {
+	// Boss attacker: armorConstant = 73*467.5 - 22167.5 = 11960, so 75% reduction is
+	// reached at 3*11960 = 35880 armor.
+	attacker := Unit{Type: EnemyUnit, Level: 73}
+	tolerance := 0.0001
+
+	modifierForArmor := func(armor float64) float64 {
+		defender := Unit{
+			Type:         PlayerUnit,
+			Level:        70,
+			initialStats: stats.Stats{stats.Armor: armor},
+			PseudoStats:  stats.NewPseudoStats(),
+		}
+		defender.stats = defender.initialStats
+		return NewAttackTable(&attacker, &defender).GetArmorDamageModifier(nil)
+	}
+
+	if modifier := modifierForArmor(23920); !WithinToleranceFloat64(1.0/3.0, modifier, tolerance) {
+		t.Fatalf("Expected %f damage taken below the cap, got %f", 1.0/3.0, modifier)
+	}
+	if modifier := modifierForArmor(35880); !WithinToleranceFloat64(0.25, modifier, tolerance) {
+		t.Fatalf("Expected %f damage taken at the cap, got %f", 0.25, modifier)
+	}
+	if modifier := modifierForArmor(50000); !WithinToleranceFloat64(0.25, modifier, tolerance) {
+		t.Fatalf("Expected %f damage taken above the cap, got %f", 0.25, modifier)
+	}
+}

--- a/sim/core/spell_resistances.go
+++ b/sim/core/spell_resistances.go
@@ -134,5 +134,6 @@ func (at *AttackTable) GetArmorDamageModifier(spell *Spell) float64 {
 	defenderArmor := at.Defender.Armor() - (at.Defender.Armor() * ignoreArmorFactor)
 	// TBC ANNI: Apply flat ArP
 	defenderArmor = max(defenderArmor-at.Attacker.stats[stats.ArmorPenetration], 0)
-	return 1 - defenderArmor/(defenderArmor+armorConstant)
+	// Damage reduction from armor is capped at 75%.
+	return max(1-defenderArmor/(defenderArmor+armorConstant), 0.25)
 }


### PR DESCRIPTION
`GetArmorDamageModifier` returned the raw formula value with no cap, but armor mitigation in TBC caps at 75% damage reduction.

The function is a Cataclysm port (the doc comment still links the Cata combat-ratings threads, and `// Assume target > 80` sits above the constant in a level-70 repo). The constant itself was corrected to the vanilla/TBC/WotLK `467.5 * level - 22167.5`, but the missing cap came along for the ride — in Cata the constant is ~33k at level 88, so the cap is unreachable and nobody noticed.

In TBC the constant is 11,960 against a level 73 attacker, so 75% reduction is reached at 35,880 armor, which tank sims do hit.

## Measured

Instrumented `GetArmorDamageModifier` and ran the tank suites with `-tags with_db`:

| case | peak armor | uncapped DR |
| --- | --- | --- |
| player -> boss | 7,685 | 42.1% |
| prot warrior / prot paladin as defender | 21,726 | 64.5% |
| feral bear, golden suite | 35,284 | 74.68% |
| feral bear p5 + full buffs | 34,743 | 74.39% |
| **feral bear p5 + Inspiration uptime 1.0** | **43,679** | **78.50%** |

Inspiration (`sim/core/buffs.go:1762`, x1.25 armor, wired up in `feralbear.go:37` via the healing model) pushes a bear well past the cap. At 78.5% vs 75%, boss physical hits land ~14% lighter than they should — `(1 - 0.785) / (1 - 0.75) = 0.86` — which skews DTPS, TMI and chance of death. Plate tanks are nowhere near it, and the player-as-attacker path never mattered.

## Changes

- `max(..., 0.25)` on the returned damage multiplier.
- `sim/core/armor_test.go` covering below / at / above the cap. It fails on master (`Expected 0.250000 damage taken above the cap, got 0.193028`).

## Results

No golden changes — the committed gear presets sit just under the cap without Inspiration. `go test -tags with_db ./sim/...` is green (8,785 tests, 37 packages).