### PR TITLE
fix(apl): escape validation text before it becomes tooltip HTML

### DIFF
--- a/ui/core/components/pickers/list_picker.tsx
+++ b/ui/core/components/pickers/list_picker.tsx
@@ -82,6 +82,12 @@ interface ListDragData<ModObject, ItemType> {
 
 let curDragData: ListDragData<any, any> | null = null;
 
+// The sim formats user-authored APL group and variable names into its validation strings, and
+// tippy's global `allowHTML: true` renders the tooltip as markup, so a shared rotation could
+// otherwise script the page.
+const HTML_ESCAPES: Record<string, string> = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+const escapeHtml = (value: string) => value.replace(/[&<>"']/g, character => HTML_ESCAPES[character]);
+
 export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<ItemType>> {
 	readonly config: ListPickerConfig<ModObject, ItemType>;
 	private readonly itemsDiv: HTMLElement;
@@ -689,7 +695,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 						`
 						<p>${this.logLevelDisplayData.get(logLevel)?.header}</p>
 						<ul>
-							${validations.map(v => `<li>${v}</li>`).join('')}
+							${validations.map(v => `<li>${escapeHtml(v)}</li>`).join('')}
 						</ul>
 					`;
 				}


### PR DESCRIPTION
## The problem

APL validation messages are rendered as **HTML**, and they are not all authored by us.

`ui/index.ts` sets `allowHTML: true` as a **global** tippy default, and
`ListPicker.makeListItemValidations` builds its tooltip body by interpolating each
validation straight into `<li>${v}</li>`. The sim formats user-supplied names into those
messages — `apl_action_group_reference.go` does it for a missing group name, and
`apl_values_operators.go` for variable names.

Rotations are shared by link and imported as JSON, so a rotation carrying markup in a group
or variable name has that markup rendered in the reader's browser as soon as the warning
tooltip appears. The reader does not have to do anything except open the rotation and hover
a warning.

## The fix

Escape the message before it is interpolated.

This is safe to do late, after `ActionId.replaceAllInString`, because that call substitutes
spell **names as plain text** — it injects no markup of its own. The only markup left in the
string is the `<p>`/`<ul>`/`<li>` wrapper we write ourselves, which is built outside the
escaped span.

One helper and one call site.

## Notes

- Reported and fixed across all four affected repos at once: `mop`, `cata`, `tbc-new` and the
  `WoWSimsCN-Mop` fork. The sink is byte-identical in each, so the patch is the same.
- `sod`, `tbc-old` and `wotlk` are **not** affected — they do not have this sink.
- The wider issue behind it is that `allowHTML: true` is a global tippy default, which makes
  every `tippy({ content })` call site in the tree an HTML sink. This PR fixes the one that is
  reachable from user-controlled data; auditing the rest is worth doing separately.
