### PR TITLE
Stop hunter item effects crashing when another class equips the item

### DIFF
--- a/sim/hunter/item_sets.go
+++ b/sim/hunter/item_sets.go
@@ -181,10 +181,23 @@ var ItemSetGronnstalkersArmor = core.NewItemSet(core.ItemSet{
 	},
 })
 
+// The bows and the mail shoulders below can be equipped by other classes, whose agents are not
+// HunterAgents. Their hunter-specific effects simply do not apply to them.
+func hunterFromAgent(agent core.Agent) (*Hunter, bool) {
+	hunterAgent, ok := agent.(HunterAgent)
+	if !ok {
+		return nil, false
+	}
+	return hunterAgent.GetHunter(), true
+}
+
 func init() {
 	// Thori'dal, the Star's Fury
 	core.NewItemEffect(ThoridalTheStarsFuryItemID, func(agent core.Agent) {
-		hunter := agent.(HunterAgent).GetHunter()
+		hunter, ok := hunterFromAgent(agent)
+		if !ok {
+			return
+		}
 
 		isEquipped := hunter.HasItemEquipped(ThoridalTheStarsFuryItemID, []proto.ItemSlot{proto.ItemSlot_ItemSlotRanged})
 		buildPhase := core.Ternary(isEquipped, core.CharacterBuildPhaseGear, core.CharacterBuildPhaseNone)
@@ -241,7 +254,10 @@ func init() {
 
 	// Beast-tamer's Shoulders
 	core.NewItemEffect(30892, func(agent core.Agent) {
-		hunter := agent.(HunterAgent).GetHunter()
+		hunter, ok := hunterFromAgent(agent)
+		if !ok {
+			return
+		}
 
 		hunter.Pet.PseudoStats.DamageDealtMultiplier *= 1.03
 		hunter.Pet.AddStat(stats.PhysicalCritPercent, 3)
@@ -250,7 +266,10 @@ func init() {
 	// Black Bow of the Betrayer
 	const BlackBowOfTheBetrayerItemID = 32336
 	core.NewItemEffect(BlackBowOfTheBetrayerItemID, func(agent core.Agent) {
-		hunter := agent.(HunterAgent).GetHunter()
+		hunter, ok := hunterFromAgent(agent)
+		if !ok {
+			return
+		}
 
 		manaMetrics := hunter.NewManaMetrics(core.ActionID{SpellID: 29471})
 


### PR DESCRIPTION
Equipping Thori'dal on a warrior crashed the sim on load: the item effect cast the agent to HunterAgent without checking, so any non-hunter with the bow panicked in ComputeStats. Black Bow of the Betrayer and Beast-tamer's Shoulders had the same unchecked cast and are equippable by other classes too.

The three effects now go through a checked cast and return early for non-hunters, who get the item's plain stats and nothing else. The other hunter item effects sit on class-locked items, so they are left as they are.

Fixes #472