### PR TITLE
fix(sim): stop strict sequences double-hooking the spell queue

### DIFF
--- a/sim/core/apl_actions_sequences.go
+++ b/sim/core/apl_actions_sequences.go
@@ -119,6 +119,10 @@ type APLActionStrictSequence struct {
 	curIdx     int
 
 	subactionSpells []*Spell
+
+	// The queue action currently hooked to advance this sequence, and the callback it replaced.
+	hookedQueueAction *PendingAction
+	hookedOnAction    func(*Simulation)
 }
 
 func (rot *APLRotation) newActionStrictSequence(config *proto.APLActionStrictSequence) APLActionImpl {
@@ -151,6 +155,7 @@ func (action *APLActionStrictSequence) PostFinalize(rot *APLRotation) {
 }
 func (action *APLActionStrictSequence) Reset(*Simulation) {
 	action.curIdx = 0
+	action.unhookQueueAction()
 	action.unit.Rotation.inSequence = false
 }
 func (action *APLActionStrictSequence) IsReady(sim *Simulation) bool {
@@ -173,6 +178,7 @@ func (action *APLActionStrictSequence) Execute(sim *Simulation) {
 }
 func (action *APLActionStrictSequence) relinquishControl() {
 	action.curIdx = 0
+	action.unhookQueueAction()
 	action.unit.Rotation.inSequence = false
 	action.unit.Rotation.popControllingAction(action)
 }
@@ -201,12 +207,7 @@ func (action *APLActionStrictSequence) GetNextAction(sim *Simulation) *APLAction
 		// The spell was already queued at this timestep; modify it to advance the sequence when it executes
 		// and return nil to wait for the GCD to become ready.
 		queueAction := action.unit.QueuedSpell.queueAction
-		oldFunc := queueAction.OnAction
-		queueAction.OnAction = func(sim *Simulation) {
-			oldFunc(sim)
-			action.advanceSequence()
-			queueAction.OnAction = oldFunc
-		}
+		action.hookQueueAction(queueAction)
 		action.unit.SetRotationTimer(sim, queueAction.NextActionAt+time.Duration(1))
 
 		return nil
@@ -219,6 +220,37 @@ func (action *APLActionStrictSequence) GetNextAction(sim *Simulation) *APLAction
 		// Return nil to wait for the GCD to become ready.
 		return nil
 	}
+}
+
+// hookQueueAction makes the queued spell's action advance this sequence when it fires.
+// Must stay idempotent: the rotation can be re-evaluated within a timestep, and a second
+// wrapper would advance twice and strand a stale hook on the queue action, which is reused
+// for later unrelated spells. The wrapper unhooks itself first, so any callback that manages
+// OnAction gets the last word; the guard keeps it off another action's hook.
+func (action *APLActionStrictSequence) hookQueueAction(queueAction *PendingAction) {
+	if action.hookedQueueAction == queueAction {
+		return
+	}
+	action.unhookQueueAction()
+
+	oldFunc := queueAction.OnAction
+	action.hookedQueueAction = queueAction
+	action.hookedOnAction = oldFunc
+	queueAction.OnAction = func(sim *Simulation) {
+		if action.hookedQueueAction == queueAction {
+			action.unhookQueueAction()
+		}
+		oldFunc(sim)
+		action.advanceSequence()
+	}
+}
+func (action *APLActionStrictSequence) unhookQueueAction() {
+	if action.hookedQueueAction == nil {
+		return
+	}
+	action.hookedQueueAction.OnAction = action.hookedOnAction
+	action.hookedQueueAction = nil
+	action.hookedOnAction = nil
 }
 func (action *APLActionStrictSequence) String() string {
 	return "Strict Sequence(" + strings.Join(MapSlice(action.subactions, func(subaction *APLAction) string { return fmt.Sprintf("(%s)", subaction) }), "+") + ")"


### PR DESCRIPTION
## Problem

A prot warrior fixture (Archimonde 25, APL with a Fear-reactive strict sequence) crashes the sim with:

```
panic: Wrong APL controllingAction in pop()
  sim/core/apl.go:507  popControllingAction
  sim/core/apl_actions_sequences.go:177  relinquishControl
  sim/core/apl_actions_sequences.go:182  advanceSequence
```

## Root cause

When a `StrictSequence` subaction gets spell-queued rather than cast, `GetNextAction` wraps the queued spell's `PendingAction.OnAction` so the sequence advances when the spell actually fires. That wrap was unconditional — and the rotation can be evaluated more than once within a single timestep, so the hook could be installed twice on the same `PendingAction`.

Traced timeline (seed 24944, single iteration):

1. **93.673s** — the strict sequence pushes itself as controlling action, casts Berserker Rage (1.5s GCD), `curIdx` → 1. Defensive Stance can't cast yet, so it is queued for 93.7327. **Hook #1** installed.
2. Still **93.673s** — off-GCD Heroic Strike casts and the rotation is re-evaluated. Subaction 1 is still not ready (`CanQueueSpell` false), so it lands in the same queue branch → **hook #2 wraps hook #1**.
3. **93.733s** — the PA fires. W2 → W1 → cast → `advanceSequence` → 2/2 → `relinquishControl` (pop succeeds) → W1 restores the original callback. W2 then advances a **second** time (`curIdx` 0 → 1, sequence state corrupt) and restores `OnAction = W1` — a stale hook left on the PA.
4. `QueuedSpell.InitiateQueue` reuses a consumed `PendingAction`. At **95.653s** Shield Block — an unrelated top-level APL action — queues onto it. Stale W1 fires → `advanceSequence` → 2/2 → `relinquishControl` on an empty `controllingActions` stack → panic.

Two defects from one cause: the crash, and a silent sequence-step skip whenever the double-hook occurs without later panicking.

Not Archimonde-specific — the precondition is generic (a strict sequence whose subaction gets queued while the rotation is re-evaluated in that timestep). Archimonde just makes it likely.

## Fix

Track the hooked `PendingAction` on the action so the install is idempotent; unhook on fire, on `relinquishControl`, and on `Reset`. The wrapper restores before invoking the callback it replaced, so a callback that manages `OnAction` itself (a plain `Sequence`'s wrapper, or a re-queue re-arming the same PA) gets the last word.

`APLActionSequence` (non-strict) has the same wrap pattern but cannot double-install: its `IsReady` gates on `CanCastOrQueue` → `CanQueueSpell` is false in the same timestep, so `Execute` can't re-enter; a cancelled queue drops the `PendingAction` along with its wrapper.

## Verification

| Check | Before | After |
|---|---|---|
| seed 24944, 1 iteration | panic | clean |
| 200k-seed hunt | first failure at 24944 | no failing seed |
| 500k iterations, concurrent | panic in under 1s | `dps=976.3 tps=1809.9` |
| `GOARCH=amd64 go test --tags=with_db ./sim/...` | — | exit 0, no `.results` drift |

## Not included

No regression test — exercising this needs a strict-sequence test harness that doesn't exist yet (no `sim/**/*_test.go` references `StrictSequence`). Happy to add one as a follow-up.

Review also flagged a **pre-existing** double-advance on untouched lines: branch 1 uses `GCD.IsReady` as a proxy for "will cast now", but `CastOrQueue` gates the real cast on `spell.CanCast`, which also needs `BothTimersReady(CD, SharedCD)`. With the GCD ready and the subaction's own CD within the queue window, the sequence pre-advances *and* the queue hook advances. That's a separate semantic decision about branch 1 and would move rotation output, so it's left out of this PR.